### PR TITLE
docs: Fix code block that wrapped non-code text

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -106,8 +106,8 @@ defmodule Ash.Filter do
 
   A filter is a nested keyword list (with some exceptions, like `true` for everything and `false` for nothing).
 
-  The key is the "predicate" (A.K.A condition) and the value is the parameter. You can use `and` and `or` to create
-  nested filters. Datalayers can expose custom predicates. Eventually, you will be able to define your own custom
+  The key is the "predicate" (or "condition") and the value is the parameter. You can use `and` and `or` to create
+  nested filters. Data layers can expose custom predicates. Eventually, you will be able to define your own custom
   predicates, which will be a mechanism for you to attach complex filters supported by the data layer to your queries.
 
   ** Important **
@@ -129,6 +129,7 @@ defmodule Ash.Filter do
       [high_score: [less_than: -10]]
     ]
   ]])
+  ```
 
   ### Other formats
 
@@ -138,7 +139,6 @@ defmodule Ash.Filter do
   (or `Ash.Filter.parse_input/4` if your query has aggregates/calculations in it). This ensures that the filter only uses public attributes,
   relationships, aggregates and calculations. You may additionally wish to pass in the query context, in the case that you have calculations
   that use the provided context.
-  ```
   """
 
   @builtin_operators Enum.map(@operators, &{&1.operator(), &1}) ++ @operator_aliases


### PR DESCRIPTION
# Contributor checklist

- [x] Documentation changes

Moves the end of a code block example to actually end at the end of the code block, whereas currently it looks like this:
<img width="1135" alt="Screen Shot 2022-05-31 at 8 33 48 am" src="https://user-images.githubusercontent.com/71990001/171064993-864d4aab-eede-4852-959e-075556f4ebb0.png">
