### PR TITLE
fix: remove `class` and `stacktrace` from `ErrorKind` implementations

### DIFF
--- a/lib/ash/error/engine_error.ex
+++ b/lib/ash/error/engine_error.ex
@@ -9,8 +9,6 @@ defmodule Ash.Error.EngineError do
 
     def code(_), do: "engine_error"
 
-    def class(_), do: :framework
-
     def message(%{state: state, message: message}) do
       transaction_info =
         if state.transaction_id do
@@ -23,7 +21,5 @@ defmodule Ash.Error.EngineError do
       #{Ash.Engine.long_breakdown(state)}
       """
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/invalid/limit_required.ex
+++ b/lib/ash/error/invalid/limit_required.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Invalid.LimitRequired do
 
     def code(_), do: "limit_is_required"
 
-    def class(_), do: :invalid
-
     def message(_) do
       "Limit is required"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/invalid/pagination_required.ex
+++ b/lib/ash/error/invalid/pagination_required.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Invalid.PaginationRequired do
 
     def code(_), do: "pagination_required"
 
-    def class(_), do: :invalid
-
     def message(_) do
       "Pagination is required"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/load/invalid_query.ex
+++ b/lib/ash/error/load/invalid_query.ex
@@ -9,8 +9,6 @@ defmodule Ash.Error.Load.InvalidQuery do
 
     def code(_), do: "invalid_load_query"
 
-    def class(_), do: :invalid
-
     def message(%{query: query, load_path: load_path}) do
       errors_by_path =
         query.errors
@@ -25,7 +23,5 @@ defmodule Ash.Error.Load.InvalidQuery do
           Enum.map_join(errors, "\n", &"* #{inspect(key)} - #{Exception.message(&1)}")
         end)
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/load/no_such_relationship.ex
+++ b/lib/ash/error/load/no_such_relationship.ex
@@ -9,8 +9,6 @@ defmodule Ash.Error.Load.NoSuchRelationship do
 
     def code(_), do: "no_such_load_relationship"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource, relationship: relationship, load_path: load_path}) do
       if load_path == [] do
         "No such relationship #{inspect(resource)}.#{relationship}"
@@ -18,7 +16,5 @@ defmodule Ash.Error.Load.NoSuchRelationship do
         "No such relationship #{inspect(resource)}.#{relationship} at #{Enum.join(load_path, ".")}"
       end
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/aggregates_not_supported.ex
+++ b/lib/ash/error/query/aggregates_not_supported.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Query.AggregatesNotSupported do
 
     def code(_), do: "aggregates_not_supported"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource, feature: feature}) do
       "Data layer for #{inspect(resource)} does not support #{feature} aggregates"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/calculations_not_supported copy.ex
+++ b/lib/ash/error/query/calculations_not_supported copy.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Query.CalculationsNotSupported do
 
     def code(_), do: "calculations_not_supported"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource, feature: feature}) do
       "Data layer for #{inspect(resource)} does not support #{feature} calculations"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/invalid_filter_reference.ex
+++ b/lib/ash/error/query/invalid_filter_reference.ex
@@ -9,8 +9,6 @@ defmodule Ash.Error.Query.InvalidFilterReference do
 
     def code(_), do: "invalid_filter_reference"
 
-    def class(_), do: :invalid
-
     def message(%{field: field, simple_equality?: true}) do
       "#{field} cannot be referenced in filters, except by simple equality"
     end
@@ -18,7 +16,5 @@ defmodule Ash.Error.Query.InvalidFilterReference do
     def message(%{field: field}) do
       "#{field} cannot be referenced in filters"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/invalid_filter_value.ex
+++ b/lib/ash/error/query/invalid_filter_value.ex
@@ -9,8 +9,6 @@ defmodule Ash.Error.Query.InvalidFilterValue do
 
     def code(_), do: "invalid_filter_value"
 
-    def class(_), do: :invalid
-
     def message(%{value: value, message: message, context: context}) when not is_nil(context) do
       if message do
         "Invalid filter value `#{inspect(value)}` supplied in `#{inspect(context)}`: " <> message
@@ -26,7 +24,5 @@ defmodule Ash.Error.Query.InvalidFilterValue do
         "Invalid filter value `#{inspect(value)}`."
       end
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/lock_not_supported.ex
+++ b/lib/ash/error/query/lock_not_supported.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Query.LockNotSupported do
 
     def code(_), do: "lock_not_supported"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource, lock_type: lock_type}) do
       "Data layer for #{inspect(resource)} does not support lock: #{inspect(lock_type)}"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/no_complex_sorts_with_keyset_pagination.ex
+++ b/lib/ash/error/query/no_complex_sorts_with_keyset_pagination.ex
@@ -18,8 +18,6 @@ defmodule Ash.Error.Query.NoComplexSortsWithKeysetPagination do
 
     def code(_), do: "no_complex_sorts_with_keyset_pagination"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource, sort: sort}) do
       """
       Attempted to sort by a calculation or aggregate while using keyset pagination with #{inspect(resource)}
@@ -29,7 +27,5 @@ defmodule Ash.Error.Query.NoComplexSortsWithKeysetPagination do
       Sort: #{inspect(sort)}
       """
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/no_such_attribute_or_relationship.ex
+++ b/lib/ash/error/query/no_such_attribute_or_relationship.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Query.NoSuchAttributeOrRelationship do
 
     def code(_), do: "no_such_attribute_or_relationship"
 
-    def class(_), do: :invalid
-
     def message(%{attribute_or_relationship: attribute_or_relationship, resource: resource}) do
       "No such attribute or relationship #{inspect(attribute_or_relationship)} for #{inspect(resource)}"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/no_such_filter_predicate.ex
+++ b/lib/ash/error/query/no_such_filter_predicate.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Query.NoSuchFilterPredicate do
 
     def code(_), do: "no_such_filter_predicate"
 
-    def class(_), do: :invalid
-
     def message(%{key: key, resource: resource}) do
       "No such filter predicate for #{inspect(resource)}: #{inspect(key)}"
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/not_found.ex
+++ b/lib/ash/error/query/not_found.ex
@@ -9,8 +9,6 @@ defmodule Ash.Error.Query.NotFound do
 
     def code(_), do: "not_found"
 
-    def class(_), do: :invalid
-
     def message(%{primary_key: nil, resource: _resource}) do
       "record not found"
     end
@@ -18,8 +16,6 @@ defmodule Ash.Error.Query.NotFound do
     def message(%{primary_key: key, resource: _resource}) do
       "record with #{id_string(key)} not found"
     end
-
-    def stacktrace(_), do: nil
 
     defp id_string(%Ash.Filter{} = filter) do
       inspect(filter)

--- a/lib/ash/error/query/read_action_required.ex
+++ b/lib/ash/error/query/read_action_required.ex
@@ -9,15 +9,11 @@ defmodule Ash.Error.Query.ReadActionRequired do
 
     def code(_), do: "read_action_required"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource}) do
       """
       A default read action is required on the destination in order to filter
       on a relationship. Destination: #{inspect(resource)}
       """
     end
-
-    def stacktrace(_), do: nil
   end
 end

--- a/lib/ash/error/query/unsupported_predicate.ex
+++ b/lib/ash/error/query/unsupported_predicate.ex
@@ -9,12 +9,8 @@ defmodule Ash.Error.Query.UnsupportedPredicate do
 
     def code(_), do: "unsupported_predicate"
 
-    def class(_), do: :invalid
-
     def message(%{resource: resource, predicate: predicate, type: type}) do
       "Data layer for #{inspect(resource)} does not support #{inspect(predicate)} for #{inspect(type)}"
     end
-
-    def stacktrace(_), do: nil
   end
 end


### PR DESCRIPTION
Still looking into errors and noticed that some implementations of `ErrorKind` have `class` and `stacktrace` while `ErrorKind` protocol does not have those methods. I assume that those are outdated placeholder things and can be removed, right?