### PR TITLE
fix: Decimal casting issues on ash_postgres

### DIFF
--- a/lib/ash/type/decimal.ex
+++ b/lib/ash/type/decimal.ex
@@ -64,8 +64,30 @@ defmodule Ash.Type.Decimal do
   end
 
   @impl true
+  def cast_input(value, _) when is_binary(value) do
+    case Decimal.parse(value) do
+      {decimal, ""} ->
+        {:ok, decimal}
+
+      _ ->
+        :error
+    end
+  end
+
+  @impl true
   def cast_input(value, _) do
     Ecto.Type.cast(:decimal, value)
+  end
+
+  @impl true
+  def cast_stored(value, _) when is_binary(value) do
+    case Decimal.parse(value) do
+      {decimal, ""} ->
+        {:ok, decimal}
+
+      _ ->
+        :error
+    end
   end
 
   @impl true
@@ -74,6 +96,7 @@ defmodule Ash.Type.Decimal do
   end
 
   @impl true
+  @spec dump_to_native(any, any) :: :error | {:ok, any}
   def dump_to_native(value, _) do
     Ecto.Type.dump(:decimal, value)
   end


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Ash.Type.Decimal wasn't working on embedded resources. It was serialised as a string. I've added `Ash.Type.Decimal.cast_input/2` and `Ash.Type.Decimal.cast_stored/2` implementations for string-encoded values.