### PR TITLE
Add clarifying language around the use of the Enum module

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -2,14 +2,14 @@ defmodule Ash.Type.Enum do
   @moduledoc """
   A type for abstracting enums into a single type.
 
-  For example, you might have:
+  For example, your existing app might look like:
   ```elixir
   attribute :status, :atom, constraints: [one_of: [:open, :closed]]
   ```
 
   But as that starts to spread around your system you may find that you want
   to centralize that logic. To do that, use this module to define an Ash type
-  easily.
+  easily:
 
   ```elixir
   defmodule MyApp.TicketStatus do


### PR DESCRIPTION
# Contributor checklist

- [x] Documentation changes

In the existing docs for the Enum module, the language around the provided examples wasn't immediately clear that the first example would be your code *before* utilising the module. This adds some small changes that clarify this