### PR TITLE
Validate attribute names for builtin validations

### DIFF
--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1214,7 +1214,8 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Transformers.ValidateRelationshipAttributes,
     Ash.Resource.Transformers.ValidateEagerIdentities,
     Ash.Resource.Transformers.ValidateAggregatesSupported,
-    Ash.Resource.Transformers.ValidateAccept
+    Ash.Resource.Transformers.ValidateAccept,
+    Ash.Resource.Transformers.ValidateValidationAttributes
   ]
 
   @moduledoc """

--- a/lib/ash/resource/transformers/validate_validation_attributes.ex
+++ b/lib/ash/resource/transformers/validate_validation_attributes.ex
@@ -1,0 +1,52 @@
+defmodule Ash.Resource.Transformers.ValidateValidationAttributes do
+  @moduledoc """
+  Validates that all built in validations point to valid attributes
+  """
+  use Spark.Dsl.Transformer
+  alias Spark.Dsl.Transformer
+
+  @impl true
+  def after_compile?, do: true
+
+  @impl true
+  def transform(dsl) do
+    attribute_names =
+      dsl
+      |> Transformer.get_entities([:attributes])
+      |> Enum.map(& &1.name)
+
+    dsl
+    |> Transformer.get_entities([:validations])
+    |> Enum.each(&validate_validation(&1, attribute_names))
+
+    {:ok, dsl}
+  end
+
+  defp validate_validation(%Ash.Resource.Validation{} = resource_validation, attribute_names) do
+    validate_validation(resource_validation.validation, attribute_names)
+
+    Enum.each(
+      resource_validation.where,
+      &validate_validation(&1, attribute_names)
+    )
+  end
+
+  defp validate_validation({validation_module, [{:attribute, attribute} | _]}, attribute_names) do
+    check(validation_module, attribute, attribute_names)
+  end
+
+  defp validate_validation({validation_module, [{:attributes, attributes} | _]}, attribute_names) do
+    Enum.each(attributes, &check(validation_module, &1, attribute_names))
+  end
+
+  defp validate_validation(_, _), do: nil
+
+  defp check(validation_module, attribute_name, attribute_names) do
+    if attribute_name not in attribute_names do
+      raise Spark.Error.DslError,
+        path: [:validations],
+        message:
+          "Validation `#{inspect(validation_module)}` expects attribute `#{attribute_name}` to be defined"
+    end
+  end
+end

--- a/lib/ash/resource/transformers/validate_validation_attributes.ex
+++ b/lib/ash/resource/transformers/validate_validation_attributes.ex
@@ -6,9 +6,6 @@ defmodule Ash.Resource.Transformers.ValidateValidationAttributes do
   alias Spark.Dsl.Transformer
 
   @impl true
-  def after_compile?, do: true
-
-  @impl true
   def transform(dsl) do
     attribute_names =
       dsl


### PR DESCRIPTION
This currently validates attribute names for builtin validations by checking the `attribute`/`attributes` field. There are also validations with a `field` field, but I've skipped it as the list of options would depend on the validation.

I've marked this as draft as the implementation is a little fragile – it depends on the observation and assumption that all validations with a `attribute`/`attributes` field have more than one option and the attribute field comes first. On the other hand it doesn't worsen anything so it's fine I guess.