### PR TITLE
improve: Provide api read error message on no data set

### DIFF
--- a/lib/ash/error/simple_data_layer/no_data_provided.ex
+++ b/lib/ash/error/simple_data_layer/no_data_provided.ex
@@ -2,7 +2,7 @@ defmodule Ash.Error.SimpleDataLayer.NoDataProvided do
   @moduledoc "Used when no data was provided to the simple data layer"
   use Ash.Error.Exception
 
-  def_ash_error([:resource, :message], class: :invalid)
+  def_ash_error([:resource, :message], class: :framework)
 
   defimpl Ash.ErrorKind do
     def id(_), do: Ash.UUID.generate()

--- a/lib/ash/error/simple_data_layer/no_data_provided.ex
+++ b/lib/ash/error/simple_data_layer/no_data_provided.ex
@@ -1,0 +1,18 @@
+defmodule Ash.Error.SimpleDataLayer.NoDataProvided do
+  @moduledoc "Used when no data was provided to the simple data layer"
+  use Ash.Error.Exception
+
+  def_ash_error([:resource, :message], class: :invalid)
+
+  defimpl Ash.ErrorKind do
+    def id(_), do: Ash.UUID.generate()
+
+    def code(_), do: "no_data_provided"
+
+    def message(%{message: message}) when message not in ["", nil], do: message
+
+    def message(%{resource: resource}) do
+      "No data provided in resource #{inspect(resource)}"
+    end
+  end
+end

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -50,7 +50,8 @@ defmodule Ash.Query do
     action_failed?: false,
     before_action: [],
     after_action: [],
-    valid?: true
+    valid?: true,
+    data_set?: false
   ]
 
   @type t :: %__MODULE__{}

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -50,8 +50,7 @@ defmodule Ash.Query do
     action_failed?: false,
     before_action: [],
     after_action: [],
-    valid?: true,
-    data_set?: false
+    valid?: true
   ]
 
   @type t :: %__MODULE__{}

--- a/test/resource/resource_test.exs
+++ b/test/resource/resource_test.exs
@@ -38,6 +38,44 @@ defmodule Ash.Test.Resource.ResourceTest do
     end
   end
 
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string
+    end
+  end
+
+  defmodule Registry do
+    @moduledoc false
+    use Ash.Registry
+
+    entries do
+      entry(Post)
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      registry Registry
+    end
+  end
+
+  test "it returns the correct error when doing a read with no data layer setup" do
+    Post
+    |> Ash.Changeset.new(%{name: "foo"})
+    |> Api.create()
+
+    {_, error} = Api.read(Post)
+    [%Ash.Error.SimpleDataLayer.NoDataProvided{message: message} | _] = error.errors
+    assert message != nil
+  end
+
   test "fails if there are multiple fields that share the same name" do
     assert_raise(
       Ash.Error.Dsl.DslError,


### PR DESCRIPTION
Issue: https://github.com/ash-project/ash/issues/266

I don't know if `class: invalid` fits with the new `no data provided` error. I just thought of it as happening when there is an invalid read from a resource.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
