### PR TITLE
improvement: Add `before_action/1` and `after_action/1` to `Ash.Resource.Preparations.Builtins`.

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -626,13 +626,11 @@ defmodule Ash.Changeset do
     end
   end
 
-  defp reset_arguments(%{arguments: arguments} = changeset) when is_map(arguments) do
+  defp reset_arguments(%{arguments: arguments} = changeset) do
     Enum.reduce(arguments, changeset, fn {key, value}, changeset ->
       set_argument(changeset, key, value)
     end)
   end
-
-  defp reset_arguments(changeset), do: changeset
 
   @doc """
   Set the result of the action. This will prevent running the underlying datalayer behavior

--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -195,13 +195,14 @@ defmodule Ash.Resource.Change.Builtins do
   ## Example
 
     change after_action(fn changeset, record ->
-      Logger.debug("Successfully executed action #{changeset.action} on #{inspect(changeset.resource)}")
+      Logger.debug("Successfully executed action #{changeset.action.name} on #{inspect(changeset.resource)}")
       {:ok, record}
     end)
   """
   # @dialyzer {:nowarn_function, "MACRO-after_action": 3}
   defmacro after_action(callback, opts \\ []) do
-    {value, function} = Spark.CodeHelpers.lift_functions(callback, :after_action, __CALLER__)
+    {value, function} =
+      Spark.CodeHelpers.lift_functions(callback, :change_after_action, __CALLER__)
 
     quote generated: true do
       unquote(function)
@@ -222,15 +223,16 @@ defmodule Ash.Resource.Change.Builtins do
 
     change after_transaction(fn
       changeset, {:ok, record} ->
-        Logger.debug("Successfully executed transaction for action #{changeset.action} on #{inspect(changeset.resource)}")
+        Logger.debug("Successfully executed transaction for action #{changeset.action.name} on #{inspect(changeset.resource)}")
         {:ok, record}
       changeset, {:error, reason} ->
-        Logger.debug("Failed to execute transaction for action #{changeset.action} on #{inspect(changeset.resource)}, reason: #{inspect(reason)}")
+        Logger.debug("Failed to execute transaction for action #{changeset.action.name} on #{inspect(changeset.resource)}, reason: #{inspect(reason)}")
         {:error, reason}
     end)
   """
   defmacro after_transaction(callback, opts \\ []) do
-    {value, function} = Spark.CodeHelpers.lift_functions(callback, :after_transaction, __CALLER__)
+    {value, function} =
+      Spark.CodeHelpers.lift_functions(callback, :change_after_transaction, __CALLER__)
 
     quote generated: true do
       unquote(function)
@@ -250,13 +252,14 @@ defmodule Ash.Resource.Change.Builtins do
   ## Example
 
     change before_action(fn changeset ->
-      Logger.debug("About to execute #{changeset.action} on #{inspect(changeset.resource)})
+      Logger.debug("About to execute #{changeset.action.name} on #{inspect(changeset.resource)})
 
       changeset
     end)
   """
   defmacro before_action(callback, opts \\ []) do
-    {value, function} = Spark.CodeHelpers.lift_functions(callback, :before_action, __CALLER__)
+    {value, function} =
+      Spark.CodeHelpers.lift_functions(callback, :change_before_action, __CALLER__)
 
     quote generated: true do
       unquote(function)
@@ -276,14 +279,14 @@ defmodule Ash.Resource.Change.Builtins do
   ## Example
 
     change before_transaction(fn changeset ->
-      Logger.debug("About to execute transaction for #{changeset.action} on #{inspect(changeset.resource)})
+      Logger.debug("About to execute transaction for #{changeset.action.name} on #{inspect(changeset.resource)})
 
       changeset
     end)
   """
   defmacro before_transaction(callback, opts \\ []) do
     {value, function} =
-      Spark.CodeHelpers.lift_functions(callback, :before_transaction, __CALLER__)
+      Spark.CodeHelpers.lift_functions(callback, :change_before_transaction, __CALLER__)
 
     quote generated: true do
       unquote(function)

--- a/lib/ash/resource/preparation/after_action.ex
+++ b/lib/ash/resource/preparation/after_action.ex
@@ -1,0 +1,11 @@
+defmodule Ash.Resource.Preparation.AfterAction do
+  @moduledoc false
+
+  use Ash.Resource.Preparation
+
+  @doc false
+  @spec prepare(Ash.Query.t(), keyword, map) :: Ash.Query.t()
+  def prepare(query, opts, _context) do
+    Ash.Query.after_action(query, opts[:callback])
+  end
+end

--- a/lib/ash/resource/preparation/before_action.ex
+++ b/lib/ash/resource/preparation/before_action.ex
@@ -1,0 +1,11 @@
+defmodule Ash.Resource.Preparation.BeforeAction do
+  @moduledoc false
+
+  use Ash.Resource.Preparation
+
+  @doc false
+  @spec prepare(Ash.Query.t(), keyword, map) :: Ash.Query.t()
+  def prepare(query, opts, _context) do
+    Ash.Query.before_action(query, opts[:callback])
+  end
+end

--- a/lib/ash/resource/preparation/builtins.ex
+++ b/lib/ash/resource/preparation/builtins.ex
@@ -35,4 +35,52 @@ defmodule Ash.Resource.Preparation.Builtins do
   def build(options) do
     {Ash.Resource.Preparation.Build, options: options}
   end
+
+  @doc ~S"""
+  Directly attach a `before_action` function to the query.
+
+  See `Ash.Query.before_action/2` for more information.
+
+  ## Example
+
+    prepare before_action(fn query ->
+      Logger.debug("About to execute query for #{query.action.name} on #{inspect(query.resource)})
+
+      query
+    end)
+  """
+  defmacro before_action(callback) do
+    {value, function} =
+      Spark.CodeHelpers.lift_functions(callback, :query_before_action, __CALLER__)
+
+    quote generated: true do
+      unquote(function)
+
+      {Ash.Resource.Preparation.BeforeAction, callback: unquote(value)}
+    end
+  end
+
+  @doc ~S"""
+  Directly attach an `after_action` function to the query.
+
+  See `Ash.Query.after_action/2` for more information.
+
+  ## Example
+
+    prepare after_action(fn query, records ->
+      Logger.debug("Query for #{query.action.name} on resource #{inspect(query.resource)} returned #{length(records)} records")
+
+      {:ok, records}
+    end)
+  """
+  defmacro after_action(callback) do
+    {value, function} =
+      Spark.CodeHelpers.lift_functions(callback, :query_after_action, __CALLER__)
+
+    quote generated: true do
+      unquote(function)
+
+      {Ash.Resource.Preparation.AfterAction, callback: unquote(value)}
+    end
+  end
 end

--- a/test/resource/preparations/lifecycle_hooks_test.exs
+++ b/test/resource/preparations/lifecycle_hooks_test.exs
@@ -1,0 +1,117 @@
+defmodule Ash.Test.Resource.Preparations.LifecycleHooksTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule TimeMachine do
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string
+    end
+
+    actions do
+      read :read_with_before_action do
+        argument :caller, :term
+
+        prepare before_action(fn query ->
+                  send(query.arguments.caller, query.phase)
+                  query
+                end)
+      end
+
+      read :read_with_after_action do
+        argument :caller, :term
+
+        prepare after_action(fn query, records ->
+                  send(query.arguments.caller, query.phase)
+                  {:ok, records}
+                end)
+      end
+
+      read :read_with_multiple_before_actions do
+        argument :caller, :term
+
+        prepare before_action(fn query ->
+                  send(query.arguments.caller, {query.phase, 1})
+                  query
+                end)
+
+        prepare before_action(fn query ->
+                  send(query.arguments.caller, {query.phase, 2})
+                  query
+                end)
+      end
+
+      read :read_with_multiple_after_actions do
+        argument :caller, :term
+
+        prepare after_action(fn query, records ->
+                  send(query.arguments.caller, {query.phase, 1})
+                  {:ok, records}
+                end)
+
+        prepare after_action(fn query, records ->
+                  send(query.arguments.caller, {query.phase, 2})
+                  {:ok, records}
+                end)
+      end
+    end
+  end
+
+  defmodule Registry do
+    @moduledoc false
+    use Ash.Registry
+
+    entries do
+      entry TimeMachine
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      registry Registry
+    end
+  end
+
+  describe "before_action/1" do
+    test "it is called before the action is run" do
+      TimeMachine
+      |> Ash.Query.for_read(:read_with_before_action, caller: self())
+      |> Api.read!()
+
+      assert_received :before_action
+    end
+
+    test "multiple before actions have the same phase" do
+      TimeMachine
+      |> Ash.Query.for_read(:read_with_multiple_before_actions, caller: self())
+      |> Api.read!()
+
+      assert_received {:before_action, 1}
+      assert_received {:before_action, 2}
+    end
+  end
+
+  describe "after_action/1" do
+    test "it is called after the action is run" do
+      TimeMachine
+      |> Ash.Query.for_read(:read_with_after_action, caller: self())
+      |> Api.read!()
+
+      assert_received :after_action
+    end
+
+    test "multiple after actions have the same phase" do
+      TimeMachine
+      |> Ash.Query.for_read(:read_with_multiple_after_actions, caller: self())
+      |> Api.read!()
+
+      assert_received {:after_action, 1}
+      assert_received {:after_action, 2}
+    end
+  end
+end


### PR DESCRIPTION
This allows folks to add lifecycle hooks right in their read actions, eg:

```elixir
prepare before_action(&IO.inspect(&1))
```

rather than:

```elixir
prepare fn query, _context -> Ash.Query.before_action(query, &IO.inspect/1) end
```

* Add (better) typespecs for `Ash.Query`.
* Remove redundant guards as detected by dialyzer.
* Add new `phase` field to `Ash.Query` which can be used to introspec whether a query is currently running lifecycle hooks.