### PR TITLE
allow specifying that calculation can't be nil

### DIFF
--- a/lib/ash/resource/calculation/calculation.ex
+++ b/lib/ash/resource/calculation/calculation.ex
@@ -1,6 +1,6 @@
 defmodule Ash.Resource.Calculation do
   @moduledoc "Represents a named calculation on a resource"
-  defstruct [:name, :type, :calculation, :arguments, :description, :private?]
+  defstruct [:name, :type, :calculation, :arguments, :description, :private?, :allow_nil?]
 
   @schema [
     name: [
@@ -26,6 +26,11 @@ defmodule Ash.Resource.Calculation do
       default: false,
       doc:
         "Whether or not the calculation will appear in any interfaces created off of this resource, e.g AshJsonApi and AshGraphql"
+    ],
+    allow_nil?: [
+      type: :boolean,
+      default: true,
+      doc: "Whether or not the calculation can return nil."
     ]
   ]
 
@@ -34,7 +39,8 @@ defmodule Ash.Resource.Calculation do
           calculation: {:ok, {atom(), any()}} | {:error, String.t()},
           arguments: list(any()),
           description: String.t() | nil,
-          private?: boolean
+          private?: boolean,
+          allow_nil?: boolean
         }
 
   defmodule Argument do


### PR DESCRIPTION
I would like a way to specify that a calculation value can't return nil to use in generating the graphql type. Let me know if there is any validation I need to add and where I should add it.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
