### PR TITLE
Improve documentation for Ash.Changeset.add_error/3

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -128,6 +128,16 @@ defmodule Ash.Changeset do
 
   @type t :: %__MODULE__{data: Ash.Resource.record()}
 
+  @type error_info ::
+          String.t()
+          | [
+              {:field, atom()}
+              | {:fields, [atom()]}
+              | {:message, String.t()}
+              | {:value, any()}
+            ]
+          | %{:__struct__ => atom(), required(atom()) => any()}
+
   alias Ash.Error.{
     Changes.InvalidArgument,
     Changes.InvalidAttribute,
@@ -3468,8 +3478,22 @@ defmodule Ash.Changeset do
     %{changeset | handle_errors: func}
   end
 
-  @doc "Adds an error to the changesets errors list, and marks the change as `valid?: false`"
-  @spec add_error(t(), term | String.t() | list(term | String.t())) :: t()
+  @doc """
+  Adds an error to the changesets errors list, and marks the change as `valid?: false`.
+
+  ## Error Data
+
+  The given `errors` argument can be a string, a keyword list, a struct, or a list of any of the three.
+
+  If `errors` is a keyword list, or a list of keyword lists, the following keys are supported in the keyword list:
+
+  - `field` (atom) - the field that the error is for. This is required, unless `fields` is given.
+  - `fields` (list of atoms) - the fields that the error is for. This is required, unless `field` is given.
+  - `message` (string) - the error message
+  - `value` (any) - (optional) the field value that caused the error
+  """
+  @spec add_error(t(), error_info() | [error_info()]) :: t()
+  @spec add_error(t(), error_info() | [error_info()], Keyword.t()) :: t()
   def add_error(changeset, errors, path \\ [])
 
   def add_error(changeset, errors, path) when is_list(errors) do


### PR DESCRIPTION
Adds missing documentation for `Ash.Changeset.add_error/3`:

### Before
<img width="866" alt="Screenshot 2023-05-05 at 12 18 21 PM" src="https://user-images.githubusercontent.com/86996/236553223-439f0ea9-3c27-42d1-88d1-4dcb9d458e22.png">

### After
<img width="861" alt="Screenshot 2023-05-05 at 12 36 24 PM" src="https://user-images.githubusercontent.com/86996/236553599-1482a819-6913-4443-bccc-d2e180fe369e.png">

<img width="851" alt="Screenshot 2023-05-05 at 12 28 44 PM" src="https://user-images.githubusercontent.com/86996/236553309-19a5d89f-e7e6-4ef5-90c1-ed5cb933daf7.png">


# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
