### PR TITLE
chore: Failing test for updating a relation in a change

### DIFF
--- a/test/actions/belongs_to_test.exs
+++ b/test/actions/belongs_to_test.exs
@@ -56,7 +56,7 @@ defmodule Ash.Test.Actions.BelongsToTest do
     end
 
     relationships do
-      belongs_to :reviewer, Reviewer, required?: false
+      belongs_to :reviewer, Ash.Test.Actions.BelongsToTest.Reviewer, required?: false
     end
   end
 

--- a/test/actions/belongs_to_test.exs
+++ b/test/actions/belongs_to_test.exs
@@ -1,0 +1,116 @@
+defmodule Ash.Test.Actions.BelongsToTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule UpdateReviewFields do
+    use Ash.Resource.Change
+
+    def init(_), do: {:ok, []}
+
+    def change(changeset, _opts, _) do
+      Ash.Changeset.before_action(changeset, fn changeset ->
+        case Ash.Changeset.get_attribute(changeset, :requires_review) do
+          true ->
+            changeset
+
+          false ->
+            changeset
+            |> Ash.Changeset.replace_relationship(:reviewer, nil)
+            |> Ash.Changeset.change_attribute(:review_by_date, nil)
+        end
+      end)
+    end
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      read :read
+      create :create, primary?: true
+
+      create :create_with_reviewer do
+        argument :reviewer_id, :uuid, allow_nil?: true
+        change manage_relationship(:reviewer_id, :reviewer, type: :replace)
+      end
+
+      update :update, primary?: true
+
+      update :update_with_reviewer do
+        argument :reviewer_id, :uuid, allow_nil?: true
+        change manage_relationship(:reviewer_id, :reviewer, type: :replace)
+        change {UpdateReviewFields, []}
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false
+      attribute :requires_review, :boolean, allow_nil?: false, default: false
+      attribute :review_by_date, :date, allow_nil?: true
+    end
+
+    relationships do
+      belongs_to :reviewer, Reviewer, required?: false
+    end
+  end
+
+  defmodule Reviewer do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, allow_nil?: false
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      resource(Post)
+      resource(Reviewer)
+    end
+  end
+
+  test "change on update clears attribute and relationship" do
+    reviewer =
+      Reviewer
+      |> Ash.Changeset.for_create(:create, %{name: "Zach"})
+      |> Api.create!()
+
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create_with_reviewer, %{
+        title: "A Post",
+        requires_review: true,
+        reviewer_id: reviewer.id,
+        review_by_date: DateTime.utc_now()
+      })
+      |> Api.create!()
+      |> Api.load!(:reviewer)
+
+    updated_post =
+      post
+      |> Ash.Changeset.for_update(:update_with_reviewer, %{
+        requires_review: false
+      })
+      |> Api.update!()
+      |> Api.load!(:reviewer)
+
+    assert updated_post.requires_review == false
+    assert updated_post.review_by_date == nil
+    assert updated_post.reviewer == nil
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Failing test for issue #257 

Updating a related field in a change on a one way (`belongs_to`) relationship works in 1.47.6, but now failing in master.

Wasn't sure where to put the test, i couldn't find any examples using a one way belongs_to relationship