### PR TITLE
fix: False default value for argument is nil in changeset

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1400,7 +1400,11 @@ defmodule Ash.Changeset do
   @doc "Gets the value of an argument provided to the changeset"
   @spec get_argument(t, atom) :: term
   def get_argument(changeset, argument) when is_atom(argument) do
-    Map.get(changeset.arguments, argument) || Map.get(changeset.arguments, to_string(argument))
+    if Map.has_key?(changeset.arguments, argument) do
+      Map.get(changeset.arguments, argument)
+    else
+      Map.get(changeset.arguments, to_string(argument))
+    end
   end
 
   @doc "fetches the value of an argument provided to the changeset or `:error`"

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -25,6 +25,16 @@ defmodule Ash.Test.Changeset.ChangesetTest do
           allow_nil? false
         end
 
+        argument :false_optional_argument, :boolean do
+          allow_nil? false
+          default false
+        end
+
+        argument :true_optional_argument, :boolean do
+          allow_nil? false
+          default true
+        end
+
         validate confirm(:name, :confirm_name)
       end
     end
@@ -854,6 +864,15 @@ defmodule Ash.Test.Changeset.ChangesetTest do
         |> Changeset.new(%{"name" => "foo"})
         |> Api.create!(action: :create_with_confirmation)
       end
+    end
+
+    test "optional arguments should use the default" do
+      changeset =
+        Category
+        |> Changeset.for_create(:create_with_confirmation)
+
+      assert Changeset.get_argument(changeset, :true_optional_argument) == true
+      assert Changeset.get_argument(changeset, :false_optional_argument) == false
     end
   end
 


### PR DESCRIPTION
I have defined an argument for an action:

      argument :some_boolean, :boolean, allow_nil?: false, default: false

When I retrieve that argument in a changeset, the value is `nil`.

If the default is `true`, it correctly comes in as `true`.

This pr contains a failing test for this scenario

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
