### PR TITLE
docs: Fix wrong policy explanation module in docs.

### DIFF
--- a/documentation/topics/policies.md
+++ b/documentation/topics/policies.md
@@ -252,7 +252,7 @@ Additionally, some checks have more expensive components that can't be checked b
 ## Explanation
 
 Policy breakdowns can be fetched on demand for a given forbidden error (either an `Ash.Error.Forbidden` that contains one ore more `Ash.Error.Forbidden.Policy`
-errors, or an `Ash.Error.Forbidden.Policy` error itself), via `Ash.Policy.Forbidden.Error.report/2`.
+errors, or an `Ash.Error.Forbidden.Policy` error itself), via `Ash.Error.Forbidden.Policy.report/2`.
 
 Here is an example policy breakdown from tests:
 


### PR DESCRIPTION
This PR changes `Ash.Policy.Forbidden.Error.report/2` to `Ash.Error.Forbidden.Policy.report/2` in `Policies` docs. 

The `Ash.Policy.Forbidden.Error` module does not exist

