### PR TITLE
fix: respect selects in related_query

### DIFF
--- a/lib/ash/actions/load.ex
+++ b/lib/ash/actions/load.ex
@@ -1281,6 +1281,7 @@ defmodule Ash.Actions.Load do
     else
       relationship.destination
       |> Ash.Query.new(related_query.api)
+      |> Ash.Query.select(related_query.select)
       |> Ash.Query.filter(^related_query.filter)
     end
   end

--- a/lib/ash/actions/load.ex
+++ b/lib/ash/actions/load.ex
@@ -510,11 +510,7 @@ defmodule Ash.Actions.Load do
       name: "load #{source}",
       api: related_query.api,
       path: this_request_path,
-      query:
-        load_query(
-          relationship,
-          related_query
-        ),
+      query: related_query,
       data:
         data(
           relationship,
@@ -798,11 +794,7 @@ defmodule Ash.Actions.Load do
       name: "load join #{join_relationship.name}",
       api: related_query.api,
       path: request_path ++ [:load, join_relationship_path_names],
-      query:
-        load_query(
-          join_relationship,
-          related_query
-        ),
+      query: related_query,
       data:
         Request.resolve(dependencies, fn
           data ->
@@ -1263,26 +1255,6 @@ defmodule Ash.Actions.Load do
           end)
 
         %{query | load: new_load}
-    end
-  end
-
-  defp load_query(%{manual: manual}, related_query)
-       when not is_nil(manual) do
-    related_query
-  end
-
-  defp load_query(
-         relationship,
-         related_query
-       ) do
-    if Map.get(relationship, :no_attributes?) do
-      relationship.destination
-      |> Ash.Query.new(related_query.api)
-    else
-      relationship.destination
-      |> Ash.Query.new(related_query.api)
-      |> Ash.Query.select(related_query.select)
-      |> Ash.Query.filter(^related_query.filter)
     end
   end
 

--- a/test/policy/rbac_test.exs
+++ b/test/policy/rbac_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Policy.RbacTest do
   @doc false
   use ExUnit.Case
 
+  require Ash.Query
+
   alias Ash.Test.Support.PolicyRbac.{Api, File, Membership, Organization, User}
 
   setup do
@@ -32,6 +34,45 @@ defmodule Ash.Test.Policy.RbacTest do
     create_file(org, "baz")
 
     assert [%{name: "foo"}] = Api.read!(File, actor: user)
+  end
+
+  test "query params on relation are passed correctly to the policy", %{
+    user: user,
+    org: org
+  } do
+    file_with_access = create_file(org, "foo")
+    give_role(user, org, :viewer, :file, file_with_access.id)
+    create_file(org, "bar")
+    create_file(org, "baz")
+
+    # select a forbidden field
+    query =
+      Organization
+      |> Ash.Query.filter(id == ^org.id)
+      |> Ash.Query.load(files: File |> Ash.Query.select([:forbidden]))
+
+    assert_raise Ash.Error.Forbidden, fn ->
+      Api.read!(query, actor: user) == []
+    end
+
+    # specify no select (everything is selected)
+    query =
+      Organization
+      |> Ash.Query.filter(id == ^org.id)
+      |> Ash.Query.load([:files])
+
+    assert_raise Ash.Error.Forbidden, fn ->
+      Api.read!(query, actor: user) == []
+    end
+
+    # select only an allowed field
+    query =
+      Organization
+      |> Ash.Query.filter(id == ^org.id)
+      |> Ash.Query.load(files: File |> Ash.Query.select([:id]))
+
+    assert [%Organization{files: [%File{id: id}]}] = Api.read!(query, actor: user)
+    assert id == file_with_access.id
   end
 
   test "unauthorized if no policy is defined", %{user: user} do

--- a/test/policy/rbac_test.exs
+++ b/test/policy/rbac_test.exs
@@ -40,6 +40,8 @@ defmodule Ash.Test.Policy.RbacTest do
     user: user,
     org: org
   } do
+    user = Map.put(user, :rel_check, true)
+
     file_with_access = create_file(org, "foo")
     give_role(user, org, :viewer, :file, file_with_access.id)
     create_file(org, "bar")

--- a/test/support/policy_rbac/resources/file.ex
+++ b/test/support/policy_rbac/resources/file.ex
@@ -8,8 +8,12 @@ defmodule Ash.Test.Support.PolicyRbac.File do
 
   policies do
     policy always() do
-      forbid_if(selecting(:forbidden))
       authorize_if(can?(:file))
+    end
+
+    policy actor_attribute_equals(:rel_check, true) do
+      forbid_if selecting(:forbidden)
+      authorize_if always()
     end
   end
 

--- a/test/support/policy_rbac/resources/file.ex
+++ b/test/support/policy_rbac/resources/file.ex
@@ -8,6 +8,7 @@ defmodule Ash.Test.Support.PolicyRbac.File do
 
   policies do
     policy always() do
+      forbid_if(selecting(:forbidden))
       authorize_if(can?(:file))
     end
   end
@@ -23,6 +24,7 @@ defmodule Ash.Test.Support.PolicyRbac.File do
   attributes do
     uuid_primary_key(:id)
     attribute(:name, :string)
+    attribute(:forbidden, :string)
   end
 
   relationships do

--- a/test/support/policy_rbac/resources/organization.ex
+++ b/test/support/policy_rbac/resources/organization.ex
@@ -19,5 +19,7 @@ defmodule Ash.Test.Support.PolicyRbac.Organization do
     has_many :memberships, Ash.Test.Support.PolicyRbac.Membership do
       destination_attribute(:organization_id)
     end
+
+    has_many :files, Ash.Test.Support.PolicyRbac.File
   end
 end


### PR DESCRIPTION
When using ash_graphql it would be nice to only get the selects inside the authorizer which were actually selected. This was the change I had to make to get it to work.  

The related query also contains other fields, I saw `limit: 1` during my debugging, is this something that should also be passed here.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
