### PR TITLE
Embedded struct casting fix

### DIFF
--- a/lib/ash/embeddable_type.ex
+++ b/lib/ash/embeddable_type.ex
@@ -132,9 +132,14 @@ defmodule Ash.EmbeddableType do
       alias __MODULE__.ShadowApi
       def storage_type, do: :map
 
-      def cast_input(%{__struct__: __MODULE__, __metadata__: %{private: %{casted?: true}}} = input, _constraints), do: {:ok, input}
+      def cast_input(
+            %{__struct__: __MODULE__, __metadata__: %{private: %{casted?: true}}} = input,
+            _constraints
+          ),
+          do: {:ok, input}
 
-      def cast_input(%{__struct__: __MODULE__} = input, constraints), do: cast_input(Map.from_struct(input), constraints)
+      def cast_input(%{__struct__: __MODULE__} = input, constraints),
+        do: cast_input(Map.from_struct(input), constraints)
 
       def cast_input(value, constraints) when is_map(value) do
         action =
@@ -163,9 +168,11 @@ defmodule Ash.EmbeddableType do
           with {:fetch, {:ok, value}} <- {:fetch, fetch_key(value, attr.name)},
                {:ok, casted} <-
                  Ash.Type.cast_stored(attr.type, value, constraints) do
-            {:cont, {:ok, struct
-                          |> Map.put(attr.name, casted)
-                          |> Ash.Resource.Info.set_metadata(%{private: %{casted?: true}})}}
+            {:cont,
+             {:ok,
+              struct
+              |> Map.put(attr.name, casted)
+              |> Ash.Resource.Info.set_metadata(%{private: %{casted?: true}})}}
           else
             {:fetch, :error} ->
               {:cont, {:ok, struct}}

--- a/lib/ash/embeddable_type.ex
+++ b/lib/ash/embeddable_type.ex
@@ -132,7 +132,7 @@ defmodule Ash.EmbeddableType do
       alias __MODULE__.ShadowApi
       def storage_type, do: :map
 
-      def cast_input(%{__struct__: __MODULE__} = input, _constraints), do: {:ok, input}
+      def cast_input(%{__struct__: __MODULE__} = input, constraints), do: cast_input(Map.from_struct(input), constraints)
 
       def cast_input(value, constraints) when is_map(value) do
         action =

--- a/test/embedded_resource_cast_struct_test.exs
+++ b/test/embedded_resource_cast_struct_test.exs
@@ -1,22 +1,6 @@
-defmodule Ash.Test.Type.DecimalTest do
+defmodule Ash.Test.EmbeddedResourceCastStructTest do
   @moduledoc false
   use ExUnit.Case, async: true
-
-  defmodule Vector2 do
-    @moduledoc false
-    use Ash.Resource, data_layer: Ash.DataLayer.Ets
-
-    ets do
-      private?(true)
-    end
-
-    attributes do
-      uuid_primary_key :id
-
-      attribute :x, :decimal
-      attribute :y, :decimal
-    end
-  end
 
   defmodule Vector3 do
     @moduledoc false
@@ -52,33 +36,12 @@ defmodule Ash.Test.Type.DecimalTest do
 
     resources do
       resource Transform
-      resource Vector2
     end
   end
 
   import Ash.Changeset
 
-  test "decimal type works on regular resource" do
-    assert vector2 = %Vector2{x: %Decimal{}, y: %Decimal{}} =
-      Vector2
-      |> new(%{x: 0, y: 0})
-      |> Api.create!()
-
-    assert vector2 == Api.get!(Vector2, vector2.id)
-
-    assert vector2_updated = %Vector2{x: %Decimal{}, y: %Decimal{}} = %Vector2{x: %Decimal{}, y: %Decimal{}} =
-      vector2
-      |> new(%{x: 1.1, y: 1.1})
-      |> Api.update!()
-
-    assert Decimal.new("1.1") == vector2_updated.x
-    assert Decimal.new("1.1") == vector2_updated.y
-
-    assert [_] = Api.read!(Vector2)
-    assert :ok = Api.destroy!(vector2_updated)
-  end
-
-  test "decimal type works on embedded resources" do
+  test "embedded resource is casted if passed as a struct" do
     assert transform = %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
       Transform
       |> new(%{position: %Vector3{x: 0, y: 0, z: 0}})

--- a/test/embedded_resource_cast_struct_test.exs
+++ b/test/embedded_resource_cast_struct_test.exs
@@ -42,19 +42,21 @@ defmodule Ash.Test.EmbeddedResourceCastStructTest do
   import Ash.Changeset
 
   test "embedded resource is casted if passed as a struct" do
-    assert transform = %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
-      Transform
-      |> new(%{position: %Vector3{x: 0, y: 0, z: 0}})
-      |> Api.create!()
+    assert transform =
+             %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
+             Transform
+             |> new(%{position: %Vector3{x: 0, y: 0, z: 0}})
+             |> Api.create!()
 
     assert [_] = Api.read!(Transform)
 
     assert transform == Api.get!(Transform, transform.id)
 
-    assert transform_updated = %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
-      transform
-      |> new(position: %Vector3{x: 1.1, y: 1.1, z: 1.1})
-      |> Api.update!()
+    assert transform_updated =
+             %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
+             transform
+             |> new(position: %Vector3{x: 1.1, y: 1.1, z: 1.1})
+             |> Api.update!()
 
     assert Decimal.new("1.1") == transform_updated.position.x
     assert Decimal.new("1.1") == transform_updated.position.y

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -46,7 +46,6 @@ defmodule Ash.Test.Type.DecimalTest do
     end
   end
 
-
   defmodule Api do
     @moduledoc false
     use Ash.Api
@@ -83,7 +82,6 @@ defmodule Ash.Test.Type.DecimalTest do
     assert transform = %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
       Transform
       |> new(%{position: %Vector3{x: 0, y: 0, z: 0}})
-      |> IO.inspect()
       |> Api.create!()
 
     assert [_] = Api.read!(Transform)

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -1,0 +1,104 @@
+defmodule Ash.Test.Type.DecimalTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule Vector2 do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :x, :decimal
+      attribute :y, :decimal
+    end
+  end
+
+  defmodule Vector3 do
+    @moduledoc false
+    use Ash.Resource, data_layer: :embedded
+
+    attributes do
+      attribute :x, :decimal
+      attribute :y, :decimal
+      attribute :z, :decimal
+    end
+  end
+
+  defmodule Transform do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :position, Vector3
+      attribute :rotation, Vector3
+      attribute :scale, Vector3
+    end
+  end
+
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      resource Transform
+      resource Vector2
+    end
+  end
+
+  import Ash.Changeset
+
+  test "decimal type works on regular resource" do
+    assert vector2 = %Vector2{x: %Decimal{}, y: %Decimal{}} =
+      Vector2
+      |> new(%{x: 0, y: 0})
+      |> Api.create!()
+
+    assert vector2 == Api.get!(Vector2, vector2.id)
+
+    assert vector2_updated = %Vector2{x: %Decimal{}, y: %Decimal{}} = %Vector2{x: %Decimal{}, y: %Decimal{}} =
+      vector2
+      |> new(%{x: 1.1, y: 1.1})
+      |> Api.update!()
+
+    assert Decimal.new("1.1") == vector2_updated.x
+    assert Decimal.new("1.1") == vector2_updated.y
+
+    assert [_] = Api.read!(Vector2)
+    assert :ok = Api.destroy!(vector2_updated)
+  end
+
+  test "decimal type works on embedded resources" do
+    assert transform = %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
+      Transform
+      |> new(%{position: %Vector3{x: 0, y: 0, z: 0}})
+      |> IO.inspect()
+      |> Api.create!()
+
+    assert [_] = Api.read!(Transform)
+
+    assert transform == Api.get!(Transform, transform.id)
+
+    assert transform_updated = %Transform{position: %Vector3{x: %Decimal{}, y: %Decimal{}, z: %Decimal{}}} =
+      transform
+      |> new(position: %Vector3{x: 1.1, y: 1.1, z: 1.1})
+      |> Api.update!()
+
+    assert Decimal.new("1.1") == transform_updated.position.x
+    assert Decimal.new("1.1") == transform_updated.position.y
+    assert Decimal.new("1.1") == transform_updated.position.z
+
+    assert :ok = Api.destroy!(transform)
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

I've discovered a strange behaviour of embedded resources. If they are passed to the `Ash.Changeset.new` as a structs, `Ash` assumes they are already casted, which is not necessarily true. 
Now `cast_input/2` and `cast_stored/2` in `Ash.EmbeddableType.single_embed_implementation` track if the resource was casted adding `%{private: %{casted?: true}}` to the resource metadata