### PR TITLE
fix: set tenant even on non-tenant resources where relevant

### DIFF
--- a/lib/ash/actions/create.ex
+++ b/lib/ash/actions/create.ex
@@ -87,7 +87,7 @@ defmodule Ash.Actions.Create do
   defp add_tenant({:ok, nil}, _), do: {:ok, nil}
 
   defp add_tenant({:ok, data}, changeset) do
-    if Ash.Resource.Info.multitenancy_strategy(changeset.resource) do
+    if changeset.tenant do
       {:ok, %{data | __metadata__: Map.put(data.__metadata__, :tenant, changeset.tenant)}}
     else
       {:ok, data}

--- a/lib/ash/actions/update.ex
+++ b/lib/ash/actions/update.ex
@@ -62,7 +62,7 @@ defmodule Ash.Actions.Update do
   end
 
   defp add_tenant({:ok, data}, changeset) do
-    if Ash.Resource.Info.multitenancy_strategy(changeset.resource) do
+    if changeset.tenant do
       {:ok, %{data | __metadata__: Map.put(data.__metadata__, :tenant, changeset.tenant)}}
     else
       {:ok, data}


### PR DESCRIPTION
As discussed on Discord.
This rectifies the edge-case of updating a Resource that doesn't have multitenancy enabled, while modifying one of it's related resources which does. i.e: Tenant belongs_to Address, while Address has a tenant_id key on it for multi-tenancy.