### PR TITLE
improvement: added options to the built-in function `relate_actor/1`

### DIFF
--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -5,9 +5,17 @@ defmodule Ash.Resource.Change.Builtins do
   The functions in this module are imported by default in the actions section.
   """
 
-  @doc "Relates the actor to the data being changed, as the provided relationship."
-  def relate_actor(relationship) do
-    {Ash.Resource.Change.RelateActor, relationship: relationship}
+  @doc """
+  Relates the actor to the data being changed, as the provided relationship.
+  Accepts the option `:allow_nil?`, which will not force an actor to be set.
+  `:allow_nil?` defaults to `false`.
+  """
+  def relate_actor(relationship, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put(:relationship, relationship)
+      |> Keyword.put_new(:allow_nil?, false)
+    {Ash.Resource.Change.RelateActor, opts}
   end
 
   @doc """

--- a/lib/ash/resource/change/relate_actor.ex
+++ b/lib/ash/resource/change/relate_actor.ex
@@ -18,13 +18,17 @@ defmodule Ash.Resource.Change.RelateActor do
   end
 
   def change(changeset, opts, %{actor: nil}) do
-    Changeset.add_error(
-      changeset,
-      InvalidRelationship.exception(
-        relationship: opts[:relationship],
-        message: "Could not relate to actor, as no actor was found"
+    if opts[:allow_nil?] do
+      changeset
+    else
+      Changeset.add_error(
+        changeset,
+        InvalidRelationship.exception(
+          relationship: opts[:relationship],
+          message: "Could not relate to actor, as no actor was found (and :allow_nil? is false)"
+        )
       )
-    )
+    end
   end
 
   def change(changeset, opts, %{actor: actor}) do

--- a/test/resource/changes/relate_actor_test.exs
+++ b/test/resource/changes/relate_actor_test.exs
@@ -1,0 +1,107 @@
+defmodule Ash.Test.Resource.Changes.RelateActorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule Author do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+    end
+
+    actions do
+      create :create
+    end
+  end
+
+  defmodule Post do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+      attribute :text, :string
+    end
+
+    relationships do
+      belongs_to :author, Author do
+        required? false
+      end
+    end
+
+    actions do
+      create :create_with_actor do
+        change relate_actor(:author)
+      end
+
+      create :create_possibly_without_actor do
+        change relate_actor(:author, allow_nil?: true)
+      end
+    end
+  end
+
+  defmodule Registry do
+    @moduledoc false
+    use Ash.Registry
+
+    entries do
+      entry Author
+      entry Post
+    end
+  end
+
+  defmodule Api do
+    use Ash.Api
+
+    resources do
+      registry Registry
+    end
+  end
+
+  test "relate_actor change with defaults work" do
+    actor =
+      Author
+      |> Ash.Changeset.for_create(:create)
+      |> Api.create!()
+
+    params = [text: "foo"]
+
+    post_with =
+      Post
+      |> Ash.Changeset.for_create(:create_with_actor, params, actor: actor)
+      |> Api.create!()
+
+    assert post_with.author_id == actor.id
+
+    {:error, changeset} =
+      Post
+      |> Ash.Changeset.for_create(:create_with_actor, params, actor: nil)
+      |> Api.create()
+
+    assert changeset.errors |> Enum.count() == 1
+  end
+
+  test "relate_actor change with `allow_nil?: true` allows both nil and an actor" do
+    actor =
+      Author
+      |> Ash.Changeset.for_create(:create)
+      |> Api.create!()
+
+    params = [text: "foo"]
+
+    post_with =
+      Post
+      |> Ash.Changeset.for_create(:create_possibly_without_actor, params, actor: actor)
+      |> Api.create!()
+
+    assert post_with.author_id == actor.id
+
+    post_without =
+      Post
+      |> Ash.Changeset.for_create(:create_possibly_without_actor, params, actor: nil)
+      |> Api.create!()
+
+    assert is_nil(post_without.author_id)
+  end
+end


### PR DESCRIPTION
The built-in change function called `relate_actor/1` for automatically associating a resource with an actor now takes a Keyword list. It also adds an option called `:allow_nil?` following previous conventions of Ash and it defaults to false, the current behaviour. When set to true, it will not add an error to the changeset if the actor is `nil`.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
