### PR TITLE
Use a proper operator in the `attribute_does_not_equal` validation

### DIFF
--- a/lib/ash/resource/validation/attribute_does_not_equal.ex
+++ b/lib/ash/resource/validation/attribute_does_not_equal.ex
@@ -34,27 +34,15 @@ defmodule Ash.Resource.Validation.AttributeDoesNotEqual do
 
   @impl true
   def validate(changeset, opts) do
-    cond do
-      changeset.action_type == :create &&
-          Ash.Changeset.get_attribute(changeset, opts[:attribute]) != opts[:value] ->
-        {:error,
-         InvalidAttribute.exception(
-           field: opts[:attribute],
-           message: "must not equal %{value}",
-           vars: [field: opts[:attribute], value: opts[:value]]
-         )}
-
-      changeset.action_type != :create && changeset.data &&
-          Map.get(changeset.data, opts[:attribute]) == opts[:value] ->
-        {:error,
-         InvalidAttribute.exception(
-           field: opts[:attribute],
-           message: "must not equal %{value}",
-           vars: [field: opts[:attribute], value: opts[:value]]
-         )}
-
-      true ->
-        :ok
+    if Ash.Changeset.get_attribute(changeset, opts[:attribute]) == opts[:value] do
+      {:error,
+       InvalidAttribute.exception(
+         field: opts[:attribute],
+         message: "must not equal %{value}",
+         vars: [field: opts[:attribute], value: opts[:value]]
+       )}
+    else
+      :ok
     end
   end
 end

--- a/lib/ash/resource/validation/attribute_equals.ex
+++ b/lib/ash/resource/validation/attribute_equals.ex
@@ -33,28 +33,15 @@ defmodule Ash.Resource.Validation.AttributeEquals do
 
   @impl true
   def validate(changeset, opts) do
-    cond do
-      changeset.action_type == :create &&
-          Ash.Changeset.get_attribute(changeset, opts[:attribute]) !=
-            opts[:value] ->
-        {:error,
-         InvalidAttribute.exception(
-           field: opts[:attribute],
-           message: "must equal %{value}",
-           vars: [field: opts[:attribute], value: opts[:value]]
-         )}
-
-      changeset.action_type != :create && changeset.data &&
-          Map.get(changeset.data, opts[:attribute]) != opts[:value] ->
-        {:error,
-         InvalidAttribute.exception(
-           field: opts[:attribute],
-           message: "must equal %{value}",
-           vars: [field: opts[:attribute], value: opts[:value]]
-         )}
-
-      true ->
-        :ok
+    if Ash.Changeset.get_attribute(changeset, opts[:attribute]) != opts[:value] do
+      {:error,
+       InvalidAttribute.exception(
+         field: opts[:attribute],
+         message: "must equal %{value}",
+         vars: [field: opts[:attribute], value: opts[:value]]
+       )}
+    else
+      :ok
     end
   end
 end

--- a/test/actions/validation_test.exs
+++ b/test/actions/validation_test.exs
@@ -25,6 +25,10 @@ defmodule Ash.Test.Actions.ValidationTest do
       validate attribute_equals(:status, "foo") do
         where([attribute_equals(:foo, true)])
       end
+
+      validate attribute_does_not_equal(:status, "foo") do
+        where([attribute_equals(:foo, false)])
+      end
     end
 
     attributes do
@@ -63,8 +67,18 @@ defmodule Ash.Test.Actions.ValidationTest do
 
   test "validations only run when their when conditions validate properly" do
     Profile
-    |> Ash.Changeset.new(%{foo: false, status: "foo"})
+    |> Ash.Changeset.new(%{foo: false, status: "bar"})
     |> Api.create!()
+
+    Profile
+    |> Ash.Changeset.new(%{foo: true, status: "foo"})
+    |> Api.create!()
+
+    assert_raise(Ash.Error.Invalid, ~r/status: must not equal foo/, fn ->
+      Profile
+      |> Ash.Changeset.new(%{foo: false, status: "foo"})
+      |> Api.create!()
+    end)
 
     assert_raise(Ash.Error.Invalid, ~r/status: must equal foo/, fn ->
       Profile


### PR DESCRIPTION
Previously, it was using `if current != expected do raise` while it
needs to do the opposite. Also, simplify the logic by making `update`
work in the same way as `create` (compare upcoming value - not the
original one).

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
