### PR TITLE
Improve attribute defaults

### DIFF
--- a/lib/ash/resource/attribute.ex
+++ b/lib/ash/resource/attribute.ex
@@ -91,6 +91,7 @@ defmodule Ash.Resource.Attribute do
                            |> OptionsHelpers.set_default!(:private?, true)
                            |> OptionsHelpers.set_default!(:default, &DateTime.utc_now/0)
                            |> OptionsHelpers.set_default!(:type, Ash.Type.UtcDatetimeUsec)
+                           |> OptionsHelpers.set_default!(:allow_nil?, false)
 
   @update_timestamp_schema @schema
                            |> OptionsHelpers.set_default!(:writable?, false)
@@ -98,20 +99,19 @@ defmodule Ash.Resource.Attribute do
                            |> OptionsHelpers.set_default!(:default, &DateTime.utc_now/0)
                            |> OptionsHelpers.set_default!(:update_default, &DateTime.utc_now/0)
                            |> OptionsHelpers.set_default!(:type, Ash.Type.UtcDatetimeUsec)
+                           |> OptionsHelpers.set_default!(:allow_nil?, false)
 
   @uuid_primary_key_schema @schema
                            |> OptionsHelpers.set_default!(:writable?, false)
                            |> OptionsHelpers.set_default!(:default, &Ash.uuid/0)
                            |> OptionsHelpers.set_default!(:primary_key?, true)
                            |> OptionsHelpers.set_default!(:type, Ash.Type.UUID)
-                           |> OptionsHelpers.set_default!(:allow_nil?, true)
 
   @integer_primary_key_schema @schema
                               |> OptionsHelpers.set_default!(:writable?, false)
                               |> OptionsHelpers.set_default!(:primary_key?, true)
                               |> OptionsHelpers.set_default!(:generated?, true)
                               |> OptionsHelpers.set_default!(:type, Ash.Type.Integer)
-                              |> OptionsHelpers.set_default!(:allow_nil?, false)
 
   def transform(%{constraints: []} = attribute), do: {:ok, attribute}
 

--- a/lib/ash/resource/attribute.ex
+++ b/lib/ash/resource/attribute.ex
@@ -106,12 +106,14 @@ defmodule Ash.Resource.Attribute do
                            |> OptionsHelpers.set_default!(:default, &Ash.uuid/0)
                            |> OptionsHelpers.set_default!(:primary_key?, true)
                            |> OptionsHelpers.set_default!(:type, Ash.Type.UUID)
+                           |> OptionsHelpers.set_default!(:allow_nil?, false)
 
   @integer_primary_key_schema @schema
                               |> OptionsHelpers.set_default!(:writable?, false)
                               |> OptionsHelpers.set_default!(:primary_key?, true)
                               |> OptionsHelpers.set_default!(:generated?, true)
                               |> OptionsHelpers.set_default!(:type, Ash.Type.Integer)
+                              |> OptionsHelpers.set_default!(:allow_nil?, false)
 
   def transform(%{constraints: []} = attribute), do: {:ok, attribute}
 

--- a/lib/ash/resource/attribute.ex
+++ b/lib/ash/resource/attribute.ex
@@ -46,7 +46,7 @@ defmodule Ash.Resource.Attribute do
       type: :boolean,
       default: false,
       doc:
-        "Whether or not the attribute is part of the primary key (one or more fields that uniquely identify a resource)." <>
+        "Whether or not the attribute is part of the primary key (one or more fields that uniquely identify a resource). " <>
           "If primary_key? is true, allow_nil? must be false."
     ],
     allow_nil?: [

--- a/lib/ash/resource/attribute.ex
+++ b/lib/ash/resource/attribute.ex
@@ -46,7 +46,8 @@ defmodule Ash.Resource.Attribute do
       type: :boolean,
       default: false,
       doc:
-        "Whether or not the attribute is part of the primary key (one or more fields that uniquely identify a resource)"
+        "Whether or not the attribute is part of the primary key (one or more fields that uniquely identify a resource)." <>
+          "If primary_key? is true, allow_nil? must be false."
     ],
     allow_nil?: [
       type: :boolean,
@@ -106,14 +107,14 @@ defmodule Ash.Resource.Attribute do
                            |> OptionsHelpers.set_default!(:default, &Ash.uuid/0)
                            |> OptionsHelpers.set_default!(:primary_key?, true)
                            |> OptionsHelpers.set_default!(:type, Ash.Type.UUID)
-                           |> OptionsHelpers.set_default!(:allow_nil?, false)
+                           |> Keyword.delete(:allow_nil?)
 
   @integer_primary_key_schema @schema
                               |> OptionsHelpers.set_default!(:writable?, false)
                               |> OptionsHelpers.set_default!(:primary_key?, true)
                               |> OptionsHelpers.set_default!(:generated?, true)
                               |> OptionsHelpers.set_default!(:type, Ash.Type.Integer)
-                              |> OptionsHelpers.set_default!(:allow_nil?, false)
+                              |> Keyword.delete(:allow_nil?)
 
   def transform(%{constraints: []} = attribute), do: {:ok, attribute}
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -51,7 +51,8 @@ defmodule Ash.Resource.Dsl do
   @integer_primary_key %Ash.Dsl.Entity{
     name: :integer_primary_key,
     describe: """
-    Declares a generated (set by the data layer), non writable, non nil, primary key column of type integer
+    Declares a generated (set by the data layer), non writable, non nil, primary key column of type integer.
+    Using `integer_primary_key`, `allow_nil?` is automatically set to `false`.
     """,
     examples: [
       "integer_primary_key :id"
@@ -59,13 +60,15 @@ defmodule Ash.Resource.Dsl do
     args: [:name],
     transform: {Ash.Resource.Attribute, :transform, []},
     target: Ash.Resource.Attribute,
-    schema: Ash.Resource.Attribute.integer_primary_key_schema()
+    schema: Ash.Resource.Attribute.integer_primary_key_schema(),
+    auto_set_fields: [allow_nil?: false]
   }
 
   @uuid_primary_key %Ash.Dsl.Entity{
     name: :uuid_primary_key,
     describe: """
-    Declares a non writable, non nil, primary key column of type uuid, which defaults to `Ash.uuid/0`
+    Declares a non writable, non nil, primary key column of type uuid, which defaults to `Ash.uuid/0`.
+    Using `uuid_primary_key`, `allow_nil?` is automatically set to `false`.
     """,
     examples: [
       "uuid_primary_key :id"
@@ -73,7 +76,8 @@ defmodule Ash.Resource.Dsl do
     args: [:name],
     transform: {Ash.Resource.Attribute, :transform, []},
     target: Ash.Resource.Attribute,
-    schema: Ash.Resource.Attribute.uuid_primary_key_schema()
+    schema: Ash.Resource.Attribute.uuid_primary_key_schema(),
+    auto_set_fields: [allow_nil?: false]
   }
 
   @attributes %Ash.Dsl.Section{

--- a/lib/ash/resource/transformers/belongs_to_attribute.ex
+++ b/lib/ash/resource/transformers/belongs_to_attribute.ex
@@ -23,7 +23,12 @@ defmodule Ash.Resource.Transformers.BelongsToAttribute do
       case Transformer.build_entity(@extension, [:attributes], :attribute,
              name: relationship.source_field,
              type: relationship.field_type,
-             allow_nil?: not relationship.required?,
+             allow_nil?:
+               if relationship.primary_key? do
+                 false
+               else
+                 not relationship.required?
+               end,
              writable?: false,
              private?: true,
              primary_key?: relationship.primary_key?

--- a/lib/ash/resource/transformers/belongs_to_attribute.ex
+++ b/lib/ash/resource/transformers/belongs_to_attribute.ex
@@ -20,34 +20,47 @@ defmodule Ash.Resource.Transformers.BelongsToAttribute do
       |> Enum.find(&(Map.get(&1, :name) == relationship.source_field))
     end)
     |> Enum.reduce_while({:ok, dsl_state}, fn relationship, {:ok, dsl_state} ->
-      case Transformer.build_entity(@extension, [:attributes], :attribute,
-             name: relationship.source_field,
-             type: relationship.field_type,
-             allow_nil?:
-               if relationship.primary_key? do
-                 false
-               else
-                 not relationship.required?
-               end,
-             writable?: false,
-             private?: true,
-             primary_key?: relationship.primary_key?
-           ) do
-        {:ok, attribute} ->
-          {:cont, {:ok, Transformer.add_entity(dsl_state, [:attributes], attribute)}}
+      entity =
+        Transformer.build_entity(@extension, [:attributes], :attribute,
+          name: relationship.source_field,
+          type: relationship.field_type,
+          allow_nil?:
+            if relationship.primary_key? do
+              false
+            else
+              not relationship.required?
+            end,
+          writable?: false,
+          private?: true,
+          primary_key?: relationship.primary_key?
+        )
 
-        {:error, error} ->
-          {:halt,
-           {:error,
-            DslError.exception(
-              module: __MODULE__,
-              message:
-                "Could not create attribute for belongs_to #{relationship.name}: #{inspect(error)}",
-              path: [:relationships, relationship.name]
-            )}}
-      end
+      valid_opts? = not (relationship.primary_key? && !relationship.required?)
+
+      entity_or_error =
+        if valid_opts? do
+          entity
+        else
+          {:error, "Relationship cannot be a primary key unless it is also marked as required"}
+        end
+
+      add_entity(entity_or_error, dsl_state, relationship)
     end)
   end
+
+  defp add_entity({:ok, attribute}, dsl_state, _relationship),
+    do: {:cont, {:ok, Transformer.add_entity(dsl_state, [:attributes], attribute)}}
+
+  defp add_entity({:error, error}, _dsl_state, relationship),
+    do:
+      {:halt,
+       {:error,
+        DslError.exception(
+          module: __MODULE__,
+          message:
+            "Could not create attribute for belongs_to #{relationship.name}: #{inspect(error)}",
+          path: [:relationships, relationship.name]
+        )}}
 
   def after?(Ash.Resource.Transformers.BelongsToSourceField), do: true
   def after?(_), do: false

--- a/lib/ash/resource/transformers/cache_primary_key.ex
+++ b/lib/ash/resource/transformers/cache_primary_key.ex
@@ -14,7 +14,7 @@ defmodule Ash.Resource.Transformers.CachePrimaryKey do
     pk_allows_nil? = Enum.any?(primary_key_attribute, & &1.allow_nil?)
 
     primary_key =
-      unless pk_allows_nil? do
+      if pk_allows_nil? == false do
         Enum.map(primary_key_attribute, & &1.name)
       else
         :error_pk_allows_nil

--- a/lib/ash/resource/transformers/cache_primary_key.ex
+++ b/lib/ash/resource/transformers/cache_primary_key.ex
@@ -6,13 +6,28 @@ defmodule Ash.Resource.Transformers.CachePrimaryKey do
   alias Ash.Error.Dsl.DslError
 
   def transform(resource, dsl_state) do
-    primary_key =
+    primary_key_attribute =
       dsl_state
       |> Transformer.get_entities([:attributes])
       |> Enum.filter(& &1.primary_key?)
-      |> Enum.map(& &1.name)
+
+    pk_allows_nil? = Enum.count(primary_key_attribute, & &1.allow_nil?) > 0
+
+    primary_key =
+      unless pk_allows_nil? do
+        Enum.map(primary_key_attribute, & &1.name)
+      else
+        :error_pk_allows_nil
+      end
 
     case primary_key do
+      :error_pk_allows_nil ->
+        {:error,
+         DslError.exception(
+           module: __MODULE__,
+           message: "Primary keys must not be allowed to be nil"
+         )}
+
       [] ->
         {:error,
          DslError.exception(

--- a/lib/ash/resource/transformers/cache_primary_key.ex
+++ b/lib/ash/resource/transformers/cache_primary_key.ex
@@ -11,7 +11,7 @@ defmodule Ash.Resource.Transformers.CachePrimaryKey do
       |> Transformer.get_entities([:attributes])
       |> Enum.filter(& &1.primary_key?)
 
-    pk_allows_nil? = Enum.count(primary_key_attribute, & &1.allow_nil?) > 0
+    pk_allows_nil? = Enum.any?(primary_key_attribute, & &1.allow_nil?)
 
     primary_key =
       unless pk_allows_nil? do

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -119,8 +119,15 @@ defmodule Ash.Test.Actions.CreateTest do
     end
 
     relationships do
-      belongs_to(:source_post, Ash.Test.Actions.CreateTest.Post, primary_key?: true)
-      belongs_to(:destination_post, Ash.Test.Actions.CreateTest.Post, primary_key?: true)
+      belongs_to(:source_post, Ash.Test.Actions.CreateTest.Post,
+        primary_key?: true,
+        required?: true
+      )
+
+      belongs_to(:destination_post, Ash.Test.Actions.CreateTest.Post,
+        primary_key?: true,
+        required?: true
+      )
     end
   end
 

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -39,7 +39,7 @@ defmodule Ash.Test.Actions.CreateTest do
     end
 
     attributes do
-      attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+      uuid_primary_key :id
       attribute(:bio, :string)
       attribute(:date, :date)
     end
@@ -84,7 +84,7 @@ defmodule Ash.Test.Actions.CreateTest do
     end
 
     attributes do
-      attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+      uuid_primary_key :id
       attribute(:name, :string)
       attribute(:bio, :string)
     end
@@ -139,7 +139,7 @@ defmodule Ash.Test.Actions.CreateTest do
     end
 
     attributes do
-      attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+      uuid_primary_key :id
       attribute(:title, :string, allow_nil?: false)
       attribute(:contents, :string)
       attribute(:tag, :string, default: "garbage")

--- a/test/actions/destroy_test.exs
+++ b/test/actions/destroy_test.exs
@@ -18,7 +18,7 @@ defmodule Ash.Test.Actions.DestroyTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :bio, :string
     end
 
@@ -43,7 +43,7 @@ defmodule Ash.Test.Actions.DestroyTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 
@@ -76,7 +76,7 @@ defmodule Ash.Test.Actions.DestroyTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :title, :string
       attribute :contents, :string
       attribute :tag, :string, default: "garbage"

--- a/test/actions/multitenancy_test.exs
+++ b/test/actions/multitenancy_test.exs
@@ -24,7 +24,7 @@ defmodule Ash.Actions.MultitenancyTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
       attribute :org_id, :uuid
     end
@@ -44,7 +44,7 @@ defmodule Ash.Actions.MultitenancyTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
       attribute :org_id, :uuid
     end
@@ -84,7 +84,7 @@ defmodule Ash.Actions.MultitenancyTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
       attribute :org_id, :uuid
     end

--- a/test/actions/pagination_test.exs
+++ b/test/actions/pagination_test.exs
@@ -58,7 +58,7 @@ defmodule Ash.Actions.PaginationTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
   end

--- a/test/actions/read_test.exs
+++ b/test/actions/read_test.exs
@@ -18,7 +18,7 @@ defmodule Ash.Test.Actions.ReadTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 
@@ -47,7 +47,7 @@ defmodule Ash.Test.Actions.ReadTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :uuid, :uuid, default: &Ecto.UUID.generate/0
       attribute :title, :string
       attribute :contents, :string

--- a/test/actions/side_load_test.exs
+++ b/test/actions/side_load_test.exs
@@ -74,8 +74,11 @@ defmodule Ash.Test.Actions.SideLoadTest do
     end
 
     relationships do
-      belongs_to :post, Post, primary_key?: true
-      belongs_to :category, Ash.Test.Actions.SideLoadTest.Category, primary_key?: true
+      belongs_to :post, Post, primary_key?: true, required?: true
+
+      belongs_to :category, Ash.Test.Actions.SideLoadTest.Category,
+        primary_key?: true,
+        required?: true
     end
   end
 

--- a/test/actions/side_load_test.exs
+++ b/test/actions/side_load_test.exs
@@ -22,7 +22,7 @@ defmodule Ash.Test.Actions.SideLoadTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 
@@ -45,7 +45,7 @@ defmodule Ash.Test.Actions.SideLoadTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :title, :string
       attribute :contents, :string
     end
@@ -92,7 +92,7 @@ defmodule Ash.Test.Actions.SideLoadTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 

--- a/test/actions/update_test.exs
+++ b/test/actions/update_test.exs
@@ -113,8 +113,13 @@ defmodule Ash.Test.Actions.UpdateTest do
     end
 
     relationships do
-      belongs_to :source_post, Ash.Test.Actions.UpdateTest.Post, primary_key?: true
-      belongs_to :destination_post, Ash.Test.Actions.UpdateTest.Post, primary_key?: true
+      belongs_to :source_post, Ash.Test.Actions.UpdateTest.Post,
+        primary_key?: true,
+        required?: true
+
+      belongs_to :destination_post, Ash.Test.Actions.UpdateTest.Post,
+        primary_key?: true,
+        required?: true
     end
   end
 

--- a/test/actions/update_test.exs
+++ b/test/actions/update_test.exs
@@ -12,7 +12,7 @@ defmodule Ash.Test.Actions.UpdateTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 
@@ -38,7 +38,7 @@ defmodule Ash.Test.Actions.UpdateTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :bio, :string
     end
 
@@ -81,7 +81,7 @@ defmodule Ash.Test.Actions.UpdateTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
       attribute :bio, :string
     end
@@ -133,7 +133,7 @@ defmodule Ash.Test.Actions.UpdateTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :title, :string
       attribute :contents, :string
     end

--- a/test/actions/validation_test.exs
+++ b/test/actions/validation_test.exs
@@ -26,7 +26,7 @@ defmodule Ash.Test.Actions.ValidationTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :bio, :string
       attribute :date, :date
       attribute :status, :string

--- a/test/ash/data_layer/ets_test.exs
+++ b/test/ash/data_layer/ets_test.exs
@@ -31,7 +31,7 @@ defmodule Ash.DataLayer.EtsTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
       attribute :age, :integer
       attribute :title, :string

--- a/test/ash/data_layer/ets_test.exs
+++ b/test/ash/data_layer/ets_test.exs
@@ -31,7 +31,7 @@ defmodule Ash.DataLayer.EtsTest do
     end
 
     attributes do
-      uuid_primary_key :id
+      uuid_primary_key :id, writable?: true
       attribute :name, :string
       attribute :age, :integer
       attribute :title, :string

--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -38,7 +38,7 @@ defmodule Ash.Test.CalculationTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :first_name, :string
       attribute :last_name, :string
     end

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -84,8 +84,11 @@ defmodule Ash.Test.Changeset.ChangesetTest do
     end
 
     relationships do
-      belongs_to :post, Ash.Test.Changeset.ChangesetTest.Post, primary_key?: true
-      belongs_to :category, Ash.Test.Changeset.ChangesetTest.Category, primary_key?: true
+      belongs_to :post, Ash.Test.Changeset.ChangesetTest.Post, primary_key?: true, required?: true
+
+      belongs_to :category, Ash.Test.Changeset.ChangesetTest.Category,
+        primary_key?: true,
+        required?: true
     end
   end
 

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -27,7 +27,7 @@ defmodule Ash.Test.Changeset.ChangesetTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 
@@ -58,7 +58,7 @@ defmodule Ash.Test.Changeset.ChangesetTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
     end
 
@@ -104,7 +104,7 @@ defmodule Ash.Test.Changeset.ChangesetTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :title, :string
       attribute :contents, :string
     end
@@ -134,8 +134,8 @@ defmodule Ash.Test.Changeset.ChangesetTest do
     end
 
     attributes do
-      attribute :serial, :integer, primary_key?: true
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      attribute :serial, :integer, primary_key?: true, allow_nil?: false
+      uuid_primary_key :id
       attribute :title, :string
       attribute :contents, :string
     end

--- a/test/filter/filter_interaction_test.exs
+++ b/test/filter/filter_interaction_test.exs
@@ -74,9 +74,15 @@ defmodule Ash.Test.Filter.FilterInteractionTest do
     end
 
     relationships do
-      belongs_to(:source_post, Ash.Test.Filter.FilterInteractionTest.Post, primary_key?: true)
+      belongs_to(:source_post, Ash.Test.Filter.FilterInteractionTest.Post,
+        primary_key?: true,
+        required?: true
+      )
 
-      belongs_to(:destination_post, Ash.Test.Filter.FilterInteractionTest.Post, primary_key?: true)
+      belongs_to(:destination_post, Ash.Test.Filter.FilterInteractionTest.Post,
+        primary_key?: true,
+        required?: true
+      )
     end
   end
 

--- a/test/filter/filter_interaction_test.exs
+++ b/test/filter/filter_interaction_test.exs
@@ -22,7 +22,7 @@ defmodule Ash.Test.Filter.FilterInteractionTest do
     end
 
     attributes do
-      attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+      uuid_primary_key :id
       attribute(:bio, :string)
     end
 
@@ -46,7 +46,7 @@ defmodule Ash.Test.Filter.FilterInteractionTest do
     end
 
     attributes do
-      attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+      uuid_primary_key :id
       attribute(:name, :string)
       attribute(:allow_second_author, :boolean)
     end
@@ -95,7 +95,7 @@ defmodule Ash.Test.Filter.FilterInteractionTest do
     end
 
     attributes do
-      attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+      uuid_primary_key :id
       attribute(:title, :string)
       attribute(:contents, :string)
       attribute(:points, :integer)

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -76,8 +76,13 @@ defmodule Ash.Test.Filter.FilterTest do
     end
 
     relationships do
-      belongs_to :source_post, Ash.Test.Filter.FilterTest.Post, primary_key?: true
-      belongs_to :destination_post, Ash.Test.Filter.FilterTest.Post, primary_key?: true
+      belongs_to :source_post, Ash.Test.Filter.FilterTest.Post,
+        primary_key?: true,
+        required?: true
+
+      belongs_to :destination_post, Ash.Test.Filter.FilterTest.Post,
+        primary_key?: true,
+        required?: true
     end
   end
 

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -21,7 +21,7 @@ defmodule Ash.Test.Filter.FilterTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :bio, :string
       attribute :private, :string, private?: true
     end
@@ -46,7 +46,7 @@ defmodule Ash.Test.Filter.FilterTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :name, :string
       attribute :allow_second_author, :boolean
     end
@@ -98,7 +98,7 @@ defmodule Ash.Test.Filter.FilterTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :title, :string
       attribute :contents, :string
       attribute :points, :integer
@@ -144,7 +144,7 @@ defmodule Ash.Test.Filter.FilterTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :deleted_at, :utc_datetime
     end
   end

--- a/test/notifier/notifier_test.exs
+++ b/test/notifier/notifier_test.exs
@@ -29,8 +29,13 @@ defmodule Ash.Test.NotifierTest do
     end
 
     relationships do
-      belongs_to :source_post, Ash.Test.NotifierTest.Post, primary_key?: true
-      belongs_to :destination_post, Ash.Test.NotifierTest.Post, primary_key?: true
+      belongs_to :source_post, Ash.Test.NotifierTest.Post,
+        primary_key?: true,
+        required?: true
+
+      belongs_to :destination_post, Ash.Test.NotifierTest.Post,
+        primary_key?: true,
+        required?: true
     end
   end
 

--- a/test/notifier/notifier_test.exs
+++ b/test/notifier/notifier_test.exs
@@ -53,7 +53,7 @@ defmodule Ash.Test.NotifierTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
 
       attribute :name, :string
     end
@@ -83,7 +83,7 @@ defmodule Ash.Test.NotifierTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
 
       attribute :name, :string
     end

--- a/test/notifier/pubsub_test.exs
+++ b/test/notifier/pubsub_test.exs
@@ -40,7 +40,7 @@ defmodule Ash.Test.Notifier.PubSubTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
 
       attribute :name, :string
     end

--- a/test/resource/actions/actions_test.exs
+++ b/test/resource/actions/actions_test.exs
@@ -11,7 +11,7 @@ defmodule Ash.Test.Dsl.Resource.Actions.ActionsTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/actions/create_test.exs
+++ b/test/resource/actions/create_test.exs
@@ -10,7 +10,7 @@ defmodule Ash.Test.Dsl.Resource.Actions.CreateTest do
           data_layer: Ash.DataLayer.Ets
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/actions/destroy_test.exs
+++ b/test/resource/actions/destroy_test.exs
@@ -10,7 +10,7 @@ defmodule Ash.Test.Dsl.Resource.Actions.DestroyTest do
           data_layer: Ash.DataLayer.Ets
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/actions/read_test.exs
+++ b/test/resource/actions/read_test.exs
@@ -10,7 +10,7 @@ defmodule Ash.Test.Dsl.Resource.Actions.ReadTest do
           data_layer: Ash.DataLayer.Ets
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/actions/update_test.exs
+++ b/test/resource/actions/update_test.exs
@@ -8,7 +8,7 @@ defmodule Ash.Test.Dsl.Resource.Actions.UpdateTest do
           data_layer: Ash.DataLayer.Ets
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/aggregates_test.exs
+++ b/test/resource/aggregates_test.exs
@@ -9,7 +9,7 @@ defmodule Ash.Test.Resource.AggregatesTest do
     use Ash.Resource
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :post_id, :uuid
     end
   end
@@ -21,7 +21,7 @@ defmodule Ash.Test.Resource.AggregatesTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/attributes_test.exs
+++ b/test/resource/attributes_test.exs
@@ -11,7 +11,7 @@ defmodule Ash.Test.Resource.AttributesTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/calculations_test.exs
+++ b/test/resource/calculations_test.exs
@@ -11,7 +11,7 @@ defmodule Ash.Test.Resource.CalculationsTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
 
           attribute :name, :string
           attribute :contents, :string

--- a/test/resource/identities_test.exs
+++ b/test/resource/identities_test.exs
@@ -9,7 +9,7 @@ defmodule Ash.Test.Resource.IdentitiesTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
 
           attribute :name, :string
           attribute :contents, :string

--- a/test/resource/relationships/belongs_to_test.exs
+++ b/test/resource/relationships/belongs_to_test.exs
@@ -11,7 +11,7 @@ defmodule Ash.Test.Resource.Relationships.BelongsToTest do
         use Ash.Resource
 
         attributes do
-          attribute(:id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0)
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/relationships/has_many_test.exs
+++ b/test/resource/relationships/has_many_test.exs
@@ -11,7 +11,7 @@ defmodule Ash.Test.Resource.Relationshihps.HasManyTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/relationships/has_one_test.exs
+++ b/test/resource/relationships/has_one_test.exs
@@ -11,7 +11,7 @@ defmodule Ash.Test.Resource.Relationshihps.HasOneTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/relationships/many_to_many_test.exs
+++ b/test/resource/relationships/many_to_many_test.exs
@@ -13,7 +13,7 @@ defmodule Ash.Test.Resource.Relationships.ManyToManyTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
         end
 
         unquote(body)

--- a/test/resource/validations_test.exs
+++ b/test/resource/validations_test.exs
@@ -9,7 +9,7 @@ defmodule Ash.Test.Resource.ValidationsTest do
         use Ash.Resource
 
         attributes do
-          attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+          uuid_primary_key :id
 
           attribute :name, :string
           attribute :contents, :string

--- a/test/type/type_test.exs
+++ b/test/type/type_test.exs
@@ -51,7 +51,7 @@ defmodule Ash.Test.Type.TypeTest do
     end
 
     attributes do
-      attribute :id, :uuid, primary_key?: true, default: &Ecto.UUID.generate/0
+      uuid_primary_key :id
       attribute :title, PostTitle, constraints: [max_length: 10]
       attribute :post_type, :atom, allow_nil?: false, constraints: [one_of: [:text, :video]]
     end


### PR DESCRIPTION
In order to mimic Ecto's behaviour, timestamps aren't allowed to be `nil` by default. Primary keys aren't allowed to be `nil` anyway.