### PR TITLE
do not autogenerate values for optional fields that have a generator

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -198,37 +198,37 @@ defmodule Ash.Generator do
             nil
         end
 
-      if attribute.allow_nil? || !is_nil(default) do
-        options = [attribute_generator(attribute)]
-
-        options =
-          if attribute.allow_nil? do
-            if keep_nil? do
-              [StreamData.constant(:__keep_nil__) | options]
-            else
-              [StreamData.constant(nil) | options]
-            end
-          else
-            options
-          end
-
-        options =
-          if attribute.allow_nil? && is_nil(default) do
-            [StreamData.constant(nil) | options]
-          else
-            options
-          end
-
-        {required,
-         Map.put(
-           optional,
-           attribute.name,
-           StreamData.one_of(options)
-         )}
+      # only create a value for attributes that didn't get a dedicated generator
+      if attribute.name in Map.keys(generators) do
+        {required, optional}
       else
-        # only create a value for attributes that didn't get a dedicated generator
-        if attribute.name in Map.keys(generators) do
-          {required, optional}
+        if attribute.allow_nil? || !is_nil(default) do
+          options = [attribute_generator(attribute)]
+
+          options =
+            if attribute.allow_nil? do
+              if keep_nil? do
+                [StreamData.constant(:__keep_nil__) | options]
+              else
+                [StreamData.constant(nil) | options]
+              end
+            else
+              options
+            end
+
+          options =
+            if attribute.allow_nil? && is_nil(default) do
+              [StreamData.constant(nil) | options]
+            else
+              options
+            end
+
+          {required,
+           Map.put(
+             optional,
+             attribute.name,
+             StreamData.one_of(options)
+           )}
         else
           {Map.put(required, attribute.name, attribute_generator(attribute)), optional}
         end

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -23,6 +23,10 @@ defmodule Ash.Test.GeneratorTest do
       uuid_primary_key :id
       attribute :name, :string, default: "Fred"
 
+      attribute :metadata, :map do
+        allow_nil? true
+      end
+
       attribute :meta, :map do
         allow_nil? false
       end
@@ -191,7 +195,8 @@ defmodule Ash.Test.GeneratorTest do
   end
 
   @meta_generator %{
-    meta: %{}
+    meta: %{},
+    metadata: %{}
   }
   describe "seed_input" do
     test "it returns attributes generated" do


### PR DESCRIPTION
The last PR, unfortunately, only worked adequately for the required fields.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
