### PR TITLE
improvement: Add timestamps() attribute

### DIFF
--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -59,7 +59,7 @@ defmodule Ash.Resource.Dsl do
     ],
     target: Ash.Resource.Attribute,
     auto_set_fields: [
-      name: :__timestamps
+      name: :__timestamps__
     ]
   }
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -59,7 +59,6 @@ defmodule Ash.Resource.Dsl do
     ],
     target: Ash.Resource.Attribute,
     auto_set_fields: [
-      type: :atom,
       name: :timestamps
     ]
   }

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -49,6 +49,21 @@ defmodule Ash.Resource.Dsl do
     args: [:name]
   }
 
+  @timestamps %Ash.Dsl.Entity{
+    name: :timestamps,
+    describe: """
+    Declares non-writable `inserted_at` and `updated_at` attributes whith create and update defaults of `&DateTime.utc_now/0`.
+    """,
+    examples: [
+      "timestamps()"
+    ],
+    target: Ash.Resource.Attribute,
+    auto_set_fields: [
+      type: :atom,
+      name: :timestamps
+    ]
+  }
+
   @integer_primary_key %Ash.Dsl.Entity{
     name: :integer_primary_key,
     describe: """
@@ -123,6 +138,7 @@ defmodule Ash.Resource.Dsl do
       @attribute,
       @create_timestamp,
       @update_timestamp,
+      @timestamps,
       @integer_primary_key,
       @uuid_primary_key
     ]
@@ -898,6 +914,7 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Transformers.HasDestinationField,
     Ash.Resource.Transformers.CreateJoinRelationship,
     Ash.Resource.Transformers.CachePrimaryKey,
+    Ash.Resource.Transformers.ReplaceTimestamps,
     Ash.Resource.Transformers.SetPrimaryActions,
     Ash.Resource.Transformers.ValidateActionTypesSupported,
     Ash.Resource.Transformers.CountableActions,

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -59,7 +59,7 @@ defmodule Ash.Resource.Dsl do
     ],
     target: Ash.Resource.Attribute,
     auto_set_fields: [
-      name: :timestamps
+      name: :__timestamps
     ]
   }
 

--- a/lib/ash/resource/transformers/replace_timestamps.ex
+++ b/lib/ash/resource/transformers/replace_timestamps.ex
@@ -16,7 +16,7 @@ defmodule Ash.Resource.Transformers.ReplaceTimestamps do
           attrs ++ [attr]
       end)
 
-    new_dsl_state = Map.put(dsl_state, [:attributes], %{entities: attributes})
+    new_dsl_state = put_in(dsl_state, [[:attributes], :entities], attributes)
 
     {:ok, new_dsl_state}
   end

--- a/lib/ash/resource/transformers/replace_timestamps.ex
+++ b/lib/ash/resource/transformers/replace_timestamps.ex
@@ -1,0 +1,43 @@
+defmodule Ash.Resource.Transformers.ReplaceTimestamps do
+  @moduledoc "Replaces a single `timestamps()` attribute with `inserted_at` and `updated_at` timestamps."
+  use Ash.Dsl.Transformer
+
+  alias Ash.Dsl.Transformer
+
+  def transform(_resource, dsl_state) do
+    attributes =
+      dsl_state
+      |> Transformer.get_entities([:attributes])
+      |> Enum.reduce([], fn
+        %{name: :timestamps}, attrs ->
+          attrs ++ timestamp_attributes()
+
+        attr, attrs ->
+          attrs ++ [attr]
+      end)
+
+    new_dsl_state = Map.put(dsl_state, [:attributes], %{entities: attributes})
+
+    {:ok, new_dsl_state}
+  end
+
+  defp timestamp_attributes do
+    %{
+      inserted_at: Ash.Resource.Attribute.create_timestamp_schema(),
+      updated_at: Ash.Resource.Attribute.update_timestamp_schema()
+    }
+    |> Enum.map(&build_attribute/1)
+    |> Enum.map(fn {:ok, attr} -> attr end)
+  end
+
+  defp build_attribute({name, schema}) do
+    params = %{
+      target: Ash.Resource.Attribute,
+      schema: schema,
+      auto_set_fields: [name: name],
+      transform: nil
+    }
+
+    Ash.Dsl.Entity.build(params, [], [])
+  end
+end

--- a/lib/ash/resource/transformers/replace_timestamps.ex
+++ b/lib/ash/resource/transformers/replace_timestamps.ex
@@ -9,7 +9,7 @@ defmodule Ash.Resource.Transformers.ReplaceTimestamps do
       dsl_state
       |> Transformer.get_entities([:attributes])
       |> Enum.reduce([], fn
-        %{name: :timestamps}, attrs ->
+        %{name: :__timestamps}, attrs ->
           attrs ++ timestamp_attributes()
 
         attr, attrs ->

--- a/lib/ash/resource/transformers/replace_timestamps.ex
+++ b/lib/ash/resource/transformers/replace_timestamps.ex
@@ -9,7 +9,7 @@ defmodule Ash.Resource.Transformers.ReplaceTimestamps do
       dsl_state
       |> Transformer.get_entities([:attributes])
       |> Enum.reduce([], fn
-        %{name: :__timestamps}, attrs ->
+        %{name: :__timestamps__}, attrs ->
           attrs ++ timestamp_attributes()
 
         attr, attrs ->


### PR DESCRIPTION
```elixir
attributes do
  timestamps()

  # will create the same attributes as

  create_timestamp :inserted_at
  update_timestamp :updated_at
end
```

I couldn't find a more elegant way to implement this, if there is one I'd be happy to change it :)