### PR TITLE
improvement: Add Ash.Error.Invalid.TenantRequired error

### DIFF
--- a/documentation/topics/multitenancy.md
+++ b/documentation/topics/multitenancy.md
@@ -35,7 +35,7 @@ Example usage of the above:
 MyApp.Users
 |> Ash.Query.filter(name == "fred")
 |> MyApi.read!()
-** (Ash.Error.Unknown)
+** (Ash.Error.Invalid)
 
 * "Queries against the Helpdesk.Accounts.User resource require a tenant to be specified"
     (ash 1.22.0) lib/ash/api/api.ex:944: Ash.Api.unwrap_or_raise!/2

--- a/lib/ash/actions/read.ex
+++ b/lib/ash/actions/read.ex
@@ -547,8 +547,7 @@ defmodule Ash.Actions.Read do
          initial_data do
       :ok
     else
-      {:error,
-       "Queries against the #{inspect(query.resource)} resource require a tenant to be specified"}
+      {:error, Ash.Error.Invalid.TenantRequired.exception(resource: query.resource)}
     end
   end
 

--- a/lib/ash/error/invalid/tenant_required.ex
+++ b/lib/ash/error/invalid/tenant_required.ex
@@ -1,0 +1,16 @@
+defmodule Ash.Error.Invalid.TenantRequired do
+  @moduledoc "Used when a tenant is not specified"
+  use Ash.Error.Exception
+
+  def_ash_error([:resource], class: :invalid)
+
+  defimpl Ash.ErrorKind do
+    def id(_), do: Ash.UUID.generate()
+
+    def code(_), do: "tenant_required"
+
+    def message(%{resource: resource}) do
+      "Queries against the #{inspect(resource)} resource require a tenant to be specified"
+    end
+  end
+end

--- a/test/actions/multitenancy_test.exs
+++ b/test/actions/multitenancy_test.exs
@@ -196,5 +196,17 @@ defmodule Ash.Actions.MultitenancyTest do
       |> Ash.Changeset.new()
       |> Api.destroy!()
     end
+
+    test "a record cannot be read without tenant specified", %{
+      tenant1: tenant1
+    } do
+      Comment
+      |> Ash.Changeset.new()
+      |> Ash.Changeset.set_tenant(tenant1)
+      |> Api.create!()
+
+      result = User |> Api.read()
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Invalid.TenantRequired{}]}} = result
+    end
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I'm currently poking with the stick into [ash_example](https://github.com/ash_project/ash_example). Without tenant specified (there is no way to pass tenant in a request for a moment), I receive an ugly looking error:
```json
{
  "data": {
    "listTickets": {
      "edges": [
        {
          "cursor": "g2wAAAABbQAAACRlOGE1YzY0NC1lMWM3LTQyOGEtYjk2YS0wMDk4NTM1NTBjMDhq",
          "node": {
            "description": null,
            "id": "e8a5c644-e1c7-428a-b96a-009853550c08",
            "reporter": null,
            "representative": null,
            "response": null,
            "status": "new",
            "subject": "sdabc"
          }
        }
      ],
      "pageInfo": {
        "hasNextPage": false,
        "hasPreviousPage": false
      }
    }
  },
  "errors": [
    {
      "locations": [
        {
          "column": 9,
          "line": 11
        }
      ],
      "message": "Raised error: 02762ef1-a47d-4ed1-96ad-ce5b4f5d70b3\n\n** (ErlangError) Erlang error: {%Ash.Error.Unknown{errors: [%Ash.Error.Unknown.UnknownError{error: \"Queries against the Helpdesk.Tickets.Customer resource require a tenant to be specified\", field: nil, changeset: nil, query: nil, error_context: [], vars: [], path: [], stacktrace: #Stacktrace<>, class: :unknown}], stacktraces?: true, changeset: nil, query: #Ash.Query<resource: Helpdesk.Tickets.Ticket, load: [reporter: #Ash.Query<resource: Helpdesk.Tickets.Customer, filter: #Ash.Filter<representative == false>, select: [:id, :first_name, :last_name, :representative]>], errors: [%Ash.Error.Unknown{errors: [%Ash.Error.Unknown.UnknownError{error: \"Queries against the Helpdesk.Tickets.Customer resource require a tenant to be specified\", field: nil, changeset: nil, query: nil, error_context: [], vars: [], path: [], stacktrace: #Stacktrace<>, class: :unknown}], stacktraces?: true, changeset: nil, query: #Ash.Query<resource: Helpdesk.Tickets.Customer, filter: #Ash.Filter<representative == false and id in []>, errors: [%Ash.Error.Unknown.UnknownError{error: \"Queries against the Helpdesk.Tickets.Customer resource require a tenant to be specified\", field: nil, changeset: nil, query: nil, error_context: [], vars: [], path: [], stacktrace: #Stacktrace<>, class: :unknown}], select: [:id, :first_name, :last_name, :representative]>, error_context: [], vars: [], path: [], stacktrace: #Stacktrace<>, class: :unknown}, %Ash.Error.Unknown.UnknownError{error: \"Queries against the Helpdesk.Tickets.Customer resource require a tenant to be specified\", field: nil, changeset: nil, query: nil, error_context: [], vars: [], path: [], stacktrace: #Stacktrace<>, class: :unknown}]>, error_context: [nil], vars: [], path: [], stacktrace: #Stacktrace<>, class: :unknown}, [{Ash.Error, :choose_error, 2, [file: 'lib/ash/error/error.ex', line: 463]}, {Ash.Error, :to_error_class, 2, [file: 'lib/ash/error/error.ex', line: 218]}, {Ash.Actions.Read, :do_run, 3, [file: 'lib/ash/actions/read.ex', line: 181]}, {Ash.Actions.Read, :run, 3, [file: 'lib/ash/actions/read.ex', line: 90]}, {Ash.Actions.Load, :artificial_limit_and_offset, 9, [file: 'lib/ash/actions/load.ex', line: 1130]}, {Ash.Actions.Load, :\"-data/9-fun-5-\", 9, [file: 'lib/ash/actions/load.ex', line: 674]}, {Ash.Engine, :\"-run_iteration/1-fun-9-\", 2, [file: 'lib/ash/engine/engine.ex', line: 468]}, {Ash.Engine, :start_pending_tasks, 1, [file: 'lib/ash/engine/engine.ex', line: 623]}, {Ash.Engine, :run_to_completion, 1, [file: 'lib/ash/engine/engine.ex', line: 273]}, {Ash.Engine, :do_run, 2, [file: 'lib/ash/engine/engine.ex', line: 202]}, {Ash.Engine, :run, 2, [file: 'lib/ash/engine/engine.ex', line: 141]}, {Ash.Actions.Read, :do_run, 3, [file: 'lib/ash/actions/read.ex', line: 170]}, {Ash.Actions.Read, :run, 3, [file: 'lib/ash/actions/read.ex', line: 90]}, {Ash.Api, :load!, 4, [file: 'lib/ash/api/api.ex', line: 784]}, {Dataloader.Source.AshGraphql.Dataloader, :run_batch, 2, [file: 'lib/graphql/dataloader.ex', line: 242]}, {Dataloader.Source.AshGraphql.Dataloader, :\"-run_batches/1-fun-1-\", 2, [file: 'lib/graphql/dataloader.ex', line: 182]}, {Task.Supervised, :invoke_mfa, 2, [file: 'lib/task/supervised.ex', line: 89]}, {Task.Supervised, :reply, 4, [file: 'lib/task/supervised.ex', line: 34]}]}\n    (ash_graphql 0.22.3) lib/graphql/resolver.ex:1469: anonymous fn/3 in AshGraphql.Graphql.Resolver.to_resolution/3\n    (elixir 1.14.0) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n    (ash_graphql 0.22.3) lib/graphql/resolver.ex:1437: AshGraphql.Graphql.Resolver.to_resolution/3\n    (absinthe 1.7.0) lib/absinthe/middleware/dataloader.ex:37: Absinthe.Middleware.Dataloader.get_result/2\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:230: Absinthe.Phase.Document.Execution.Resolution.reduce_resolution/1\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:185: Absinthe.Phase.Document.Execution.Resolution.do_resolve_field/3\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:114: Absinthe.Phase.Document.Execution.Resolution.walk_results/6\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:93: Absinthe.Phase.Document.Execution.Resolution.walk_result/5\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:114: Absinthe.Phase.Document.Execution.Resolution.walk_results/6\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:93: Absinthe.Phase.Document.Execution.Resolution.walk_result/5\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:114: Absinthe.Phase.Document.Execution.Resolution.walk_results/6\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:103: Absinthe.Phase.Document.Execution.Resolution.walk_result/5\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:114: Absinthe.Phase.Document.Execution.Resolution.walk_results/6\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:93: Absinthe.Phase.Document.Execution.Resolution.walk_result/5\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:114: Absinthe.Phase.Document.Execution.Resolution.walk_results/6\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:93: Absinthe.Phase.Document.Execution.Resolution.walk_result/5\n    (absinthe 1.7.0) lib/absinthe/phase/document/execution/resolution.ex:67: Absinthe.Phase.Document.Execution.Resolution.perform_resolution/3\n\"\n",
      "path": [
        "listTickets",
        "edges",
        0,
        "node",
        "reporter"
      ]
    }
  ]
}
```

Introducing new `Ash.Error.Invalid.TenantRequired` instead of using `Ash.Error.Unknown.UnknownError`