### PR TITLE
Fix the typespec for the `Ash.Changeset.get_data/2` function

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1175,7 +1175,7 @@ defmodule Ash.Changeset do
   end
 
   @doc "Gets the original value for an attribute"
-  @spec get_data(t, atom) :: {:ok, any} | :error
+  @spec get_data(t, atom) :: term
   def get_data(changeset, attribute) do
     Map.get(changeset.data, attribute)
   end


### PR DESCRIPTION
`Map.get/2` returns a value or `nil`.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
