### PR TITLE
feat: Add `:one_of` constraint to the Atom type

### DIFF
--- a/lib/ash/type/atom.ex
+++ b/lib/ash/type/atom.ex
@@ -1,4 +1,10 @@
 defmodule Ash.Type.Atom do
+  @constraints [
+    one_of: [
+      type: :any,
+      doc: "Allows constraining the value of an atom to a pre-defined list"
+    ]
+  ]
   @moduledoc """
   Stores an atom as a string in the database
 
@@ -8,6 +14,28 @@ defmodule Ash.Type.Atom do
 
   @impl true
   def storage_type, do: :string
+
+  @impl true
+  def constraints, do: @constraints
+
+  def apply_constraints(nil, _), do: :ok
+
+  def apply_constraints(value, constraints) do
+    errors =
+      Enum.reduce(constraints, [], fn
+        {:one_of, atom_list}, errors ->
+          if Enum.member?(atom_list, value) do
+            errors
+          else
+            ["atom must be one of `#{inspect(atom_list)}`" | errors]
+          end
+      end)
+
+    case errors do
+      [] -> :ok
+      errors -> {:error, errors}
+    end
+  end
 
   @impl true
   def cast_input(value) when is_atom(value) do

--- a/test/type/type_test.exs
+++ b/test/type/type_test.exs
@@ -53,6 +53,7 @@ defmodule Ash.Test.Type.TypeTest do
     attributes do
       attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
       attribute :title, PostTitle, constraints: [max_length: 10]
+      attribute :post_type, :atom, allow_nil?: false, constraints: [one_of: [:text, :video]]
     end
 
     actions do
@@ -75,16 +76,24 @@ defmodule Ash.Test.Type.TypeTest do
   test "it accepts valid data" do
     post =
       Post
-      |> new(%{title: "foobar"})
+      |> new(%{title: "foobar", post_type: :text})
       |> Api.create!()
 
     assert post.title == "foobar"
   end
 
-  test "it rejects invalid data" do
+  test "it rejects invalid title data" do
     assert_raise(Ash.Error.Invalid, ~r/is too long, max_length is 10/, fn ->
       Post
-      |> new(%{title: "foobarbazbuzbiz"})
+      |> new(%{title: "foobarbazbuzbiz", post_type: :text})
+      |> Api.create!()
+    end)
+  end
+
+  test "it rejects invalid atom data" do
+    assert_raise(Ash.Error.Invalid, ~r/atom must be one of/, fn ->
+      Post
+      |> new(%{title: "foobar", post_type: :something_else})
       |> Api.create!()
     end)
   end


### PR DESCRIPTION
This is something I came across that I wanted during some experimentation with Ash, and I decided to take a crack at drafting a quick PR for it! 

Basically when defining an `:atom` attribute I wanted to ensure that the input value is restricted to a pre-defined list of atoms.

Quick example in context:

```elixir
    attribute :type, :atom, allow_nil?: false, constraints: [
      one_of: [:text_post, :video_post, :image_post]
    ]
```

Feedback encouraged! I love what I see of the Ash framework so far 😄 

# Contributor checklist
- [ ] ~~Bug fixes include regression tests~~
- [x] Features include unit/acceptance tests
