### PR TITLE
CI: re-enable latest versions of Elixir/Erlang

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,6 +19,8 @@ jobs:
         include:
           - elixir: 1.13.1
             otp: 24.1.2
+          - elixir: 1.14.1
+            otp: 25.1.1
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
These were disabled due to a dialyzer error in Erlang, which has since been fixed in a newer Erlang version.

I installed these versions locally and checked that everything still works as expected; and dialyzer no longer errors.

Closes #382

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
