### PR TITLE
improvement(read_uses_flow?): Build stub for `Ash.Actions.Flows.Read`.

### DIFF
--- a/lib/ash/actions/flows/read.ex
+++ b/lib/ash/actions/flows/read.ex
@@ -1,0 +1,42 @@
+defmodule Ash.Actions.Flows.Read do
+  @moduledoc """
+  Execute a read action.
+  """
+  require Ash.Flags
+  use Ash.Flow
+
+  flow do
+    argument :query, :struct do
+      allow_nil? false
+      constraints instance_of: Ash.Query
+    end
+
+    argument :action, :struct do
+      allow_nil? false
+      constraints instance_of: Ash.Resource.Actions.Read
+    end
+
+    returns :fake_result
+  end
+
+  steps do
+    custom :fake_result, Ash.Actions.Flows.Read.FakeResult do
+      input %{query: arg(:query), action: arg(:action)}
+    end
+  end
+
+  @dialyzer {:no_return, [run: 3]}
+  def run(query, action, opts) do
+    Ash.Flags.assert!(:read_uses_flow?, true)
+
+    __MODULE__
+    |> Ash.Flow.run(%{query: query, action: action}, opts)
+    |> case do
+      result when result.errors == [] ->
+        {:ok, result.result}
+
+      result ->
+        {:error, result}
+    end
+  end
+end

--- a/lib/ash/actions/flows/read/fake_result.ex
+++ b/lib/ash/actions/flows/read/fake_result.ex
@@ -1,0 +1,10 @@
+defmodule Ash.Actions.Flows.Read.FakeResult do
+  @moduledoc """
+  Generates a fake result, as the flow has to actually return something.
+  """
+  use Ash.Flow.Step
+
+  def run(_input, _opts, _context) do
+    {:ok, []}
+  end
+end

--- a/lib/ash/actions/read.ex
+++ b/lib/ash/actions/read.ex
@@ -72,7 +72,7 @@ defmodule Ash.Actions.Read do
   def run(query, action, opts \\ [])
 
   if Ash.Flags.read_uses_flow?() do
-    def run(query, action, opts), do: Ash.Actions.ReadFlow.run(query, action, opts)
+    def run(query, action, opts), do: Ash.Actions.Flows.Read.run(query, action, opts)
   else
     def run(query, action, opts) do
       {query, opts} = Ash.Actions.Helpers.add_process_context(query.api, query, opts)

--- a/lib/ash/error/framework/flag_assertion_failed.ex
+++ b/lib/ash/error/framework/flag_assertion_failed.ex
@@ -1,0 +1,26 @@
+defmodule Ash.Error.Framework.FlagAssertionFailed do
+  @moduledoc "Used when unreachable code/conditions are reached in the framework"
+  use Ash.Error.Exception
+
+  def_ash_error([:flag, :heading], class: :framework)
+
+  defimpl Ash.ErrorKind do
+    def id(_), do: Ash.UUID.generate()
+
+    def code(_), do: "flag_failed"
+
+    def message(error) do
+      flag_env_name =
+        error.flag
+        |> to_string()
+        |> String.trim_trailing("?")
+        |> String.upcase()
+
+      """
+      #{error.heading}
+
+      If you are trying to develop or test against a flagged feature either set the flag to the appropriate value in `config.exs` or set the `FLAG_#{flag_env_name}` environment variable (at both compile time and run time).
+      """
+    end
+  end
+end

--- a/lib/ash/flags.ex
+++ b/lib/ash/flags.ex
@@ -6,13 +6,63 @@ defmodule Ash.Flags do
   paths.
   """
 
+  @flags [
+    read_uses_flow?: false
+  ]
+
+  @flag_config Application.compile_env(:ash, :flags, [])
+
+  @flag_values Enum.reduce(@flags, %{}, fn {key, default}, values ->
+                 Map.put(values, key, Keyword.get(@flag_config, key, default))
+               end)
+
+  @noop {:__block__, [], []}
+
   @doc "Should read actions use the new flow-based executor?"
   @spec read_uses_flow? :: Macro.t()
   defmacro read_uses_flow? do
     quote do
-      :ash
-      |> Application.compile_env(:flags, [])
-      |> Keyword.get(:read_uses_flow?, false)
+      unquote(Map.get(@flag_values, :read_uses_flow?))
+    end
+  end
+
+  @doc """
+  Ensure that the feature flag is set to the expected value, otherwise an
+  exception will be thrown at run time.
+  """
+  @spec assert!(atom, any) :: Macro.t()
+  defmacro assert!(flag, expected) when :erlang.map_get(flag, @flag_values) == expected, do: @noop
+
+  defmacro assert!(flag, expected) when :erlang.map_get(flag, @flag_values) != expected do
+    actual = Map.get(@flag_values, flag)
+
+    heading =
+      "Expected value of the `#{inspect(flag)}` feature flag to be `#{inspect(expected)}`, however it is `#{inspect(actual)}`."
+
+    quote do
+      raise Ash.Error.Framework.FlagAssertionFailed.exception(
+              flag: unquote(flag),
+              heading: unquote(heading)
+            )
+    end
+  end
+
+  @doc """
+  Ensure that the feature flag is set to the expected value, otherwise an
+  exception will be thrown at run time.
+  """
+  @spec refute!(atom, any) :: Macro.t()
+  defmacro refute!(flag, expected) when :erlang.map_get(flag, @flag_values) != expected, do: @noop
+
+  defmacro refute!(flag, expected) when :erlang.map_get(flag, @flag_values) == expected do
+    heading =
+      "Expected value of the `#{inspect(flag)}` feature flag not to be `#{inspect(expected)}`."
+
+    quote do
+      raise Ash.Error.Framework.FlagAssertionFailed.exception(
+              flag: unquote(flag),
+              heading: unquote(heading)
+            )
     end
   end
 end


### PR DESCRIPTION
Returns an empty result, but at least it returns a result so now we have failing tests with this feature flag, rather than a compile error.
