### PR TITLE
docs: Fix broken link on Getting Started Tutorial

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -594,7 +594,7 @@ Check out the {{link:ash:guide:Code Interface}} to derive things like `Helpdesk.
 
 #### Persist your data
 
-See {{link:ash_postgres:guide:Get Started With Postgres:AshPostgres}} to see how to back your resources with Postgres. This is highly recommended, as the Postgres data layer provides tons of advanced capabilities.
+See {{link:ash_postgres:library|AshPostgres}} to see how to back your resources with Postgres. This is highly recommended, as the Postgres data layer provides tons of advanced capabilities.
 
 #### Add an API
 

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -594,7 +594,7 @@ Check out the {{link:ash:guide:Code Interface}} to derive things like `Helpdesk.
 
 #### Persist your data
 
-See {{link:ash_postgres:library|AshPostgres}} to see how to back your resources with Postgres. This is highly recommended, as the Postgres data layer provides tons of advanced capabilities.
+See {{link:ash_postgres:guide:Get Started With Postgres|AshPostgres}} to see how to back your resources with Postgres. This is highly recommended, as the Postgres data layer provides tons of advanced capabilities.
 
 #### Add an API
 


### PR DESCRIPTION
- [X] Documentation changes

Fixes ash-project/ash_hq#62
