### PR TITLE
docs: Render `api_short_name` visibly in the Monitoring guide

### DIFF
--- a/documentation/topics/monitoring.md
+++ b/documentation/topics/monitoring.md
@@ -8,24 +8,26 @@ Ash emits the following telemetry events, suffixed with `:start` and `:stop`. St
 
 ### Important
 
-Note the mention of `:start` and `:stop` suffixes. The event below `[:ash, <api_short_name>, :create]`, is actually referring to two events, `[:ash, <api_short_name>, :create, :start]` and `[:ash, <api_short_name>, :create, :stop]`.
+Note the mention of `:start` and `:stop` suffixes. The event below `[:ash, (api_short_name), :create]`, is actually referring to two events, `[:ash, (api_short_name), :create, :start]` and `[:ash, (api_short_name), :create, :stop]`.
+
+_Replace `(api_short_name)` with your API short name, from `d:Ash.Api.Info.short_name`._
 
 ### Events
 
-- `[:ash, <api_short_name>, :create]` - The execution of a create action. Use `resource_short_name` and `action` metadata to break down measurements.
-- `[:ash, <api_short_name>, :update]` - The execution of a update action. Use `resource_short_name` and `action` metadata to break down measurements.
-- `[:ash, <api_short_name>, :read]` - The execution of a read action. Use `resource_short_name` and `action` metadata to break down measurements.
-- `[:ash, <api_short_name>, :destroy]` - The execution of a destroy action. Use `resource_short_name` and `action` metadata to break down measurements.
+- `[:ash, (api_short_name), :create]` - The execution of a create action. Use `resource_short_name` and `action` metadata to break down measurements.
+- `[:ash, (api_short_name), :update]` - The execution of a update action. Use `resource_short_name` and `action` metadata to break down measurements.
+- `[:ash, (api_short_name), :read]` - The execution of a read action. Use `resource_short_name` and `action` metadata to break down measurements.
+- `[:ash, (api_short_name), :destroy]` - The execution of a destroy action. Use `resource_short_name` and `action` metadata to break down measurements.
 - `[:ash, :changeset]` - A changeset being processed for a given action, i.e with `Ash.Changeset.for_create`. Use `resource_short_name` metadata to break down measurements.
 - `[:ash, :query]` - A query being processed for an action, with `Ash.Query.for_read`. Use `resource_short_name` metadata to break down measurements.
 - `[:ash, :validation]` - A validation being run on a changeset. Use `resource_short_name` and `validation` metadata to break down measurements.
 - `[:ash, :change]` - A change being run on a changeset. Use `resource_short_name` and `change` metadata to break down measurements.
-- `[:ash, :before_action]` - A before_action being run on a changeset. Use `resource_short_name` to break down measurements. 
+- `[:ash, :before_action]` - A before_action being run on a changeset. Use `resource_short_name` to break down measurements.
 - `[:ash, :after_action]` - An after_action being run on a changeset. Use `resource_short_name` to break down measurements.
 - `[:ash, :preparation]` - A preparation being run on a changeset. Use `resource_short_name` and `preparation` metadata to break down measurements.
 - `[:ash, :request_step]` - The resolution of an internal request. Ash breaks up its operations internally into multiple requests, this can give you a high resolution insight onto the execution of those internal requests resolution. Use `name` metadata to break down measurements.
 - `[:ash, :flow]` - The execution of an Ash flow. Use `flow_short_name` to break down measurements.
-- `[:ash, :flow, :custom_step]` - The execution of a custom flow step (only if using the built in runner, which is currently the only runner). Use `flow_short_name` and `name` metadata to break down measurements. 
+- `[:ash, :flow, :custom_step]` - The execution of a custom flow step (only if using the built in runner, which is currently the only runner). Use `flow_short_name` and `name` metadata to break down measurements.
 
 ## Tracing
 
@@ -65,7 +67,7 @@ defmodule MyApp.CustomChange do
 
   def change(changeset, _, _) do
     changeset
-    |> Ash.Changeset.before_action(fn changeset -> 
+    |> Ash.Changeset.before_action(fn changeset ->
       Ash.Tracer.span(:custom, "custom name", changeset.context[:private][:tracer]) do
         # optionally set some metadata
         metadata = %{...}

--- a/lib/ash/api/info.ex
+++ b/lib/ash/api/info.ex
@@ -119,7 +119,7 @@ defmodule Ash.Api.Info do
   end
 
   @doc "The short name for an api"
-  @spec short_name(Ash.Api.t()) :: nil | :infinity | integer()
+  @spec short_name(Ash.Api.t()) :: atom
   def short_name(api) do
     Extension.get_opt(api, [:execution], :short_name, nil) || api.default_short_name()
   end


### PR DESCRIPTION
Because it currently looks like a HTML tag, it's not being rendered visibly - 

<img width="341" alt="Screenshot 2023-02-01 at 10 14 34 am" src="https://user-images.githubusercontent.com/543859/215928622-0f23b332-9f49-465e-9bff-dce35ae96a21.png">

This tweaks the short name to render in parens instead, and adds a note about what the short name actually is. (And the typespec was incorrect)

(I can't really figure out how a short name would actually be defined in an API module, so I guess it's just the default which is an atom!)