### PR TITLE
chore: update to import config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ash, :allow_flow, true
 


### PR DESCRIPTION
No longer have to see `warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:1` after running mix commands.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
