### PR TITLE
improvement: add support for generic actions in `api.can`

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -477,8 +477,6 @@ defmodule Ash.CodeInterface do
                       |> Kernel.||(unquote(resource))
                       |> Ash.Query.for_read(unquote(action.name), params, query_opts)
                     end
-
-                  query = %{query | api: unquote(api)}
                 end
 
               act =
@@ -589,6 +587,12 @@ defmodule Ash.CodeInterface do
 
         subject_name = elem(subject, 0)
 
+        resolve_subject =
+          quote do
+            unquote(resolve_subject)
+            unquote(subject) = %{unquote(subject) | api: unquote(api)}
+          end
+
         common_args =
           quote do: [
                   unquote_splicing(subject_args),
@@ -623,24 +627,22 @@ defmodule Ash.CodeInterface do
           unquote(subject)
         end
 
-        if action.type != :action do
-          # sobelow_skip ["DOS.BinToAtom"]
-          @dialyzer {:nowarn_function, {:"can_#{interface.name}", length(common_args) + 1}}
-          def unquote(:"can_#{interface.name}")(actor, unquote_splicing(common_args)) do
-            unquote(resolve_opts_params)
-            opts = Keyword.put(opts, :actor, actor)
-            unquote(resolve_subject)
-            unquote(api).can(unquote(subject), actor, opts)
-          end
+        # sobelow_skip ["DOS.BinToAtom"]
+        @dialyzer {:nowarn_function, {:"can_#{interface.name}", length(common_args) + 1}}
+        def unquote(:"can_#{interface.name}")(actor, unquote_splicing(common_args)) do
+          unquote(resolve_opts_params)
+          opts = Keyword.put(opts, :actor, actor)
+          unquote(resolve_subject)
+          unquote(api).can(unquote(subject), actor, opts)
+        end
 
-          # sobelow_skip ["DOS.BinToAtom"]
-          @dialyzer {:nowarn_function, {:"can_#{interface.name}?", length(common_args) + 1}}
-          def unquote(:"can_#{interface.name}?")(actor, unquote_splicing(common_args)) do
-            unquote(resolve_opts_params)
-            opts = Keyword.put(opts, :actor, actor)
-            unquote(resolve_subject)
-            unquote(api).can?(unquote(subject), actor, opts)
-          end
+        # sobelow_skip ["DOS.BinToAtom"]
+        @dialyzer {:nowarn_function, {:"can_#{interface.name}?", length(common_args) + 1}}
+        def unquote(:"can_#{interface.name}?")(actor, unquote_splicing(common_args)) do
+          unquote(resolve_opts_params)
+          opts = Keyword.put(opts, :actor, actor)
+          unquote(resolve_subject)
+          unquote(api).can?(unquote(subject), actor, opts)
         end
       end
     end

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -95,6 +95,11 @@ defmodule Ash.Test.CodeInterfaceTest do
       assert %Ash.ActionInput{action: %{name: :hello}, params: %{name: "bob"}} =
                User.input_to_hello("bob")
     end
+
+    test "generic actions have a helper to test authorization" do
+      assert {:ok, false} == User.can_hello(nil, "fred")
+      assert false == User.can_hello?(nil, "fred")
+    end
   end
 
   describe "read actions" do


### PR DESCRIPTION
Now `api.can`/`api.can?` can accept `ActionInput` or a name of a generic action.

Now code interface generates `can_$act`/`can_$act?` helpers for generic actions.

In code interface made sure that the subject (query/input/changeset) get `api` property set to current api, before it was done only for query (with recent change), but based on types and code in `api.can` I assume it should be applicable to changesets/inputs too.
