### PR TITLE
fix: add `:forbidden` to `error_class`, lowercase code for `Forbidden`

### DIFF
--- a/lib/ash/error/error.ex
+++ b/lib/ash/error/error.ex
@@ -6,12 +6,12 @@ defmodule Ash.Error do
   alias Ash.Error.{Forbidden, Framework, Invalid, Stacktrace, Unknown}
   alias Ash.Error.Unknown.UnknownError
 
-  @type error_class() :: :invalid | :authorization | :framework | :unknown
+  @type error_class() :: :forbidden | :invalid | :framework | :unknown
 
   @type t :: %{
           required(:__struct__) => module,
           required(:__exception__) => true,
-          required(:class) => :invalid | :forbidden | :framework | :unknown,
+          required(:class) => error_class(),
           required(:path) => [atom | integer],
           required(:changeset) => Ash.Changeset.t() | nil,
           required(:query) => Ash.Query.t() | nil,
@@ -568,8 +568,8 @@ defmodule Ash.Error do
     end)
   end
 
-  defp header(:invalid), do: "Input Invalid"
   defp header(:forbidden), do: "Forbidden"
+  defp header(:invalid), do: "Input Invalid"
   defp header(:framework), do: "Framework Error"
   defp header(:unknown), do: "Unknown Error"
 

--- a/lib/ash/error/forbidden.ex
+++ b/lib/ash/error/forbidden.ex
@@ -16,6 +16,6 @@ defmodule Ash.Error.Forbidden do
       Ash.Error.error_descriptions(errors)
     end
 
-    def code(_), do: "Forbidden"
+    def code(_), do: "forbidden"
   end
 end

--- a/lib/ash/error/forbidden/policy.ex
+++ b/lib/ash/error/forbidden/policy.ex
@@ -407,6 +407,6 @@ defmodule Ash.Error.Forbidden.Policy do
       end
     end
 
-    def code(_), do: "Forbidden"
+    def code(_), do: "forbidden"
   end
 end


### PR DESCRIPTION
Some small things about forbidden errors:

Type `error_class` contained `:authorization` instead of `:forbidden`.

`ErrorKind.code()` for `Error.Forbidden` and `Error.Forbidden.Policy` was capitalized "Forbidden" when all other error codes are in lowercase.

(Moved `defp header(:invalid)` bellow `defp header(:forbidden)` to be consistent with order in other places inside the file.)