### PR TITLE
fix: allow overriding validation message on a list of errors

### DIFF
--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -38,6 +38,10 @@ defmodule Ash.Test.Changeset.ChangesetTest do
 
         validate confirm(:name, :confirm_name)
       end
+
+      create :with_name_validation do
+        validate present(:name), message: "this validates the name is present"
+      end
     end
 
     attributes do
@@ -900,6 +904,17 @@ defmodule Ash.Test.Changeset.ChangesetTest do
                  "name" => "foo",
                  "confirm_name" => "bar"
                }).errors
+    end
+
+    test "a message can be specified as part of a `present` validation" do
+      assert [
+               %Ash.Error.Changes.InvalidAttribute{
+                 class: :invalid,
+                 field: :name,
+                 message: "this validates the name is present",
+                 path: []
+               }
+             ] = Ash.Changeset.for_create(Category, :with_name_validation, %{"name" => ""}).errors
     end
   end
 end


### PR DESCRIPTION
As described in #411, this fixes an issue where applying a custom validation message for a validation that returns a list of errors, would cause weirdnesses to happen.

Because the `present` validation takes a list of fields to validate, it returns a list of errors, possibly including one for each field. 

This worked when no message was provided - the list of `Ash.Error.Changes.InvalidAttribute` errors was passed to `Ash.Changeset.add_error/3` and all was fine - but when a message was provided, the list of errors was converted to a single string (the message) and that was stored on the changeset instead.

Now each element of the list gets the same treatment as a single error, and it seems to work well in my testing! Closes #411 

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
