### PR TITLE
docs: format code blocks appropriately

### DIFF
--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -194,10 +194,10 @@ defmodule Ash.Resource.Change.Builtins do
 
   ## Example
 
-    change after_action(fn changeset, record ->
-      Logger.debug("Successfully executed action #{changeset.action.name} on #{inspect(changeset.resource)}")
-      {:ok, record}
-    end)
+      change after_action(fn changeset, record ->
+        Logger.debug("Successfully executed action #{changeset.action.name} on #{inspect(changeset.resource)}")
+        {:ok, record}
+      end)
   """
   # @dialyzer {:nowarn_function, "MACRO-after_action": 3}
   defmacro after_action(callback, opts \\ []) do
@@ -221,14 +221,14 @@ defmodule Ash.Resource.Change.Builtins do
 
   ## Example
 
-    change after_transaction(fn
-      changeset, {:ok, record} ->
-        Logger.debug("Successfully executed transaction for action #{changeset.action.name} on #{inspect(changeset.resource)}")
-        {:ok, record}
-      changeset, {:error, reason} ->
-        Logger.debug("Failed to execute transaction for action #{changeset.action.name} on #{inspect(changeset.resource)}, reason: #{inspect(reason)}")
-        {:error, reason}
-    end)
+      change after_transaction(fn
+        changeset, {:ok, record} ->
+          Logger.debug("Successfully executed transaction for action #{changeset.action.name} on #{inspect(changeset.resource)}")
+          {:ok, record}
+        changeset, {:error, reason} ->
+          Logger.debug("Failed to execute transaction for action #{changeset.action.name} on #{inspect(changeset.resource)}, reason: #{inspect(reason)}")
+          {:error, reason}
+      end)
   """
   defmacro after_transaction(callback, opts \\ []) do
     {value, function} =
@@ -251,11 +251,11 @@ defmodule Ash.Resource.Change.Builtins do
 
   ## Example
 
-    change before_action(fn changeset ->
-      Logger.debug("About to execute #{changeset.action.name} on #{inspect(changeset.resource)})
+      change before_action(fn changeset ->
+        Logger.debug("About to execute #{changeset.action.name} on #{inspect(changeset.resource)})
 
-      changeset
-    end)
+        changeset
+      end)
   """
   defmacro before_action(callback, opts \\ []) do
     {value, function} =
@@ -278,11 +278,11 @@ defmodule Ash.Resource.Change.Builtins do
 
   ## Example
 
-    change before_transaction(fn changeset ->
-      Logger.debug("About to execute transaction for #{changeset.action.name} on #{inspect(changeset.resource)})
+      change before_transaction(fn changeset ->
+        Logger.debug("About to execute transaction for #{changeset.action.name} on #{inspect(changeset.resource)})
 
-      changeset
-    end)
+        changeset
+      end)
   """
   defmacro before_transaction(callback, opts \\ []) do
     {value, function} =


### PR DESCRIPTION
This will allow them to render correctly on Hexdocs and AshHQ

Currently they're a bit broken because they're only using two spaces for indentation, not 4 like the rest of the examples.

<img width="781" alt="Screenshot 2023-03-16 at 3 55 15 pm" src="https://user-images.githubusercontent.com/543859/225550917-064a2eb7-aff6-41fe-845b-aeb7fe30d413.png">
<img width="895" alt="Screenshot 2023-03-16 at 3 55 21 pm" src="https://user-images.githubusercontent.com/543859/225550931-2df2736b-687f-4e83-8381-0089ca701811.png">

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
