### PR TITLE
improvement: SVG, PDF, PNG, Markdown and plain mermaid formats

### DIFF
--- a/lib/mix/mermaid.ex
+++ b/lib/mix/mermaid.ex
@@ -12,6 +12,7 @@ defmodule Mix.Mermaid do
     end
   end
 
+  # sobelow_skip ["Traversal"]
   def generate_diagram(source, suffix, "plain", markdown, message) do
     source
     |> Mix.Mermaid.file(suffix, "mermaid")
@@ -20,6 +21,7 @@ defmodule Mix.Mermaid do
     Mix.shell().info(message)
   end
 
+  # sobelow_skip ["Traversal"]
   def generate_diagram(source, suffix, "md", markdown, message) do
     source
     |> Mix.Mermaid.file(suffix, "md")

--- a/lib/mix/mermaid.ex
+++ b/lib/mix/mermaid.ex
@@ -14,7 +14,7 @@ defmodule Mix.Mermaid do
 
   # sobelow_skip ["Traversal"]
   def generate_diagram(source, suffix, "plain", markdown, message) do
-    file = Mix.Mermaid.file(source, suffix, "mermaid")
+    file = Mix.Mermaid.file(source, suffix, "mmd")
 
     File.write!(file, markdown)
 

--- a/lib/mix/mermaid.ex
+++ b/lib/mix/mermaid.ex
@@ -14,7 +14,7 @@ defmodule Mix.Mermaid do
 
   def generate_diagram(source, suffix, "plain", markdown, message) do
     source
-    |> Mix.Mermaid.file(suffix, ".mermaid")
+    |> Mix.Mermaid.file(suffix, "mermaid")
     |> File.write!(markdown)
 
     Mix.shell().info(message)
@@ -22,7 +22,7 @@ defmodule Mix.Mermaid do
 
   def generate_diagram(source, suffix, "md", markdown, message) do
     source
-    |> Mix.Mermaid.file(suffix, ".mermaid")
+    |> Mix.Mermaid.file(suffix, "md")
     |> File.write!("""
     ```mermaid
     #{markdown}

--- a/lib/mix/mermaid.ex
+++ b/lib/mix/mermaid.ex
@@ -76,7 +76,7 @@ defmodule Mix.Mermaid do
     |> System.cmd([
       "-c",
       """
-      cat <<EOF | mmdc --output #{file} #{config()}
+      cat <<EOF | mmdc --output #{file} --pdfFit #{config()}
       #{markdown}
       EOF
       """

--- a/lib/mix/mermaid.ex
+++ b/lib/mix/mermaid.ex
@@ -12,6 +12,43 @@ defmodule Mix.Mermaid do
     end
   end
 
+  def generate_diagram(source, suffix, "plain", markdown, message) do
+    source
+    |> Mix.Mermaid.file(suffix, ".mermaid")
+    |> File.write!(markdown)
+
+    Mix.shell().info(message)
+  end
+
+  def generate_diagram(source, suffix, "md", markdown, message) do
+    source
+    |> Mix.Mermaid.file(suffix, ".mermaid")
+    |> File.write!("""
+    ```mermaid
+    #{markdown}
+    ```
+    """)
+
+    Mix.shell().info(message)
+  end
+
+  def generate_diagram(source, suffix, format, markdown, message)
+      when format in ["svg", "pdf", "png"] do
+    source
+    |> Mix.Mermaid.file(suffix, format)
+    |> Mix.Mermaid.create_diagram(markdown)
+
+    Mix.shell().info(message)
+  end
+
+  def generate_diagram(_, _, format, _, _) do
+    Mix.shell().error("""
+    Invalid format `#{format}`.
+
+    Valid options are `plain`, `md`, `svg`, `pdf` or `png`.
+    """)
+  end
+
   @doc """
   Generate a diagram filename next to the source file.
   """

--- a/lib/mix/mermaid.ex
+++ b/lib/mix/mermaid.ex
@@ -14,33 +14,33 @@ defmodule Mix.Mermaid do
 
   # sobelow_skip ["Traversal"]
   def generate_diagram(source, suffix, "plain", markdown, message) do
-    source
-    |> Mix.Mermaid.file(suffix, "mermaid")
-    |> File.write!(markdown)
+    file = Mix.Mermaid.file(source, suffix, "mermaid")
 
-    Mix.shell().info(message)
+    File.write!(file, markdown)
+
+    Mix.shell().info(message <> " (#{file})")
   end
 
   # sobelow_skip ["Traversal"]
   def generate_diagram(source, suffix, "md", markdown, message) do
-    source
-    |> Mix.Mermaid.file(suffix, "md")
-    |> File.write!("""
+    file = Mix.Mermaid.file(source, suffix, "md")
+
+    File.write!(file, """
     ```mermaid
     #{markdown}
     ```
     """)
 
-    Mix.shell().info(message)
+    Mix.shell().info(message <> " (#{file})")
   end
 
   def generate_diagram(source, suffix, format, markdown, message)
       when format in ["svg", "pdf", "png"] do
-    source
-    |> Mix.Mermaid.file(suffix, format)
-    |> Mix.Mermaid.create_diagram(markdown)
+    file = Mix.Mermaid.file(source, suffix, format)
 
-    Mix.shell().info(message)
+    Mix.Mermaid.create_diagram(file, markdown)
+
+    Mix.shell().info(message <> " (#{file})")
   end
 
   def generate_diagram(_, _, format, _, _) do

--- a/lib/mix/tasks/generate_flow_charts.ex
+++ b/lib/mix/tasks/generate_flow_charts.ex
@@ -14,7 +14,6 @@ defmodule Mix.Tasks.Ash.GenerateFlowCharts do
   ## Command line options
 
     * `--only` - only generates the given Flow file
-
     * `--format` - Can be set to one of either:
       * `plain` - Prints just the mermaid output as text. This is the default.
       * `md` - Prints the mermaid diagram in a markdown code block.

--- a/lib/mix/tasks/generate_flow_charts.ex
+++ b/lib/mix/tasks/generate_flow_charts.ex
@@ -29,7 +29,10 @@ defmodule Mix.Tasks.Ash.GenerateFlowCharts do
     Mix.Task.run("compile")
 
     {opts, _} =
-      OptionParser.parse!(argv, strict: [only: :keep, format: :string], aliases: [o: :only])
+      OptionParser.parse!(argv,
+        strict: [only: :keep, format: :string],
+        aliases: [o: :only, f: :format]
+      )
 
     only =
       if opts[:only] && opts[:only] != [] do

--- a/lib/mix/tasks/generate_resource_diagrams.ex
+++ b/lib/mix/tasks/generate_resource_diagrams.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
                 "mermaid-er-diagram",
                 format,
                 Ash.Api.Info.Diagram.mermaid_er_diagram(api),
-                "Generated ER Diagram for #{inspect(api)}"
+                "Generated ER Diagram for #{inspect(api)} (as #{format})"
               )
 
             "class" ->
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
                 "mermaid-class-diagram",
                 format,
                 Ash.Api.Info.Diagram.mermaid_class_diagram(api),
-                "Generated Class Diagram for #{inspect(api)}"
+                "Generated Class Diagram for #{inspect(api)} (as #{format})"
               )
 
             type ->

--- a/lib/mix/tasks/generate_resource_diagrams.ex
+++ b/lib/mix/tasks/generate_resource_diagrams.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
     {opts, _} =
       OptionParser.parse!(argv,
         strict: [only: :keep, type: :string, format: :string],
-        aliases: [o: :only, t: :type]
+        aliases: [o: :only, t: :type, f: :format]
       )
 
     only =

--- a/lib/mix/tasks/generate_resource_diagrams.ex
+++ b/lib/mix/tasks/generate_resource_diagrams.ex
@@ -31,6 +31,8 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
         Enum.map(List.wrap(opts[:only]), &Path.expand/1)
       end
 
+    format = Keyword.get(opts, :format, "plain")
+
     apis()
     |> Task.async_stream(
       fn api ->
@@ -39,18 +41,22 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
         if is_nil(only) || Path.expand(source) in only do
           case Keyword.get(opts, :type, "class") do
             "er" ->
-              source
-              |> Mix.Mermaid.file("mermaid-er-diagram", "pdf")
-              |> Mix.Mermaid.create_diagram(Ash.Api.Info.Diagram.mermaid_er_diagram(api))
-
-              Mix.shell().info("Generated ER Diagram for #{inspect(api)}")
+              Mix.Mermaid.generate_diagram(
+                source,
+                "mermaid-er-diagram",
+                format,
+                Ash.Api.Info.Diagram.mermaid_er_diagram(api),
+                "Generated ER Diagram for #{inspect(api)}"
+              )
 
             "class" ->
-              source
-              |> Mix.Mermaid.file("mermaid-class-diagram", "pdf")
-              |> Mix.Mermaid.create_diagram(Ash.Api.Info.Diagram.mermaid_class_diagram(api))
-
-              Mix.shell().info("Generated Class Diagram for #{inspect(api)}")
+              Mix.Mermaid.generate_diagram(
+                source,
+                "mermaid-class-diagram",
+                format,
+                Ash.Api.Info.Diagram.mermaid_class_diagram(api),
+                "Generated Class Diagram for #{inspect(api)}"
+              )
 
             type ->
               Mix.shell().error("""

--- a/lib/mix/tasks/generate_resource_diagrams.ex
+++ b/lib/mix/tasks/generate_resource_diagrams.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
                 "mermaid-er-diagram",
                 format,
                 Ash.Api.Info.Diagram.mermaid_er_diagram(api),
-                "Generated ER Diagram for #{inspect(api)} (as #{format})"
+                "Generated ER Diagram for #{inspect(api)}"
               )
 
             "class" ->
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
                 "mermaid-class-diagram",
                 format,
                 Ash.Api.Info.Diagram.mermaid_class_diagram(api),
-                "Generated Class Diagram for #{inspect(api)} (as #{format})"
+                "Generated Class Diagram for #{inspect(api)}"
               )
 
             type ->

--- a/lib/mix/tasks/generate_resource_diagrams.ex
+++ b/lib/mix/tasks/generate_resource_diagrams.ex
@@ -12,6 +12,12 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
 
     * `--type` - `er` or `class` (defaults to `class`)
     * `--only` - only generates the given API file
+    * `--format` - Can be set to one of either:
+      * `plain` - Prints just the mermaid output as text. This is the default.
+      * `md` - Prints the mermaid diagram in a markdown code block.
+      * `svg` - Generates an SVG
+      * `pdf` - Generates a PDF
+      * `png` - Generates a PNG
 
   """
   use Mix.Task
@@ -22,7 +28,7 @@ defmodule Mix.Tasks.Ash.GenerateResourceDiagrams do
 
     {opts, _} =
       OptionParser.parse!(argv,
-        strict: [only: :keep, type: :string],
+        strict: [only: :keep, type: :string, format: :string],
         aliases: [o: :only, t: :type]
       )
 


### PR DESCRIPTION
Support a variety of different formats for all mermaid diagrams and flowcharts.

Closes #422 