### PR TITLE
Improve module names

### DIFF
--- a/test/policy/rbac_test.exs
+++ b/test/policy/rbac_test.exs
@@ -1,8 +1,8 @@
-defmodule Ash.Policy.Test.RbacTest do
+defmodule Ash.Test.Policy.RbacTest do
   @doc false
   use ExUnit.Case
 
-  alias Ash.Policy.Test.Rbac.{Api, File, Membership, Organization, User}
+  alias Ash.Test.Support.PolicyRbac.{Api, File, Membership, Organization, User}
 
   setup do
     [

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -1,9 +1,9 @@
-defmodule Ash.Policy.Test.SimpleTest do
+defmodule Ash.Test.Policy.SimpleTest do
   @doc false
   use ExUnit.Case
   require Ash.Query
 
-  alias Ash.Policy.Test.Simple.{Api, Car, Organization, Post, Trip, User}
+  alias Ash.Test.Support.PolicySimple.{Api, Car, Organization, Post, Trip, User}
 
   setup do
     [

--- a/test/support/policy_rbac/api.ex
+++ b/test/support/policy_rbac/api.ex
@@ -1,0 +1,8 @@
+defmodule Ash.Test.Support.PolicyRbac.Api do
+  @moduledoc false
+  use Ash.Api
+
+  resources do
+    registry(Ash.Test.Support.PolicyRbac.Registry)
+  end
+end

--- a/test/support/policy_rbac/checks/role_checks.ex
+++ b/test/support/policy_rbac/checks/role_checks.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Rbac.Checks.RoleChecks do
+defmodule Ash.Test.Support.PolicyRbac.Checks.RoleChecks do
   @moduledoc false
 
   @behaviour Ash.Policy.Check

--- a/test/support/policy_rbac/resources/file.ex
+++ b/test/support/policy_rbac/resources/file.ex
@@ -1,10 +1,10 @@
-defmodule Ash.Policy.Test.Rbac.File do
+defmodule Ash.Test.Support.PolicyRbac.File do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets,
     authorizers: [Ash.Policy.Authorizer]
 
-  import Ash.Policy.Test.Rbac.Checks.RoleChecks, only: [can?: 1]
+  import Ash.Test.Support.PolicyRbac.Checks.RoleChecks, only: [can?: 1]
 
   policies do
     policy always() do
@@ -26,6 +26,6 @@ defmodule Ash.Policy.Test.Rbac.File do
   end
 
   relationships do
-    belongs_to(:organization, Ash.Policy.Test.Rbac.Organization)
+    belongs_to(:organization, Ash.Test.Support.PolicyRbac.Organization)
   end
 end

--- a/test/support/policy_rbac/resources/membership.ex
+++ b/test/support/policy_rbac/resources/membership.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Rbac.Membership do
+defmodule Ash.Test.Support.PolicyRbac.Membership do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets
@@ -30,7 +30,7 @@ defmodule Ash.Policy.Test.Rbac.Membership do
   end
 
   relationships do
-    belongs_to(:user, Ash.Policy.Test.Rbac.User)
-    belongs_to(:organization, Ash.Policy.Test.Rbac.Organization)
+    belongs_to(:user, Ash.Test.Support.PolicyRbac.User)
+    belongs_to(:organization, Ash.Test.Support.PolicyRbac.Organization)
   end
 end

--- a/test/support/policy_rbac/resources/organization.ex
+++ b/test/support/policy_rbac/resources/organization.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Simple.CarUser do
+defmodule Ash.Test.Support.PolicyRbac.Organization do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets
@@ -16,7 +16,8 @@ defmodule Ash.Policy.Test.Simple.CarUser do
   end
 
   relationships do
-    belongs_to(:user, Ash.Policy.Test.Simple.User)
-    belongs_to(:car, Ash.Policy.Test.Simple.Car)
+    has_many :memberships, Ash.Test.Support.PolicyRbac.Membership do
+      destination_field(:organization_id)
+    end
   end
 end

--- a/test/support/policy_rbac/resources/registry.ex
+++ b/test/support/policy_rbac/resources/registry.ex
@@ -1,8 +1,8 @@
-defmodule Ash.Policy.Test.Rbac.Registry do
+defmodule Ash.Test.Support.PolicyRbac.Registry do
   @moduledoc false
   use Ash.Registry
 
-  alias Ash.Policy.Test.Rbac
+  alias Ash.Test.Support.PolicyRbac, as: Rbac
 
   entries do
     entry(Rbac.User)

--- a/test/support/policy_rbac/resources/user.ex
+++ b/test/support/policy_rbac/resources/user.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Rbac.User do
+defmodule Ash.Test.Support.PolicyRbac.User do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets,
@@ -19,8 +19,8 @@ defmodule Ash.Policy.Test.Rbac.User do
   end
 
   relationships do
-    has_many(:memberships, Ash.Policy.Test.Rbac.Membership, destination_field: :user_id)
+    has_many(:memberships, Ash.Test.Support.PolicyRbac.Membership, destination_field: :user_id)
 
-    belongs_to(:organization, Ash.Policy.Test.Rbac.Organization)
+    belongs_to(:organization, Ash.Test.Support.PolicyRbac.Organization)
   end
 end

--- a/test/support/policy_simple/api.ex
+++ b/test/support/policy_simple/api.ex
@@ -1,0 +1,8 @@
+defmodule Ash.Test.Support.PolicySimple.Api do
+  @moduledoc false
+  use Ash.Api
+
+  resources do
+    registry(Ash.Test.Support.PolicySimple.Registry)
+  end
+end

--- a/test/support/policy_simple/registry.ex
+++ b/test/support/policy_simple/registry.ex
@@ -1,8 +1,8 @@
-defmodule Ash.Policy.Test.Simple.Registry do
+defmodule Ash.Test.Support.PolicySimple.Registry do
   @moduledoc false
   use Ash.Registry
 
-  alias Ash.Policy.Test.Simple
+  alias Ash.Test.Support.PolicySimple, as: Simple
 
   entries do
     entry(Simple.User)

--- a/test/support/policy_simple/resources/car.ex
+++ b/test/support/policy_simple/resources/car.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Simple.Car do
+defmodule Ash.Test.Support.PolicySimple.Car do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets,
@@ -29,8 +29,8 @@ defmodule Ash.Policy.Test.Simple.Car do
   end
 
   relationships do
-    many_to_many :users, Ash.Policy.Test.Simple.User do
-      through(Ash.Policy.Test.Simple.CarUser)
+    many_to_many :users, Ash.Test.Support.PolicySimple.User do
+      through(Ash.Test.Support.PolicySimple.CarUser)
       source_field_on_join_table(:car_id)
       destination_field_on_join_table(:user_id)
     end

--- a/test/support/policy_simple/resources/car_user.ex
+++ b/test/support/policy_simple/resources/car_user.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Rbac.Organization do
+defmodule Ash.Test.Support.PolicySimple.CarUser do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets
@@ -16,8 +16,7 @@ defmodule Ash.Policy.Test.Rbac.Organization do
   end
 
   relationships do
-    has_many :memberships, Ash.Policy.Test.Rbac.Membership do
-      destination_field(:organization_id)
-    end
+    belongs_to(:user, Ash.Test.Support.PolicySimple.User)
+    belongs_to(:car, Ash.Test.Support.PolicySimple.Car)
   end
 end

--- a/test/support/policy_simple/resources/organization.ex
+++ b/test/support/policy_simple/resources/organization.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Simple.Organization do
+defmodule Ash.Test.Support.PolicySimple.Organization do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets
@@ -22,8 +22,8 @@ defmodule Ash.Policy.Test.Simple.Organization do
   end
 
   relationships do
-    has_many(:users, Ash.Policy.Test.Simple.User)
-    has_many(:posts, Ash.Policy.Test.Simple.Post)
-    belongs_to(:owner, Ash.Policy.Test.Simple.User)
+    has_many(:users, Ash.Test.Support.PolicySimple.User)
+    has_many(:posts, Ash.Test.Support.PolicySimple.Post)
+    belongs_to(:owner, Ash.Test.Support.PolicySimple.User)
   end
 end

--- a/test/support/policy_simple/resources/post.ex
+++ b/test/support/policy_simple/resources/post.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Simple.Post do
+defmodule Ash.Test.Support.PolicySimple.Post do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets,
@@ -46,7 +46,7 @@ defmodule Ash.Policy.Test.Simple.Post do
   end
 
   relationships do
-    belongs_to(:organization, Ash.Policy.Test.Simple.Organization)
-    belongs_to(:author, Ash.Policy.Test.Simple.User)
+    belongs_to(:organization, Ash.Test.Support.PolicySimple.Organization)
+    belongs_to(:author, Ash.Test.Support.PolicySimple.User)
   end
 end

--- a/test/support/policy_simple/resources/trip.ex
+++ b/test/support/policy_simple/resources/trip.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Simple.Trip do
+defmodule Ash.Test.Support.PolicySimple.Trip do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets,
@@ -25,6 +25,6 @@ defmodule Ash.Policy.Test.Simple.Trip do
   end
 
   relationships do
-    belongs_to(:car, Ash.Policy.Test.Simple.Car)
+    belongs_to(:car, Ash.Test.Support.PolicySimple.Car)
   end
 end

--- a/test/support/policy_simple/resources/user.ex
+++ b/test/support/policy_simple/resources/user.ex
@@ -1,4 +1,4 @@
-defmodule Ash.Policy.Test.Simple.User do
+defmodule Ash.Test.Support.PolicySimple.User do
   @moduledoc false
   use Ash.Resource,
     data_layer: Ash.DataLayer.Ets,
@@ -31,11 +31,11 @@ defmodule Ash.Policy.Test.Simple.User do
   end
 
   relationships do
-    belongs_to(:organization, Ash.Policy.Test.Simple.Organization)
-    has_many(:posts, Ash.Policy.Test.Simple.Post, destination_field: :author_id)
+    belongs_to(:organization, Ash.Test.Support.PolicySimple.Organization)
+    has_many(:posts, Ash.Test.Support.PolicySimple.Post, destination_field: :author_id)
 
-    many_to_many :cars, Ash.Policy.Test.Simple.Car do
-      through(Ash.Policy.Test.Simple.CarUser)
+    many_to_many :cars, Ash.Test.Support.PolicySimple.Car do
+      through(Ash.Test.Support.PolicySimple.CarUser)
       source_field_on_join_table(:user_id)
       destination_field_on_join_table(:car_id)
     end

--- a/test/support/rbac/api.ex
+++ b/test/support/rbac/api.ex
@@ -1,8 +1,0 @@
-defmodule Ash.Policy.Test.Rbac.Api do
-  @moduledoc false
-  use Ash.Api
-
-  resources do
-    registry(Ash.Policy.Test.Rbac.Registry)
-  end
-end

--- a/test/support/simple/api.ex
+++ b/test/support/simple/api.ex
@@ -1,8 +1,0 @@
-defmodule Ash.Policy.Test.Simple.Api do
-  @moduledoc false
-  use Ash.Api
-
-  resources do
-    registry(Ash.Policy.Test.Simple.Registry)
-  end
-end


### PR DESCRIPTION
It wasn't obvious where to look for the test resources, the module names now match the file paths