### PR TITLE
feat: `show_private?` option for diagrams

### DIFF
--- a/lib/ash/api/diagram/diagram.ex
+++ b/lib/ash/api/diagram/diagram.ex
@@ -12,8 +12,9 @@ defmodule Ash.Api.Info.Diagram do
   """
 
   @indent "    "
+  @show_private? false
 
-  @default_opts indent: @indent
+  @default_opts indent: @indent, show_private?: @show_private?
 
   defp resource_name(resource) do
     resource
@@ -68,12 +69,22 @@ defmodule Ash.Api.Info.Diagram do
   """
   def mermaid_er_diagram(api, opts \\ @default_opts) do
     indent = opts[:indent] || @indent
+    show_private? = Access.get(opts, :show_private?, @show_private?)
 
     resources =
       for resource <- Ash.Api.Info.resources(api) do
-        attrs = Ash.Resource.Info.public_attributes(resource)
-        calcs = Ash.Resource.Info.public_calculations(resource)
-        aggs = Ash.Resource.Info.public_aggregates(resource)
+        {attrs, calcs, aggs} =
+          if show_private? do
+            {
+              Ash.Resource.Info.attributes(resource),
+              Ash.Resource.Info.calculations(resource),
+              Ash.Resource.Info.aggregates(resource)
+            }
+          else
+            {Ash.Resource.Info.public_attributes(resource),
+             Ash.Resource.Info.public_calculations(resource),
+             Ash.Resource.Info.public_aggregates(resource)}
+          end
 
         contents =
           [
@@ -121,14 +132,26 @@ defmodule Ash.Api.Info.Diagram do
   """
   def mermaid_class_diagram(api, opts \\ @default_opts) do
     indent = opts[:indent] || @indent
+    show_private? = Access.get(opts, :show_private?, @show_private?)
 
     resources =
       for resource <- Ash.Api.Info.resources(api) do
-        attrs = Ash.Resource.Info.public_attributes(resource)
-        calcs = Ash.Resource.Info.public_calculations(resource)
-        aggs = Ash.Resource.Info.public_aggregates(resource)
         actions = Ash.Resource.Info.actions(resource)
-        relationships = Ash.Resource.Info.public_relationships(resource)
+
+        {attrs, calcs, aggs, relationships} =
+          if show_private? do
+            {
+              Ash.Resource.Info.attributes(resource),
+              Ash.Resource.Info.calculations(resource),
+              Ash.Resource.Info.aggregates(resource),
+              Ash.Resource.Info.relationships(resource)
+            }
+          else
+            {Ash.Resource.Info.public_attributes(resource),
+             Ash.Resource.Info.public_calculations(resource),
+             Ash.Resource.Info.public_aggregates(resource),
+             Ash.Resource.Info.public_relationships(resource)}
+          end
 
         contents =
           [

--- a/test/api/diagram_test.exs
+++ b/test/api/diagram_test.exs
@@ -51,4 +51,58 @@ defmodule Ash.Test.Api.Info.DiagramTest do
                Org -- User
            """
   end
+
+  test "include private fields in a mermaid entity relationship diagram from an Api if specified" do
+    assert Ash.Api.Info.Diagram.mermaid_er_diagram(Ash.Test.Support.Flow.Api, show_private?: true) == """
+           erDiagram
+               User {
+                   UUID id
+                   String first_name
+                   String last_name
+                   String email
+                   Boolean approved
+                   UUID org_id
+               }
+               Org {
+                   UUID id
+                   String name
+               }
+
+               Org ||--|| User : ""
+           """
+  end
+
+  test "include private fields in a mermaid class diagram from an Api if specified" do
+    assert Ash.Api.Info.Diagram.mermaid_class_diagram(Ash.Test.Support.Flow.Api, show_private?: true) == """
+           classDiagram
+               class User {
+                   UUID id
+                   String first_name
+                   String last_name
+                   String email
+                   Boolean approved
+                   UUID org_id
+                   Org org
+                   destroy()
+                   read()
+                   for_org()
+                   create()
+                   update()
+                   approve()
+                   unapprove()
+               }
+               class Org {
+                   UUID id
+                   String name
+                   User[] users
+                   destroy()
+                   update()
+                   read()
+                   create()
+                   by_name()
+               }
+
+               Org -- User
+           """
+  end
 end


### PR DESCRIPTION
This PR aims to resolve #394 by adding a `show_private?` option to `mermaid_er_diagram/2` and `mermaid_class_diagram/2` in `Ash.Api.Info.Diagram`

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes  
  (I couldn't find any?)
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
