### PR TITLE
Add `Negate` validation

### DIFF
--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -138,4 +138,6 @@ defmodule Ash.Resource.Validation do
         {:error, "Expected items of [:create, :update, :destroy], got: #{inspect(list)}"}
     end
   end
+
+  def validation_type, do: @validation_type
 end

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -62,6 +62,17 @@ defmodule Ash.Resource.Validation.Builtins do
   end
 
   @doc """
+  Validates that other validation does not pass
+
+  ## Examples
+    validate negate(one_of(:status, [:closed, :finished]))
+  """
+  @spec negate(validation :: Validation.ref()) :: Validation.ref()
+  def negate(validation) do
+    {Validation.Negate, validation: validation}
+  end
+
+  @doc """
   Validates that the action is a specific action. Primarily meant for use in `where`.
 
   ## Examples

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -18,14 +18,8 @@ defmodule Ash.Resource.Validation.Negate do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
          {:ok, validation_opts} <- validation.init(validation_opts) do
-       Keyword.put(opts, :validation, {validation, validation_opts})
+      opts = Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}
-    else
-      {:error, exception} = error when is_binary(exception) ->
-        error
-
-      {:error, error} ->
-        {:error, Exception.message(error)}
     end
   end
 

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -1,0 +1,47 @@
+defmodule Ash.Resource.Validation.Negate do
+  @moduledoc false
+
+  alias Ash.Error.Changes.InvalidAttribute
+
+  @opt_schema [
+    validation: [
+      type: Ash.Resource.Validation.validation_type(),
+      required: true,
+      doc: "The validation module to negate another validation"
+    ]
+  ]
+
+  use Ash.Resource.Validation
+
+  @impl true
+  def init(opts) do
+    with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
+         {validation, validation_opts} = opts[:validation],
+         {:ok, _opts} <- validation.init(validation_opts) do
+      {:ok, opts}
+    else
+      {:error, exception} = error when is_binary(exception) ->
+        error
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  @impl true
+  def validate(changeset, opts) do
+    {validation, validation_opts} = opts[:validation]
+
+    case validation.validate(changeset, validation_opts) do
+      {:error, _} ->
+        :ok
+
+      :ok ->
+        {:error,
+         InvalidAttribute.exception(
+           message: "must not pass validation %{validation}",
+           vars: [validation: opts[:validation]]
+         )}
+    end
+  end
+end

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -17,7 +17,8 @@ defmodule Ash.Resource.Validation.Negate do
   def init(opts) do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
-         {:ok, _opts} <- validation.init(validation_opts) do
+         {:ok, validation_opts} <- validation.init(validation_opts) do
+       Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}
     else
       {:error, exception} = error when is_binary(exception) ->

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -1,0 +1,37 @@
+defmodule Ash.Test.Resource.Validation.NegateTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Resource.Validation.Negate
+
+  @moduletag :wip
+
+  defmodule Post do
+    use Ash.Resource
+
+    attributes do
+      uuid_primary_key :id
+      attribute :status, :atom
+    end
+  end
+
+  describe "Negate validation" do
+    test "passes when inner validation fails" do
+      {:ok, opts} =
+        Negate.init(validation: Ash.Resource.Validation.Builtins.one_of(:status, [:canceled]))
+
+      changeset = Post |> Ash.Changeset.new(%{status: :valid})
+
+      assert :ok = Negate.validate(changeset, opts)
+    end
+
+    test "fails when inner validation passes" do
+      {:ok, opts} =
+        Negate.init(validation: Ash.Resource.Validation.Builtins.one_of(:status, [:canceled]))
+
+      changeset = Post |> Ash.Changeset.new(%{status: :canceled})
+
+      assert {:error, %Ash.Error.Changes.InvalidAttribute{}} = Negate.validate(changeset, opts)
+    end
+  end
+end

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -4,8 +4,6 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
 
   alias Ash.Resource.Validation.Negate
 
-  @moduletag :wip
-
   defmodule Post do
     use Ash.Resource
 


### PR DESCRIPTION
This PR adds `negate` validation that negates other validations. This allows to do things like `negate(one_of(:attr, [:val1, :val2])`.

Originally I wanted to name it `not` but when adding a builtin I've found that it might conflict with `Kernel.not` so I've renamed it to `negate`
