### PR TITLE
fix: update type spec for Ash.Sort to include single atom instead of only list.

### DIFF
--- a/lib/ash/sort/sort.ex
+++ b/lib/ash/sort/sort.ex
@@ -11,7 +11,7 @@ defmodule Ash.Sort do
   @type sort_order ::
           :asc | :desc | :asc_nils_first | :asc_nils_last | :desc_nils_first | :desc_nils_last
 
-  @type t :: list(atom | {atom, sort_order})
+  @type t :: list(atom | {atom, sort_order}) | atom
 
   alias Ash.Error.Query.{InvalidSortOrder, NoSuchAttribute}
 


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
