### PR TITLE
docs: Update create_timestamp description

### DIFF
--- a/documentation/introduction/getting_started.md
+++ b/documentation/introduction/getting_started.md
@@ -95,6 +95,7 @@ defmodule MyApp.Tweet do
 
     # `create_timestamp` above is just shorthand for:
     # attribute :inserted_at, :utc_datetime_usec,
+    #   private?: true,
     #   writable?: false,
     #   default: &DateTime.utc_now/0
   end


### PR DESCRIPTION
# Description
Adds the default value of the `private?` field to the description of `create_timestamp`

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
