### PR TITLE
improvement: Implement string length validation

### DIFF
--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -34,6 +34,11 @@ defmodule Ash.Resource.Validation.Builtins do
     {Validation.AttributeEquals, attribute: attribute, value: value}
   end
 
+  @doc "Validates that an attribute on the original record meets the given length criteria"
+  def string_length(attribute, opts \\ []) do
+    {Validation.StringLength, Keyword.merge(opts, attribute: attribute)}
+  end
+
   @doc """
   Validates that an attribute's value matches a given regex or string, using the provided error, message if not.
 

--- a/lib/ash/resource/validation/string_length.ex
+++ b/lib/ash/resource/validation/string_length.ex
@@ -1,0 +1,104 @@
+defmodule Ash.Resource.Validation.StringLength do
+  @moduledoc false
+  use Ash.Resource.Validation
+
+  alias Ash.Error.Changes.InvalidAttribute
+
+  @opt_schema [
+    min: [
+      type: :non_neg_integer,
+      doc: "String must be this length at least"
+    ],
+    max: [
+      type: :non_neg_integer,
+      doc: "String must be this length at most"
+    ],
+    exact: [
+      type: :non_neg_integer,
+      doc: "String must be this length exactly"
+    ],
+    attribute: [
+      type: :atom,
+      required: true
+    ],
+    message: [
+      type: :string,
+      doc: "The message that will be placed on the field in the case of failure"
+    ]
+  ]
+
+  @impl true
+  def init(opts) do
+    case Ash.OptionsHelpers.validate(opts, @opt_schema) do
+      {:ok, opts} ->
+        {:ok, opts}
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  @impl true
+  def validate(changeset, opts) do
+    Ash.Changeset.get_attribute(changeset, opts[:attribute])
+    |> do_validate(Enum.into(opts, %{}))
+  end
+
+  defp do_validate(nil, _) do
+    :ok
+  end
+
+  defp do_validate(value, %{exact: exact} = opts) do
+    if String.length(value) == exact do
+      :ok
+    else
+      {:error,
+       InvalidAttribute.exception(
+         field: opts[:attribute],
+         message: opts[:message] || "%{field} must have length of exactly %{exact}",
+         vars: [field: opts[:attribute], exact: exact]
+       )}
+    end
+  end
+
+  defp do_validate(value, %{min: min, max: max} = opts) do
+    string_length = String.length(value)
+
+    if string_length >= min and string_length <= max do
+      :ok
+    else
+      {:error,
+       InvalidAttribute.exception(
+         field: opts[:attribute],
+         message: opts[:message] || "%{field} must have length of between %{min} and %{max}",
+         vars: [field: opts[:attribute], min: min, max: max]
+       )}
+    end
+  end
+
+  defp do_validate(value, %{min: min} = opts) do
+    if String.length(value) >= min do
+      :ok
+    else
+      {:error,
+       InvalidAttribute.exception(
+         field: opts[:attribute],
+         message: opts[:message] || "%{field} must have length of at least %{min}",
+         vars: [field: opts[:attribute], min: min]
+       )}
+    end
+  end
+
+  defp do_validate(value, %{max: max} = opts) do
+    if String.length(value) <= max do
+      :ok
+    else
+      {:error,
+       InvalidAttribute.exception(
+         field: opts[:attribute],
+         message: opts[:message] || "%{field} must have length of no more than %{max}",
+         vars: [field: opts[:attribute], max: max]
+       )}
+    end
+  end
+end

--- a/lib/ash/resource/validation/string_length.ex
+++ b/lib/ash/resource/validation/string_length.ex
@@ -5,6 +5,10 @@ defmodule Ash.Resource.Validation.StringLength do
   alias Ash.Error.Changes.InvalidAttribute
 
   @opt_schema [
+    attribute: [
+      type: :atom,
+      required: true
+    ],
     min: [
       type: :non_neg_integer,
       doc: "String must be this length at least"
@@ -16,14 +20,6 @@ defmodule Ash.Resource.Validation.StringLength do
     exact: [
       type: :non_neg_integer,
       doc: "String must be this length exactly"
-    ],
-    attribute: [
-      type: :atom,
-      required: true
-    ],
-    message: [
-      type: :string,
-      doc: "The message that will be placed on the field in the case of failure"
     ]
   ]
 
@@ -55,7 +51,7 @@ defmodule Ash.Resource.Validation.StringLength do
       {:error,
        InvalidAttribute.exception(
          field: opts[:attribute],
-         message: opts[:message] || "%{field} must have length of exactly %{exact}",
+         message: "%{field} must have length of exactly %{exact}",
          vars: [field: opts[:attribute], exact: exact]
        )}
     end
@@ -70,7 +66,7 @@ defmodule Ash.Resource.Validation.StringLength do
       {:error,
        InvalidAttribute.exception(
          field: opts[:attribute],
-         message: opts[:message] || "%{field} must have length of between %{min} and %{max}",
+         message: "%{field} must have length of between %{min} and %{max}",
          vars: [field: opts[:attribute], min: min, max: max]
        )}
     end
@@ -83,7 +79,7 @@ defmodule Ash.Resource.Validation.StringLength do
       {:error,
        InvalidAttribute.exception(
          field: opts[:attribute],
-         message: opts[:message] || "%{field} must have length of at least %{min}",
+         message: "%{field} must have length of at least %{min}",
          vars: [field: opts[:attribute], min: min]
        )}
     end
@@ -96,7 +92,7 @@ defmodule Ash.Resource.Validation.StringLength do
       {:error,
        InvalidAttribute.exception(
          field: opts[:attribute],
-         message: opts[:message] || "%{field} must have length of no more than %{max}",
+         message: "%{field} must have length of no more than %{max}",
          vars: [field: opts[:attribute], max: max]
        )}
     end

--- a/test/resource/validation/string_length_test.exs
+++ b/test/resource/validation/string_length_test.exs
@@ -1,0 +1,157 @@
+defmodule Ash.Test.Resource.Validation.StringLengthTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Resource.Validation.StringLength
+
+  defmodule Post do
+    use Ash.Resource
+
+    attributes do
+      uuid_primary_key :id
+      attribute :body, :string
+    end
+  end
+
+  describe "min length" do
+    test "validate success" do
+      {:ok, opts} = StringLength.init(attribute: :body, min: 3)
+      changeset = Post |> Ash.Changeset.new(%{body: "yes"})
+
+      assert :ok = StringLength.validate(changeset, opts)
+    end
+
+    test "validate failure" do
+      {:ok, opts} = StringLength.init(attribute: :body, min: 3)
+      changeset = Ash.Changeset.new(Post, %{body: "no"})
+
+      assert_error(changeset, opts, "body must have length of at least 3")
+    end
+
+    test "validate failure with message" do
+      {:ok, opts} =
+        StringLength.init(
+          attribute: :body,
+          min: 3,
+          message: "too short, minimum of %{min} characters"
+        )
+
+      changeset = Ash.Changeset.new(Post, %{body: "no"})
+
+      assert_error(changeset, opts, "too short, minimum of 3 characters")
+    end
+  end
+
+  describe "max length" do
+    test "validate success" do
+      {:ok, opts} = StringLength.init(attribute: :body, max: 3)
+      changeset = Post |> Ash.Changeset.new(%{body: "yes"})
+
+      assert :ok = StringLength.validate(changeset, opts)
+    end
+
+    test "validate failure" do
+      {:ok, opts} = StringLength.init(attribute: :body, max: 3)
+      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+
+      assert_error(changeset, opts, "body must have length of no more than 3")
+    end
+
+    test "validate failure with message" do
+      {:ok, opts} =
+        StringLength.init(
+          attribute: :body,
+          max: 3,
+          message: "too long, maximum of %{max} characters"
+        )
+
+      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+
+      assert_error(changeset, opts, "too long, maximum of 3 characters")
+    end
+  end
+
+  describe "exact length" do
+    test "validate success" do
+      {:ok, opts} = StringLength.init(attribute: :body, exact: 3)
+      changeset = Post |> Ash.Changeset.new(%{body: "yes"})
+
+      assert :ok = StringLength.validate(changeset, opts)
+    end
+
+    test "validate failure" do
+      {:ok, opts} = StringLength.init(attribute: :body, exact: 3)
+
+      changeset = Ash.Changeset.new(Post, %{body: "no"})
+      assert_error(changeset, opts, "body must have length of exactly 3")
+
+      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      assert_error(changeset, opts, "body must have length of exactly 3")
+    end
+
+    test "validate failure with message" do
+      {:ok, opts} =
+        StringLength.init(
+          attribute: :body,
+          exact: 3,
+          message: "must be %{exact} characters"
+        )
+
+      changeset = Ash.Changeset.new(Post, %{body: "no"})
+      assert_error(changeset, opts, "must be 3 characters")
+
+      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      assert_error(changeset, opts, "must be 3 characters")
+    end
+  end
+
+  describe "min and max length" do
+    test "validate success" do
+      {:ok, opts} = StringLength.init(attribute: :body, min: 2, max: 4)
+      changeset = Post |> Ash.Changeset.new(%{body: "yes"})
+
+      assert :ok = StringLength.validate(changeset, opts)
+    end
+
+    test "validate failure" do
+      {:ok, opts} = StringLength.init(attribute: :body, min: 2, max: 4)
+
+      changeset = Ash.Changeset.new(Post, %{body: "n"})
+      assert_error(changeset, opts, "body must have length of between 2 and 4")
+
+      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      assert_error(changeset, opts, "body must have length of between 2 and 4")
+    end
+
+    test "validate failure with message" do
+      {:ok, opts} =
+        StringLength.init(
+          attribute: :body,
+          min: 2,
+          max: 4,
+          message: "must be at least %{min} and at most %{max} characters"
+        )
+
+      changeset = Ash.Changeset.new(Post, %{body: "n"})
+      assert_error(changeset, opts, "must be at least 2 and at most 4 characters")
+
+      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      assert_error(changeset, opts, "must be at least 2 and at most 4 characters")
+    end
+  end
+
+  defp assert_error(changeset, opts, expected_message) do
+    {:error, %{message: message, vars: vars}} = StringLength.validate(changeset, opts)
+    assert expected_message == translate_message(message, vars)
+  end
+
+  defp translate_message(message, vars) do
+    Enum.reduce(vars, message, fn {key, value}, acc ->
+      if String.contains?(acc, "%{#{key}}") do
+        String.replace(acc, "%{#{key}}", to_string(value))
+      else
+        acc
+      end
+    end)
+  end
+end

--- a/test/resource/validation/string_length_test.exs
+++ b/test/resource/validation/string_length_test.exs
@@ -27,19 +27,6 @@ defmodule Ash.Test.Resource.Validation.StringLengthTest do
 
       assert_error(changeset, opts, "body must have length of at least 3")
     end
-
-    test "validate failure with message" do
-      {:ok, opts} =
-        StringLength.init(
-          attribute: :body,
-          min: 3,
-          message: "too short, minimum of %{min} characters"
-        )
-
-      changeset = Ash.Changeset.new(Post, %{body: "no"})
-
-      assert_error(changeset, opts, "too short, minimum of 3 characters")
-    end
   end
 
   describe "max length" do
@@ -52,22 +39,9 @@ defmodule Ash.Test.Resource.Validation.StringLengthTest do
 
     test "validate failure" do
       {:ok, opts} = StringLength.init(attribute: :body, max: 3)
-      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      changeset = Ash.Changeset.new(Post, %{body: "invalid"})
 
       assert_error(changeset, opts, "body must have length of no more than 3")
-    end
-
-    test "validate failure with message" do
-      {:ok, opts} =
-        StringLength.init(
-          attribute: :body,
-          max: 3,
-          message: "too long, maximum of %{max} characters"
-        )
-
-      changeset = Ash.Changeset.new(Post, %{body: "no way"})
-
-      assert_error(changeset, opts, "too long, maximum of 3 characters")
     end
   end
 
@@ -85,23 +59,8 @@ defmodule Ash.Test.Resource.Validation.StringLengthTest do
       changeset = Ash.Changeset.new(Post, %{body: "no"})
       assert_error(changeset, opts, "body must have length of exactly 3")
 
-      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      changeset = Ash.Changeset.new(Post, %{body: "invalid"})
       assert_error(changeset, opts, "body must have length of exactly 3")
-    end
-
-    test "validate failure with message" do
-      {:ok, opts} =
-        StringLength.init(
-          attribute: :body,
-          exact: 3,
-          message: "must be %{exact} characters"
-        )
-
-      changeset = Ash.Changeset.new(Post, %{body: "no"})
-      assert_error(changeset, opts, "must be 3 characters")
-
-      changeset = Ash.Changeset.new(Post, %{body: "no way"})
-      assert_error(changeset, opts, "must be 3 characters")
     end
   end
 
@@ -119,24 +78,8 @@ defmodule Ash.Test.Resource.Validation.StringLengthTest do
       changeset = Ash.Changeset.new(Post, %{body: "n"})
       assert_error(changeset, opts, "body must have length of between 2 and 4")
 
-      changeset = Ash.Changeset.new(Post, %{body: "no way"})
+      changeset = Ash.Changeset.new(Post, %{body: "invalid"})
       assert_error(changeset, opts, "body must have length of between 2 and 4")
-    end
-
-    test "validate failure with message" do
-      {:ok, opts} =
-        StringLength.init(
-          attribute: :body,
-          min: 2,
-          max: 4,
-          message: "must be at least %{min} and at most %{max} characters"
-        )
-
-      changeset = Ash.Changeset.new(Post, %{body: "n"})
-      assert_error(changeset, opts, "must be at least 2 and at most 4 characters")
-
-      changeset = Ash.Changeset.new(Post, %{body: "no way"})
-      assert_error(changeset, opts, "must be at least 2 and at most 4 characters")
     end
   end
 


### PR DESCRIPTION
Here's a first crack at a string length validator. It can be used with `:min`, `:max`, `:exact` and a combination of `:min` and `:max`. The contents of the default error message is dependent on the other params provided, and the error message can be overridden.

```elixir
    validate string_length(:body, min: 3, message: "must be min %{min} characters")
```

# Contributor checklist

- [X] Bug fixes include regression tests
- [X] Features include unit/acceptance tests
