### PR TITLE
fix: Add missing `[:ash, :query]` telemetry

### DIFF
--- a/documentation/topics/monitoring.md
+++ b/documentation/topics/monitoring.md
@@ -16,7 +16,6 @@ Ash emits the following telemetry events, suffixed with `:start` and `:stop`. St
 - `[:ash, :change]` - A change being run on a changeset. Use `resource_short_name` and `change` metadata to break down measurements.
 - `[:ash, :before_action]` - A before_action being run on a changeset. Use `resource_short_name` to break down measurements. 
 - `[:ash, :after_action]` - An after_action being run on a changeset. Use `resource_short_name` to break down measurements.
-- `[:ash, :after_action]` - A before_action being run on a changeset.
 - `[:ash, :preparation]` - A preparation being run on a changeset. Use `resource_short_name` and `preparation` metadata to break down measurements.
 - `[:ash, :request_step]` - The resolution of an internal request. Ash breaks up its operations internally into multiple requests, this can give you a high resolution insight onto the execution of those internal requests resolution. Use `name` metadata to break down measurements.
 - `[:ash, :flow]` - The execution of an Ash flow. Use `flow_short_name` to break down measurements.

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -283,31 +283,35 @@ defmodule Ash.Query do
       Ash.Tracer.span :query,
                       name,
                       opts[:tracer] do
-        metadata = %{
-          resource_short_name: Ash.Resource.Info.short_name(query.resource),
-          resource: query.resource,
-          actor: opts[:actor],
-          tenant: opts[:tenant],
-          action: action.name,
-          authorize?: opts[:authorize?]
-        }
+        Ash.Tracer.telemetry_span [:ash, :query], %{
+          resource_short_name: Ash.Resource.Info.short_name(query.resource)
+        } do
+          metadata = %{
+            resource_short_name: Ash.Resource.Info.short_name(query.resource),
+            resource: query.resource,
+            actor: opts[:actor],
+            tenant: opts[:tenant],
+            action: action.name,
+            authorize?: opts[:authorize?]
+          }
 
-        Ash.Tracer.set_metadata(opts[:tracer], :query, metadata)
+          Ash.Tracer.set_metadata(opts[:tracer], :query, metadata)
 
-        query
-        |> Map.put(:action, action)
-        |> reset_arguments()
-        |> timeout(query.timeout || opts[:timeout])
-        |> set_actor(opts)
-        |> set_authorize?(opts)
-        |> set_tracer(opts)
-        |> Ash.Query.set_tenant(opts[:tenant] || query.tenant)
-        |> Map.put(:__validated_for_action__, action_name)
-        |> cast_params(action, args)
-        |> set_argument_defaults(action)
-        |> require_arguments(action)
-        |> run_preparations(action, opts[:actor], opts[:authorize?], opts[:tracer], metadata)
-        |> add_action_filters(action, opts[:actor])
+          query
+          |> Map.put(:action, action)
+          |> reset_arguments()
+          |> timeout(query.timeout || opts[:timeout])
+          |> set_actor(opts)
+          |> set_authorize?(opts)
+          |> set_tracer(opts)
+          |> Ash.Query.set_tenant(opts[:tenant] || query.tenant)
+          |> Map.put(:__validated_for_action__, action_name)
+          |> cast_params(action, args)
+          |> set_argument_defaults(action)
+          |> require_arguments(action)
+          |> run_preparations(action, opts[:actor], opts[:authorize?], opts[:tracer], metadata)
+          |> add_action_filters(action, opts[:actor])
+        end
       end
     else
       add_error(query, :action, "No such action #{action_name}")


### PR DESCRIPTION
Includes removing a duplicate reference to `[:ash, :after_action]` in the docs.

I couldn't work out how to write a test for it (the existing Tracer test didn't seem to invoke it) but I did load this branch into my app and verified that recording telemetry via `summary("ash.query.stop.duration", unit: {:native, :millisecond}, tags: [:resource_short_name])` works as expected.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
