### PR TITLE
Docs: Fix Api.get example

### DIFF
--- a/documentation/introduction/getting_started.md
+++ b/documentation/introduction/getting_started.md
@@ -278,7 +278,7 @@ iex(3)> MyApp.Api.read(MyApp.User)
      id: "2642ca11-330b-4a07-83c7-b0e9ef391df6"
    }
  ]}
-iex(4)> MyApp.Api.get(MyApp.User, "ash.man@enguento.com")
+iex(4)> MyApp.Api.get(MyApp.User, "2642ca11-330b-4a07-83c7-b0e9ef391df6")
 {:ok,
  %MyApp.User{
    __meta__: #Ecto.Schema.Metadata<:built, "">,


### PR DESCRIPTION
The `Api.get` example in the docs uses the email instead of the ID to
get the newly created resource. Trying this locally while running
through the getting started tutorial returns a `nil` resource using the
email, but the correct resource when using the ID.

This fix updates the docs to use the ID in the get call.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
