### PR TITLE
chore: Enable Credo's Readability.StrictModuleLayout

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -156,7 +156,9 @@
         #
         # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
         #
-        {Credo.Check.Readability.StrictModuleLayout, false},
+        {Credo.Check.Readability.StrictModuleLayout,
+          order: [:shortdoc, :moduledoc, :behaviour, :use, :defstruct, :type, :import, :alias, :require],
+          ignore: [:module_attribute, :type]},
         {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
         {Credo.Check.Consistency.UnusedVariableNames, false},
         {Credo.Check.Design.DuplicatedCode, false},

--- a/lib/ash/actions/create.ex
+++ b/lib/ash/actions/create.ex
@@ -1,10 +1,11 @@
 defmodule Ash.Actions.Create do
   @moduledoc false
-  require Logger
 
   alias Ash.Actions.Helpers
   alias Ash.Engine
   alias Ash.Engine.Request
+
+  require Logger
 
   @spec run(Ash.Api.t(), Ash.Changeset.t(), Ash.Resource.Actions.action(), Keyword.t()) ::
           {:ok, Ash.Resource.record(), list(Ash.Notifier.Notification.t())}

--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -1,9 +1,10 @@
 defmodule Ash.Actions.ManagedRelationships do
   @moduledoc false
-  require Ash.Query
 
   alias Ash.Error.Changes.InvalidRelationship
   alias Ash.Error.Query.NotFound
+
+  require Ash.Query
 
   def load(_api, created, %{relationships: rels}, _) when rels == %{},
     do: {:ok, created}

--- a/lib/ash/actions/read.ex
+++ b/lib/ash/actions/read.ex
@@ -1,7 +1,5 @@
 defmodule Ash.Actions.Read do
   @moduledoc false
-  require Logger
-  require Ash.Query
 
   alias Ash.Actions.{Helpers, SideLoad}
   alias Ash.Engine
@@ -10,6 +8,9 @@ defmodule Ash.Actions.Read do
   alias Ash.Error.Query.NoReadAction
   alias Ash.Filter
   alias Ash.Query.Aggregate
+
+  require Logger
+  require Ash.Query
 
   def unpaginated_read(query, action \\ nil, opts \\ []) do
     action = action || Ash.Resource.Info.primary_action(query.resource, :read)

--- a/lib/ash/actions/update.ex
+++ b/lib/ash/actions/update.ex
@@ -1,10 +1,11 @@
 defmodule Ash.Actions.Update do
   @moduledoc false
 
-  require Logger
   alias Ash.Actions.Helpers
   alias Ash.Engine
   alias Ash.Engine.Request
+
+  require Logger
 
   @spec run(Ash.Api.t(), Ash.Resource.record(), Ash.Resource.Actions.action(), Keyword.t()) ::
           {:ok, Ash.Resource.record(), list(Ash.Notifier.Notification.t())}

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -29,6 +29,8 @@ defmodule Ash.Api do
   See the resource DSL documentation for more.
   """
 
+  use Ash.Dsl, default_extensions: [extensions: [Ash.Api.Dsl]]
+
   import Ash.OptionsHelpers, only: [merge_schemas: 3]
 
   alias Ash.Actions.{Create, Destroy, Read, Update}
@@ -38,6 +40,8 @@ defmodule Ash.Api do
     NoSuchAction,
     NoSuchResource
   }
+
+  alias Ash.Dsl.Extension
 
   require Ash.Query
 
@@ -409,10 +413,6 @@ defmodule Ash.Api do
   @callback reload(record :: Ash.Resource.record()) ::
               {:ok, Ash.Resource.record()} | {:error, term}
 
-  alias Ash.Dsl.Extension
-
-  use Ash.Dsl, default_extensions: [extensions: [Ash.Api.Dsl]]
-
   def handle_opts(_) do
     quote do
       @behaviour Ash.Api
@@ -424,8 +424,6 @@ defmodule Ash.Api do
       use Ash.Api.Interface
     end
   end
-
-  alias Ash.Dsl.Extension
 
   def resource(api, resource) do
     api

--- a/lib/ash/data_layer/ets.ex
+++ b/lib/ash/data_layer/ets.ex
@@ -5,8 +5,6 @@ defmodule Ash.DataLayer.Ets do
   This is used for testing. *Do not use this data layer in production*
   """
 
-  alias Ash.Actions.Sort
-
   @behaviour Ash.DataLayer
 
   @ets %Ash.Dsl.Section{
@@ -29,8 +27,9 @@ defmodule Ash.DataLayer.Ets do
       ]
     ]
   }
-
   use Ash.Dsl.Extension, sections: [@ets]
+
+  alias Ash.Actions.Sort
   alias Ash.Dsl.Extension
 
   @spec private?(Ash.Resource.t()) :: boolean

--- a/lib/ash/data_layer/mnesia.ex
+++ b/lib/ash/data_layer/mnesia.ex
@@ -10,8 +10,32 @@ defmodule Ash.DataLayer.Mnesia do
   in place. This is primarily used for testing the behavior of data layers in Ash. If it was improved,
   it could be a viable data layer.
   """
+  @behaviour Ash.DataLayer
+
+  @mnesia %Ash.Dsl.Section{
+    name: :mnesia,
+    describe: """
+    A section for configuring the mnesia data layer
+    """,
+    examples: [
+      """
+      mnesia do
+        table :custom_table
+      end
+      """
+    ],
+    schema: [
+      table: [
+        type: :atom,
+        doc: "The table name to use, defaults to the name of the resource"
+      ]
+    ]
+  }
+
+  use Ash.Dsl.Extension, sections: [@mnesia]
 
   alias Ash.Actions.Sort
+  alias Ash.Dsl.Extension
   alias :mnesia, as: Mnesia
 
   def start(api) do
@@ -39,32 +63,6 @@ defmodule Ash.DataLayer.Mnesia do
       end
     end)
   end
-
-  @behaviour Ash.DataLayer
-
-  @mnesia %Ash.Dsl.Section{
-    name: :mnesia,
-    describe: """
-    A section for configuring the mnesia data layer
-    """,
-    examples: [
-      """
-      mnesia do
-        table :custom_table
-      end
-      """
-    ],
-    schema: [
-      table: [
-        type: :atom,
-        doc: "The table name to use, defaults to the name of the resource"
-      ]
-    ]
-  }
-
-  use Ash.Dsl.Extension, sections: [@mnesia]
-
-  alias Ash.Dsl.Extension
 
   def table(resource) do
     Extension.get_opt(resource, [:ets], :private?, resource, true)

--- a/lib/ash/data_layer/simple/simple.ex
+++ b/lib/ash/data_layer/simple/simple.ex
@@ -6,6 +6,12 @@ defmodule Ash.DataLayer.Simple do
   by embedded resources
   """
 
+  @transformers [
+    Ash.DataLayer.Simple.Transformers.ValidateDslSections
+  ]
+
+  use Ash.Dsl.Extension, transformers: @transformers, sections: []
+
   alias Ash.Query.Operator.{
     Eq,
     GreaterThan,
@@ -73,10 +79,4 @@ defmodule Ash.DataLayer.Simple do
   def destroy(_resource, _changeset) do
     :ok
   end
-
-  @transformers [
-    Ash.DataLayer.Simple.Transformers.ValidateDslSections
-  ]
-
-  use Ash.Dsl.Extension, transformers: @transformers, sections: []
 end

--- a/lib/ash/dsl/extension.ex
+++ b/lib/ash/dsl/extension.ex
@@ -721,8 +721,8 @@ defmodule Ash.Dsl.Extension do
 
         {:module, module, _, _} =
           defmodule mod_name do
-            alias Ash.Dsl
             @moduledoc false
+            alias Ash.Dsl
 
             require Dsl.Extension
 

--- a/lib/ash/engine/engine.ex
+++ b/lib/ash/engine/engine.ex
@@ -33,6 +33,9 @@ defmodule Ash.Engine do
   interface at the moment, though, so this documentation is just here to explain how it works
   it is not intended to give you enough information to use the engine directly.
   """
+
+  use GenServer
+
   defstruct [
     :api,
     :requests,
@@ -52,8 +55,6 @@ defmodule Ash.Engine do
   ]
 
   alias Ash.Engine.{Request, Runner}
-
-  use GenServer
 
   require Logger
 

--- a/lib/ash/engine/request.ex
+++ b/lib/ash/engine/request.ex
@@ -4,12 +4,45 @@ defmodule Ash.Engine.Request do
 
   See `new/1` for more information
   """
+  defstruct [
+    :id,
+    :async?,
+    :error?,
+    :resource,
+    :changeset,
+    :path,
+    :action_type,
+    :action,
+    :data,
+    :name,
+    :api,
+    :query,
+    :authorization_filter,
+    :write_to_data?,
+    :strict_check_only?,
+    :verbose?,
+    :state,
+    :actor,
+    :authorize?,
+    :engine_pid,
+    manage_changeset?: false,
+    notify?: false,
+    authorized?: false,
+    authorizer_state: %{},
+    dependencies_to_send: %{},
+    dependency_data: %{},
+    dependencies_requested: []
+  ]
 
+  @type t :: %__MODULE__{}
+
+  alias Ash.Authorizer
   alias Ash.Error.Forbidden.MustPassStrictCheck
   alias Ash.Error.Framework.AssumptionFailed
   alias Ash.Error.Invalid.{DuplicatedPath, ImpossiblePath}
 
   require Ash.Query
+  require Logger
 
   defmodule UnresolvedField do
     @moduledoc """
@@ -44,42 +77,6 @@ defmodule Ash.Engine.Request do
       ])
     end
   end
-
-  defstruct [
-    :id,
-    :async?,
-    :error?,
-    :resource,
-    :changeset,
-    :path,
-    :action_type,
-    :action,
-    :data,
-    :name,
-    :api,
-    :query,
-    :authorization_filter,
-    :write_to_data?,
-    :strict_check_only?,
-    :verbose?,
-    :state,
-    :actor,
-    :authorize?,
-    :engine_pid,
-    manage_changeset?: false,
-    notify?: false,
-    authorized?: false,
-    authorizer_state: %{},
-    dependencies_to_send: %{},
-    dependency_data: %{},
-    dependencies_requested: []
-  ]
-
-  @type t :: %__MODULE__{}
-
-  require Logger
-
-  alias Ash.Authorizer
 
   @doc """
   Create an unresolved field.

--- a/lib/ash/engine/request_handler.ex
+++ b/lib/ash/engine/request_handler.ex
@@ -1,5 +1,7 @@
 defmodule Ash.Engine.RequestHandler do
   @moduledoc false
+  use GenServer
+
   defstruct [
     :request,
     :verbose?,
@@ -11,10 +13,9 @@ defmodule Ash.Engine.RequestHandler do
     notifications_sent: MapSet.new()
   ]
 
-  use GenServer
-  require Logger
-
   alias Ash.Engine.Request
+
+  require Logger
 
   def init(opts) do
     Process.put(:"$callers", opts[:callers])
@@ -175,9 +176,7 @@ defmodule Ash.Engine.RequestHandler do
     log(
       state,
       fn ->
-        "Synchronous runner stuck: async request handler current state #{
-          inspect(state.request.path)
-        } #{state.request.state}"
+        "Synchronous runner stuck: async request handler current state #{inspect(state.request.path)} #{state.request.state}"
       end
     )
 

--- a/lib/ash/error/error.ex
+++ b/lib/ash/error/error.ex
@@ -2,6 +2,9 @@ defmodule Ash.Error do
   @moduledoc """
   Tools and utilities used by Ash to manage and conform errors
   """
+
+  alias Ash.Error.{Forbidden, Framework, Invalid, Unknown}
+
   @type error_class() :: :invalid | :authorization | :framework | :unknown
 
   @type t :: struct
@@ -15,8 +18,6 @@ defmodule Ash.Error do
     :framework,
     :unknown
   ]
-
-  alias Ash.Error.{Forbidden, Framework, Invalid, Unknown}
 
   @error_modules [
     forbidden: Forbidden,

--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -1,4 +1,5 @@
 defmodule Ash.Filter do
+  # credo:disable-for-this-file Credo.Check.Readability.StrictModuleLayout
   @dialyzer {:nowarn_function, do_map: 2, map: 2}
   alias Ash.Actions.SideLoad
   alias Ash.Engine.Request

--- a/lib/ash/query/aggregate.ex
+++ b/lib/ash/query/aggregate.ex
@@ -13,19 +13,19 @@ defmodule Ash.Query.Aggregate do
     :load
   ]
 
-  @kinds [:count, :first, :sum]
-
   @type t :: %__MODULE__{}
+
+  @kinds [:count, :first, :sum]
   @type kind :: unquote(Enum.reduce(@kinds, &{:|, [], [&1, &2]}))
+
+  alias Ash.Actions.SideLoad
+  alias Ash.Engine.Request
+  alias Ash.Error.Query.{NoReadAction, NoSuchRelationship}
 
   require Ash.Query
 
   @doc false
   def kinds, do: @kinds
-
-  alias Ash.Actions.SideLoad
-  alias Ash.Engine.Request
-  alias Ash.Error.Query.{NoReadAction, NoSuchRelationship}
 
   def new(resource, name, kind, relationship, query, field) do
     field_type =

--- a/lib/ash/query/boolean_expression.ex
+++ b/lib/ash/query/boolean_expression.ex
@@ -2,10 +2,10 @@ defmodule Ash.Query.BooleanExpression do
   @moduledoc "Represents a boolean expression"
   @dialyzer {:nowarn_function, optimized_new: 4}
 
+  defstruct [:op, :left, :right]
+
   alias Ash.Query.Operator.{Eq, In, NotEq}
   alias Ash.Query.Ref
-
-  defstruct [:op, :left, :right]
 
   def new(_, nil, nil), do: nil
   def new(_, left, nil), do: left

--- a/lib/ash/query/function/function.ex
+++ b/lib/ash/query/function/function.ex
@@ -6,6 +6,8 @@ defmodule Ash.Query.Function do
   are there. A function must meet both behaviours.
   """
 
+  alias Ash.Query.{BooleanExpression, Call, Not, Ref}
+
   @type arg :: any
   @doc """
   The number and types of arguments supported.
@@ -13,8 +15,6 @@ defmodule Ash.Query.Function do
   @callback args() :: [arg]
   @callback new(list(term)) :: {:ok, term}
   @callback evaluate(func :: map) :: :unknown | {:known, term}
-
-  alias Ash.Query.{BooleanExpression, Call, Not, Ref}
 
   def new(mod, args) do
     args = List.wrap(args)

--- a/lib/ash/query/operator/operator.ex
+++ b/lib/ash/query/operator/operator.ex
@@ -6,6 +6,8 @@ defmodule Ash.Query.Operator do
   are there. An operator must meet both behaviours.
   """
 
+  alias Ash.Query.{Call, Expression, Not, Ref}
+
   @doc """
   Create a new predicate. There are various return types possible:
 
@@ -23,8 +25,6 @@ defmodule Ash.Query.Operator do
   If not defined, it will be inferred
   """
   @callback to_string(struct, Inspect.Opts.t()) :: term
-
-  alias Ash.Query.{Call, Expression, Not, Ref}
 
   @doc "Create a new operator. Pass the module and the left and right values"
   def new(mod, %Ref{} = left, right) do

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -54,6 +54,20 @@ defmodule Ash.Query do
 
   @type t :: %__MODULE__{}
 
+  alias Ash.Actions.Sort
+
+  alias Ash.Error.Query.{
+    AggregatesNotSupported,
+    InvalidArgument,
+    InvalidLimit,
+    InvalidOffset,
+    NoReadAction,
+    Required
+  }
+
+  alias Ash.Error.SideLoad.{InvalidQuery, NoSuchRelationship}
+  alias Ash.Query.{Aggregate, BooleanExpression, Calculation}
+
   defimpl Inspect do
     import Inspect.Algebra
 
@@ -121,20 +135,6 @@ defmodule Ash.Query do
     defp or_empty(value, true), do: value
     defp or_empty(_, false), do: empty()
   end
-
-  alias Ash.Actions.Sort
-
-  alias Ash.Error.Query.{
-    AggregatesNotSupported,
-    InvalidArgument,
-    InvalidLimit,
-    InvalidOffset,
-    NoReadAction,
-    Required
-  }
-
-  alias Ash.Error.SideLoad.{InvalidQuery, NoSuchRelationship}
-  alias Ash.Query.{Aggregate, BooleanExpression, Calculation}
 
   @doc """
   Attach a filter statement to the query.

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -913,9 +913,6 @@ defmodule Ash.Resource.Dsl do
     ]
   }
 
-  @doc false
-  def identity(x), do: x
-
   @sections [
     @identities,
     @attributes,
@@ -959,4 +956,7 @@ defmodule Ash.Resource.Dsl do
   use Ash.Dsl.Extension,
     sections: @sections,
     transformers: @transformers
+
+  @doc false
+  def identity(x), do: x
 end

--- a/lib/ash/resource/relationships/has_one.ex
+++ b/lib/ash/resource/relationships/has_one.ex
@@ -33,8 +33,8 @@ defmodule Ash.Resource.Relationships.HasOne do
           description: String.t()
         }
 
-  alias Ash.OptionsHelpers
   import Ash.Resource.Relationships.SharedOptions
+  alias Ash.OptionsHelpers
 
   @global_opts shared_options()
                |> OptionsHelpers.make_required!(:destination_field)

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -50,16 +50,6 @@ defmodule Ash.Resource.Validation do
     on: []
   ]
 
-  defmacro __using__(_) do
-    quote do
-      @behaviour Ash.Resource.Validation
-
-      def init(opts), do: {:ok, opts}
-
-      defoverridable init: 1
-    end
-  end
-
   @type t :: %__MODULE__{
           validation: {atom(), list(atom())},
           module: atom(),
@@ -111,6 +101,16 @@ defmodule Ash.Resource.Validation do
   ]
 
   @action_schema Keyword.delete(@schema, :on)
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour Ash.Resource.Validation
+
+      def init(opts), do: {:ok, opts}
+
+      defoverridable init: 1
+    end
+  end
 
   def transform(%__MODULE__{validation: {module, opts}} = validation) do
     {:ok, %{validation | module: module, opts: opts}}

--- a/lib/ash/resource/validation/attribute_does_not_equal.ex
+++ b/lib/ash/resource/validation/attribute_does_not_equal.ex
@@ -1,5 +1,9 @@
 defmodule Ash.Resource.Validation.AttributeDoesNotEqual do
   @moduledoc "A validation that fails unless the attribute does not equal a specific value"
+  use Ash.Resource.Validation
+
+  alias Ash.Error.Changes.InvalidAttribute
+
   @opt_schema [
     attribute: [
       type: :atom,
@@ -12,10 +16,6 @@ defmodule Ash.Resource.Validation.AttributeDoesNotEqual do
       doc: "The value the attribute must not equal"
     ]
   ]
-
-  alias Ash.Error.Changes.InvalidAttribute
-
-  use Ash.Resource.Validation
 
   @impl true
   def init(opts) do

--- a/lib/ash/resource/validation/changing.ex
+++ b/lib/ash/resource/validation/changing.ex
@@ -1,8 +1,9 @@
 defmodule Ash.Resource.Validation.Changing do
   @moduledoc false
-  alias Ash.Error.Changes.InvalidAttribute
 
   use Ash.Resource.Validation
+
+  alias Ash.Error.Changes.InvalidAttribute
 
   @opt_schema [
     field: [

--- a/lib/ash/resource/validation/match.ex
+++ b/lib/ash/resource/validation/match.ex
@@ -1,8 +1,9 @@
 defmodule Ash.Resource.Validation.Match do
   @moduledoc false
-  alias Ash.Error.Changes.InvalidAttribute
 
   use Ash.Resource.Validation
+
+  alias Ash.Error.Changes.InvalidAttribute
 
   @opt_schema [
     attribute: [

--- a/lib/ash/resource/validation/one_of.ex
+++ b/lib/ash/resource/validation/one_of.ex
@@ -1,8 +1,9 @@
 defmodule Ash.Resource.Validation.OneOf do
   @moduledoc false
-  alias Ash.Error.Changes.InvalidAttribute
 
   use Ash.Resource.Validation
+
+  alias Ash.Error.Changes.InvalidAttribute
 
   @opt_schema [
     values: [

--- a/lib/ash/resource/validation/present.ex
+++ b/lib/ash/resource/validation/present.ex
@@ -1,8 +1,8 @@
 defmodule Ash.Resource.Validation.Present do
   @moduledoc false
-  alias Ash.Error.Changes.{InvalidAttribute, InvalidChanges}
-
   use Ash.Resource.Validation
+
+  alias Ash.Error.Changes.{InvalidAttribute, InvalidChanges}
 
   @opt_schema [
     at_least: [

--- a/lib/ash/sort/sort.ex
+++ b/lib/ash/sort/sort.ex
@@ -3,12 +3,12 @@ defmodule Ash.Sort do
   Utilities and types for sorting.
   """
 
-  alias Ash.Error.Query.{InvalidSortOrder, NoSuchAttribute}
-
   @type sort_order ::
           :asc | :desc | :asc_nils_first | :asc_nils_last | :desc_nils_first | :desc_nils_last
 
   @type t :: list(atom | {atom, sort_order})
+
+  alias Ash.Error.Query.{InvalidSortOrder, NoSuchAttribute}
 
   @doc """
   A utility for parsing sorts provided from external input. Only allows sorting

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -35,11 +35,6 @@ defmodule Ash.Type do
     url_encoded_binary: Ash.Type.UrlEncodedBinary
   ]
 
-  @builtin_types Keyword.values(@short_names)
-
-  def builtin?(type) when type in @builtin_types, do: true
-  def builtin?(_), do: false
-
   @doc_array_constraints Keyword.put(@array_constraints, :items,
                            type: :any,
                            doc:
@@ -106,7 +101,11 @@ defmodule Ash.Type do
   All the Ash built-in types are implemented with `use Ash.Type` so they are good
   examples to look at to create your own `Ash.Type`
   """
+
   @type constraints :: Keyword.t()
+  @type constraint_error :: String.t() | {String.t(), Keyword.t()}
+  @type t :: atom | {:array, atom}
+
   @callback storage_type() :: Ecto.Type.t()
   @callback ecto_type() :: Ecto.Type.t()
   @callback cast_input(term, constraints) :: {:ok, term} | {:error, Keyword.t()} | :error
@@ -155,8 +154,10 @@ defmodule Ash.Type do
     dump_to_embedded_array: 2
   ]
 
-  @type constraint_error :: String.t() | {String.t(), Keyword.t()}
-  @type t :: atom | {:array, atom}
+  @builtin_types Keyword.values(@short_names)
+
+  def builtin?(type) when type in @builtin_types, do: true
+  def builtin?(_), do: false
 
   def embedded_type?({:array, type}) do
     embedded_type?(type)

--- a/lib/mix/tasks/ash.formatter.ex
+++ b/lib/mix/tasks/ash.formatter.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Ash.Formatter do
-  @moduledoc "Generates a .formatter.exs from a list of extensions, and writes it."
+  @shortdoc "Generates a .formatter.exs from a list of extensions, and writes it."
+  @moduledoc @shortdoc
   use Mix.Task
 
   @formatter_exs_template """
@@ -17,7 +18,6 @@ defmodule Mix.Tasks.Ash.Formatter do
 
   """
 
-  @shortdoc @moduledoc
   @spec run(term) :: no_return
   def run(opts) do
     Mix.Task.run("compile")

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -2,7 +2,10 @@ defmodule Ash.Test.Actions.CreateTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
+
   defmodule Authorized do
+    @moduledoc false
     use Ash.Resource,
       data_layer: Ash.DataLayer.Ets,
       authorizers: [Ash.Test.Authorizer]
@@ -76,6 +79,7 @@ defmodule Ash.Test.Actions.CreateTest do
   end
 
   defmodule DuplicateName do
+    @moduledoc false
     use Ash.Resource.Change
 
     def change(changeset, _, _) do
@@ -205,6 +209,7 @@ defmodule Ash.Test.Actions.CreateTest do
   end
 
   defmodule GeneratedPkey do
+    @moduledoc false
     use Ash.Resource,
       data_layer: Ash.DataLayer.Ets
 
@@ -238,8 +243,6 @@ defmodule Ash.Test.Actions.CreateTest do
       resource(GeneratedPkey)
     end
   end
-
-  import Ash.Changeset
 
   describe "simple creates" do
     test "allows creating a record with valid attributes" do

--- a/test/actions/destroy_test.exs
+++ b/test/actions/destroy_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Actions.DestroyTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
+
   defmodule Profile do
     @moduledoc false
     use Ash.Resource, data_layer: Ash.DataLayer.Ets
@@ -99,8 +101,6 @@ defmodule Ash.Test.Actions.DestroyTest do
       resource(Profile)
     end
   end
-
-  import Ash.Changeset
 
   describe "simple destroy" do
     test "allows destroying a record" do

--- a/test/actions/read_test.exs
+++ b/test/actions/read_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Actions.ReadTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
+
   require Ash.Query
 
   defmodule Author do
@@ -66,8 +68,6 @@ defmodule Ash.Test.Actions.ReadTest do
       resource Author
     end
   end
-
-  import Ash.Changeset
 
   describe "api.get/3" do
     setup do

--- a/test/actions/side_load_test.exs
+++ b/test/actions/side_load_test.exs
@@ -2,6 +2,7 @@ defmodule Ash.Test.Actions.SideLoadTest do
   @moduledoc false
   use ExUnit.Case, async: false
 
+  import Ash.Changeset
   require Ash.Query
 
   defmodule Author do
@@ -83,6 +84,7 @@ defmodule Ash.Test.Actions.SideLoadTest do
   end
 
   defmodule Category do
+    @moduledoc false
     use Ash.Resource, data_layer: Ash.DataLayer.Ets
 
     ets do
@@ -129,8 +131,6 @@ defmodule Ash.Test.Actions.SideLoadTest do
 
     :ok
   end
-
-  import Ash.Changeset
 
   describe "side_loads" do
     test "it allows sideloading related data" do

--- a/test/actions/update_test.exs
+++ b/test/actions/update_test.exs
@@ -2,7 +2,10 @@ defmodule Ash.Test.Actions.UpdateTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
+
   defmodule Authorized do
+    @moduledoc false
     use Ash.Resource,
       data_layer: Ash.DataLayer.Ets,
       authorizers: [Ash.Test.Authorizer]
@@ -53,6 +56,7 @@ defmodule Ash.Test.Actions.UpdateTest do
   end
 
   defmodule DuplicateName do
+    @moduledoc false
     use Ash.Resource.Change
 
     def change(changeset, _, _) do
@@ -171,8 +175,6 @@ defmodule Ash.Test.Actions.UpdateTest do
       resource(Authorized)
     end
   end
-
-  import Ash.Changeset
 
   describe "simple updates" do
     test "allows updating a record with valid attributes" do

--- a/test/filter/filter_interaction_test.exs
+++ b/test/filter/filter_interaction_test.exs
@@ -1,6 +1,7 @@
 defmodule Ash.Test.Filter.FilterInteractionTest do
   use ExUnit.Case, async: false
 
+  import Ash.Changeset
   import ExUnit.CaptureLog
 
   alias Ash.DataLayer.Mnesia
@@ -145,8 +146,6 @@ defmodule Ash.Test.Filter.FilterInteractionTest do
       end)
     end)
   end
-
-  import Ash.Changeset
 
   test "mnesia data layer sanity test" do
     post =

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Filter.FilterTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
+
   alias Ash.Filter
 
   require Ash.Query
@@ -168,8 +170,6 @@ defmodule Ash.Test.Filter.FilterTest do
       resource(PostLink)
     end
   end
-
-  import Ash.Changeset
 
   describe "predicate optimization" do
     # Testing against the stringified query may be a bad idea, but its a quick win and we

--- a/test/type/ci_string_test.exs
+++ b/test/type/ci_string_test.exs
@@ -2,6 +2,7 @@ defmodule Ash.Test.Type.CiString do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
   require Ash.Query
 
   defmodule Post do
@@ -40,8 +41,6 @@ defmodule Ash.Test.Type.CiString do
       resource(Post)
     end
   end
-
-  import Ash.Changeset
 
   test "it handles non-empty values" do
     post =

--- a/test/type/string_test.exs
+++ b/test/type/string_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Type.StringTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import Ash.Changeset
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource, data_layer: Ash.DataLayer.Ets
@@ -38,8 +40,6 @@ defmodule Ash.Test.Type.StringTest do
       resource(Post)
     end
   end
-
-  import Ash.Changeset
 
   test "it handles non-empty values" do
     post =

--- a/test/type/type_test.exs
+++ b/test/type/type_test.exs
@@ -1,6 +1,7 @@
 defmodule Ash.Test.Type.TypeTest do
   @moduledoc false
   use ExUnit.Case, async: true
+  import Ash.Changeset
 
   defmodule PostTitle do
     @moduledoc false
@@ -71,8 +72,6 @@ defmodule Ash.Test.Type.TypeTest do
       resource(Post)
     end
   end
-
-  import Ash.Changeset
 
   test "it accepts valid data" do
     post =


### PR DESCRIPTION
Enforce layout of module parts

This will make it easier for contributors to read and understand the code base.

# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
