### PR TITLE
bring validation behaviour in line with rest of builtins

### DIFF
--- a/lib/ash/resource/validation/attribute_does_not_equal.ex
+++ b/lib/ash/resource/validation/attribute_does_not_equal.ex
@@ -31,7 +31,7 @@ defmodule Ash.Resource.Validation.AttributeDoesNotEqual do
 
   @impl true
   def validate(changeset, opts) do
-    value = Ash.Changeset.get_attribute(changeset, opts[:attribute])
+    value = Ash.Changeset.get_argument_or_attribute(changeset, opts[:attribute])
 
     if value == opts[:value] do
       {:error,

--- a/lib/ash/resource/validation/attribute_equals.ex
+++ b/lib/ash/resource/validation/attribute_equals.ex
@@ -30,7 +30,7 @@ defmodule Ash.Resource.Validation.AttributeEquals do
 
   @impl true
   def validate(changeset, opts) do
-    value = Ash.Changeset.get_attribute(changeset, opts[:attribute])
+    value = Ash.Changeset.get_argument_or_attribute(changeset, opts[:attribute])
 
     if value != opts[:value] do
       {:error,

--- a/lib/ash/resource/validation/attribute_in.ex
+++ b/lib/ash/resource/validation/attribute_in.ex
@@ -30,7 +30,7 @@ defmodule Ash.Resource.Validation.AttributeIn do
 
   @impl true
   def validate(changeset, opts) do
-    value = Ash.Changeset.get_attribute(changeset, opts[:attribute])
+    value = Ash.Changeset.get_argument_or_attribute(changeset, opts[:attribute])
 
     if value in opts[:list] do
       :ok


### PR DESCRIPTION
Most builtins check both attribute / argument, bring the remaining ones in line with this behaviour.

\ made a good suggestion in discord which would allow use of attr() / arg() syntax. I think this PR would still have value as an initial starting point to bring everything in line.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
