### PR TITLE
Improvement: Add upserts options to flow's create step

### DIFF
--- a/lib/ash/flow/executor/ash_engine.ex
+++ b/lib/ash/flow/executor/ash_engine.ex
@@ -964,7 +964,9 @@ defmodule Ash.Flow.Executor.AshEngine do
           input: action_input,
           tenant: tenant,
           wait_for: wait_for,
-          halt_if: halt_if
+          halt_if: halt_if,
+          upsert?: upsert?,
+          upsert_identity: upsert_identity
         } = create
 
         List.wrap(
@@ -1003,6 +1005,8 @@ defmodule Ash.Flow.Executor.AshEngine do
                 authorize?: opts[:authorize?],
                 actor: opts[:actor],
                 tracer: opts[:tracer],
+                upsert?: upsert?,
+                upsert_identity: upsert_identity,
                 changeset_dependencies: request_deps,
                 tenant: fn context ->
                   context = Ash.Helpers.deep_merge_maps(context, additional_context)

--- a/lib/ash/flow/step/create.ex
+++ b/lib/ash/flow/step/create.ex
@@ -1,12 +1,31 @@
 defmodule Ash.Flow.Step.Create do
   @moduledoc false
-  use Ash.Flow.Step.BuiltinStep, [:resource, :action, :api, :tenant, :input]
+  use Ash.Flow.Step.BuiltinStep, [
+    :resource,
+    :action,
+    :api,
+    :tenant,
+    :input,
+    :upsert?,
+    :upsert_identity
+  ]
+
   @shared_opts Ash.Flow.Step.shared_opts()
   @shared_action_opts Ash.Flow.Step.shared_action_opts()
 
   def schema,
     do:
-      []
+      [
+        upsert?: [
+          type: :boolean,
+          doc: "Wether or not this action is always an upsert.",
+          default: false
+        ],
+        upsert_identity: [
+          type: :atom,
+          doc: "The identity to use for the upsert."
+        ]
+      ]
       |> Spark.OptionsHelpers.merge_schemas(@shared_opts, "Global Options")
       |> Spark.OptionsHelpers.merge_schemas(@shared_action_opts, "Action Step Opts")
 end


### PR DESCRIPTION
Currently there's no way to specify upsert options for create actions in the Flows. 
This PR adds support for that by adding this to Spark schema and passes it in AshEngine to `Ash.Actions.Create.as_requests` function.