### PR TITLE
docs: add drop-in configuration code snippet for the Spark formatter plugin

### DIFF
--- a/documentation/topics/development-utilities.md
+++ b/documentation/topics/development-utilities.md
@@ -25,6 +25,26 @@ Add the following to your `.formatter.exs`
 
 ### Configuration
 
+#### Minimal config for your Ash Resources
+
+```elixir
+config :spark, :formatter,
+  remove_parens?: true,
+  "Ash.Resource": [
+    type: Ash.Resource,
+    section_order: [
+      :authentication,
+      :token,
+      :attributes,
+      :relationships,
+      :policies,
+      :postgres
+    ]
+  ]
+```
+
+#### If you use a different module than Ash.Resource
+
 ```elixir
 config :spark, :formatter,
   [


### PR DESCRIPTION
I was frustrated by the existing code snippet for the configuration of the spark formatter.

Basically the ellipsis means I can't copy paste it to my own config, so I added a complete code snipped from the Ash-HQ config.

I kept the "If you use a different module than Ash.Resource" part in a separate subsection.