### PR TITLE
docs: Update pubsub docs to be readable on AshHQ

### DIFF
--- a/lib/ash/notifier/pub_sub/pub_sub.ex
+++ b/lib/ash/notifier/pub_sub/pub_sub.ex
@@ -76,7 +76,7 @@ defmodule Ash.Notifier.PubSub do
         default: :notification,
         doc: """
         What shape the event payloads will be in. `:notification` just sends the notification, `phoenix_broadcast` sends a `%Phoenix.Socket.Broadcast{}`, and `:broadcast`
-        sends `%{topic: <topic>, event: <event>, notification: <notification>}`
+        sends `%{topic: (topic), event: (event), notification: (notification)}`
         """
       ],
       name: [


### PR DESCRIPTION
After conversion to HTML, the placeholders in the code sample are treated as HTML elements and not rendered correctly.

<img width="772" alt="Screenshot 2023-02-24 at 3 13 38 pm" src="https://user-images.githubusercontent.com/543859/221115824-1dc9e255-bad6-496a-b909-cea3c39c6d5b.png">

<img width="356" alt="Screenshot 2023-02-24 at 3 15 32 pm" src="https://user-images.githubusercontent.com/543859/221115952-bc24e77a-0593-4ff0-a45a-cb718b821990.png">

(kinda like #500, denote the placeholders with parentheses instead of angle brackets)
