### PR TITLE
fix: prevent exception when describing some checks

### DIFF
--- a/lib/ash/error/forbidden/policy.ex
+++ b/lib/ash/error/forbidden/policy.ex
@@ -352,12 +352,11 @@ defmodule Ash.Error.Forbidden.Policy do
         {:ok, false} ->
           "✘"
 
+        {:ok, :unknown} ->
+          unknown_or_error_glyph(success?, filter_check?)
+
         :error ->
-          if success? && filter_check? do
-            "✓"
-          else
-            "?"
-          end
+          unknown_or_error_glyph(success?, filter_check?)
       end
 
     [
@@ -370,6 +369,9 @@ defmodule Ash.Error.Forbidden.Policy do
       tag
     ]
   end
+
+  defp unknown_or_error_glyph(success?, filter_check?) when success? and filter_check?, do: "✓"
+  defp unknown_or_error_glyph(_, _), do: "?"
 
   defp check_type(%{type: :authorize_if}), do: "authorize if"
   defp check_type(%{type: :forbid_if}), do: "forbid if"


### PR DESCRIPTION
Checks that result in {:ok, :unknown} no longer cause an exception to be raised when describing them for output to the log file.