### PR TITLE
docs: Correct create!/1 return typo in Getting Started Guide

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -193,12 +193,12 @@ Helpdesk.Support.Ticket
 This returns what we call a `record` which is an instance of a resource.
 
 ```elixir
-{:ok, #Helpdesk.Support.Ticket<
+#Helpdesk.Support.Ticket<
   ...,
   id: "c0f8dc32-a018-4eb4-8656-d5810118f4ea",
   subject: nil,
   ...
->}
+>
 ```
 
 ### Customizing our Actions


### PR DESCRIPTION
Getting Started guide exemplifies `create!/1` as returning  an `{:ok, #Resource<>}` tuple, when it should be `#Resource<>`

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
