### PR TITLE
allow functions for generators

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -251,6 +251,9 @@ defmodule Ash.Generator do
       case value do
         %StreamData{} ->
           {key, value}
+          
+        value when is_function(value, 0) ->
+          {key, StreamData.constant(value.())}
 
         value ->
           {key, StreamData.constant(value)}


### PR DESCRIPTION
Adding the possibility to allow functions as generators it would be possible to use pass in functions from e.g.  [Faker](https://hexdocs.pm/faker/Faker.html). This was just a quick win for me, please let me know if this is something that could have been achieved with a bit more knowledge of StreamData

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
