### PR TITLE
Fix documentation TOC

### DIFF
--- a/lib/ash/dsl/extension.ex
+++ b/lib/ash/dsl/extension.ex
@@ -167,7 +167,7 @@ defmodule Ash.Dsl.Extension do
         docs =
           if depth == 0 do
             String.duplicate(" ", depth + 1) <>
-              "* [#{section.name}](#module-#{to_string(section.name)})"
+              "* [#{section.name}](#module-#{section.name})"
           else
             String.duplicate(" ", depth + 1) <> "* #{section.name}"
           end

--- a/lib/ash/dsl/extension.ex
+++ b/lib/ash/dsl/extension.ex
@@ -167,7 +167,7 @@ defmodule Ash.Dsl.Extension do
         docs =
           if depth == 0 do
             String.duplicate(" ", depth + 1) <>
-              "* [#{section.name}](#module-#{link_name(section.name)})"
+              "* [#{section.name}](#module-#{to_string(section.name)})"
           else
             String.duplicate(" ", depth + 1) <> "* #{section.name}"
           end
@@ -333,13 +333,6 @@ defmodule Ash.Dsl.Extension do
 
     #{entities_doc}
     """
-  end
-
-  defp link_name(name) do
-    name
-    |> to_string()
-    |> String.split("_")
-    |> Enum.join("-")
   end
 
   def get_opt_config(resource, path, value) do


### PR DESCRIPTION
**I found just one example where this fix is needed, maybe it needs to be the other way around**

Example: https://hexdocs.pm/ash/1.36.3/Ash.Resource.Dsl.html#content

The generated `code_interface` TOC link is `#module-code-interface` while the correct link would be `#module-code_interface`.