### PR TITLE
fix: swap `Exception.exception?` for `Kernel.is_exception`

### DIFF
--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -141,7 +141,7 @@ defmodule Ash.ActionInput do
       end
 
     Enum.reduce(messages, input, fn message, input ->
-      if Exception.exception?(message) do
+      if is_exception(message) do
         error =
           message
           |> Ash.Error.to_ash_error()

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -3801,7 +3801,7 @@ defmodule Ash.Changeset do
       end
 
     Enum.reduce(messages, changeset, fn message, changeset ->
-      if Exception.exception?(message) do
+      if is_exception(message) do
         error =
           message
           |> Ash.Error.to_ash_error()


### PR DESCRIPTION
`Exception.exception?` [is deprecated](https://hexdocs.pm/elixir/1.12/Exception.html#exception?/1) and [will be removed in elixir 1.15](https://github.com/elixir-lang/elixir/blob/a64d42f5d3cb6c32752af9d3312897e8cd5bb7ec/lib/elixir/lib/exception.ex#L49)

`Kernel.is_exception` has been available [since elixir 1.11](https://hexdocs.pm/elixir/1.14/Kernel.html#is_exception/1), and [since ash requires elixir ~> 1.11](https://github.com/ash-project/ash/blob/main/mix.exs#L16) we are safe to depend on it.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
