### PR TITLE
improvement: Add builtin changes for lifecycle hooks.

### DIFF
--- a/lib/ash/error/error.ex
+++ b/lib/ash/error/error.ex
@@ -8,7 +8,18 @@ defmodule Ash.Error do
 
   @type error_class() :: :invalid | :authorization | :framework | :unknown
 
-  @type t :: struct
+  @type t :: %{
+          required(:__struct__) => module,
+          required(:__exception__) => true,
+          required(:class) => :invalid | :forbidden | :framework | :unknown,
+          required(:path) => [atom | integer],
+          required(:changeset) => Ash.Changeset.t() | nil,
+          required(:query) => Ash.Query.t() | nil,
+          required(:error_context) => list(String.t()),
+          required(:vars) => Keyword.t(),
+          required(:stacktrace) => Ash.Error.Stacktrace.t() | nil,
+          optional(atom) => any
+        }
 
   # We use these error classes also to choose a single error
   # to raise when multiple errors have occurred. We raise them

--- a/lib/ash/error/stacktrace.ex
+++ b/lib/ash/error/stacktrace.ex
@@ -2,6 +2,8 @@ defmodule Ash.Error.Stacktrace do
   @moduledoc "A placeholder for a stacktrace so that we can avoid printing it everywhere"
   defstruct [:stacktrace]
 
+  @type t :: %__MODULE__{stacktrace: list}
+
   defimpl Inspect do
     def inspect(_, _) do
       "#Stacktrace<>"

--- a/lib/ash/resource/change/after_action.ex
+++ b/lib/ash/resource/change/after_action.ex
@@ -1,0 +1,10 @@
+defmodule Ash.Resource.Change.AfterAction do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  @doc false
+  @spec change(Ash.Changeset.t(), keyword, Ash.Resource.Change.context()) :: Ash.Changeset.t()
+  def change(changeset, opts, _) do
+    Ash.Changeset.after_action(changeset, opts[:callback], prepend?: opts[:prepend?])
+  end
+end

--- a/lib/ash/resource/change/after_transaction.ex
+++ b/lib/ash/resource/change/after_transaction.ex
@@ -1,0 +1,10 @@
+defmodule Ash.Resource.Change.AfterTransaction do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  @doc false
+  @spec change(Ash.Changeset.t(), keyword, Ash.Resource.Change.context()) :: Ash.Changeset.t()
+  def change(changeset, opts, _) do
+    Ash.Changeset.after_transaction(changeset, opts[:callback], prepend?: opts[:prepend?])
+  end
+end

--- a/lib/ash/resource/change/before_action.ex
+++ b/lib/ash/resource/change/before_action.ex
@@ -1,0 +1,10 @@
+defmodule Ash.Resource.Change.BeforeAction do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  @doc false
+  @spec change(Ash.Changeset.t(), keyword, Ash.Resource.Change.context()) :: Ash.Changeset.t()
+  def change(changeset, opts, _) do
+    Ash.Changeset.before_action(changeset, opts[:callback], append?: opts[:append?])
+  end
+end

--- a/lib/ash/resource/change/before_transaction.ex
+++ b/lib/ash/resource/change/before_transaction.ex
@@ -1,0 +1,10 @@
+defmodule Ash.Resource.Change.BeforeTransaction do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  @doc false
+  @spec change(Ash.Changeset.t(), keyword, Ash.Resource.Change.context()) :: Ash.Changeset.t()
+  def change(changeset, opts, _) do
+    Ash.Changeset.before_transaction(changeset, opts[:callback], append?: opts[:append?])
+  end
+end

--- a/test/resource/changes/lifecycle_hooks_test.exs
+++ b/test/resource/changes/lifecycle_hooks_test.exs
@@ -1,0 +1,127 @@
+defmodule Ash.Test.Resource.Changes.LifecycleHooksTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule TimeMachine do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string
+    end
+
+    actions do
+      defaults [:read, :update, :destroy]
+
+      create :create_with_before_action do
+        argument :caller, :term
+
+        change before_action(fn changeset ->
+                 send(changeset.arguments.caller, changeset.phase)
+                 changeset
+               end)
+      end
+
+      create :create_with_before_transaction do
+        argument :caller, :term
+
+        change before_transaction(fn changeset ->
+                 send(changeset.arguments.caller, changeset.phase)
+
+                 changeset
+               end)
+      end
+
+      create :create_with_after_action do
+        argument :caller, :term
+
+        change after_action(fn changeset, record ->
+                 send(changeset.arguments.caller, changeset.phase)
+
+                 {:ok, record}
+               end)
+      end
+
+      create :create_with_after_transaction do
+        argument :caller, :term
+
+        change after_transaction(fn changeset, {:ok, record} ->
+                 send(changeset.arguments.caller, changeset.phase)
+
+                 {:ok, record}
+               end)
+      end
+    end
+  end
+
+  defmodule Registry do
+    @moduledoc false
+    use Ash.Registry
+
+    entries do
+      entry TimeMachine
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      registry Registry
+    end
+  end
+
+  describe "before_action/2" do
+    test "it is called before the action is run" do
+      TimeMachine
+      |> Ash.Changeset.for_create(:create_with_before_action,
+        name: "Delorean DMC-12",
+        caller: self()
+      )
+      |> Api.create!()
+
+      assert_received :before_action
+    end
+  end
+
+  describe "before_transaction/2" do
+    test "it is called before the transaction is run" do
+      TimeMachine
+      |> Ash.Changeset.for_create(:create_with_before_transaction,
+        name: "Delorean DMC-12",
+        caller: self()
+      )
+      |> Api.create!()
+
+      assert_received :before_transaction
+    end
+  end
+
+  describe "after_action/2" do
+    test "it is called after the action is run" do
+      TimeMachine
+      |> Ash.Changeset.for_create(:create_with_after_action,
+        name: "Delorean DMC-12",
+        caller: self()
+      )
+      |> Api.create!()
+
+      assert_received :after_action
+    end
+  end
+
+  describe "after_transaction/2" do
+    test "it is called after the transaction is run" do
+      TimeMachine
+      |> Ash.Changeset.for_create(:create_with_after_transaction,
+        name: "Delorean DMC-12",
+        caller: self()
+      )
+      |> Api.create!()
+
+      assert_received :after_transaction
+    end
+  end
+end

--- a/test/resource/changes/load_test.exs
+++ b/test/resource/changes/load_test.exs
@@ -3,6 +3,7 @@ defmodule Ash.Test.Resource.Changes.LoadTest do
   use ExUnit.Case, async: true
 
   defmodule Post do
+    @moduledoc false
     use Ash.Resource,
       data_layer: Ash.DataLayer.Ets
 


### PR DESCRIPTION
This allows very-slightly-more-succinct access to lifecycle hooks, eg:

    change before_action(&IO.inspect/1)

rather than:

    change fn changeset -> Ash.Changeset.before_action(changeset, &IO.inspect/1) end

It's pretty basic, but I think lifecycle hooks are very likely the most common reason that custom changes get written so this should reduce the cognitive burden of writing hooks.

## Additional changes:

* Add (better) typespecs for `Ash.Changeset`, `Ash.Error` and `Ash.Error.Stacktrace`.
* Remove redundant `change_dependencies` field from `Ash.Changeset`.
* Add new `phase` field to `Ash.Changeset` which can be used to introspect whether a changeset is currently running lifecycle hooks.
