### PR TITLE
docs: Fix some documentation warnings

### DIFF
--- a/documentation/topics/pagination.md
+++ b/documentation/topics/pagination.md
@@ -4,7 +4,7 @@ Pagination is configured at the action level. There are two kinds of pagination 
 pros and cons to each. An action can support both at the same time, or only one (or none). A full count of records can be
 requested by passing `page: [count: true]`, but it should be kept in mind that doing this requires running the same query
 twice, one of which is a count of all records. Ash does these in parallel, but it can still be quite expensive on large
-datasets. For more information on the options for configuring actions to support pagination, see the pagination section in `Ash.Resource.Dsl.Read.read/2`
+datasets. For more information on the options for configuring actions to support pagination, see the [pagination section](Ash.Resource.Dsl.html#module-pagination) in `Ash.Resource.Dsl`.
 
 ## Offset Pagination
 

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -378,7 +378,7 @@ defmodule Ash.Api do
               {:ok, Ash.Page.page()} | {:error, term}
 
   @doc """
-  Load fields or relationships on already fetched records. See `c:load/2` for more information.
+  Load fields or relationships on already fetched records. See `c:load/3` for more information.
   """
   @callback load!(
               record_or_records :: Ash.Resource.record() | [Ash.Resource.record()],


### PR DESCRIPTION
i.e. warnings that appear when you run `mix docs`

Although this PR doesn't fix the majority of them, since the majority are errors from referring to `@moduledoc false` modules in docs and typespecs.

# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
