### PR TITLE
Fix typo in Ash.Flow moduledoc

### DIFF
--- a/lib/ash/flow/flow.ex
+++ b/lib/ash/flow/flow.ex
@@ -1,6 +1,6 @@
 defmodule Ash.Flow do
   @moduledoc """
-  A flow is a static definition of a set of steps to be .
+  A flow is a static definition of a set of steps to be run.
 
   See the [guide](/documentation/topics/flows.md) for more.
   """


### PR DESCRIPTION
Pretty self-explanatory :). Looked up the missing word from the Flow guide.

# Contributor checklist

- [x] Documentation changes

