### PR TITLE
Add `Negate` validation

### DIFF
--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -138,4 +138,6 @@ defmodule Ash.Resource.Validation do
         {:error, "Expected items of [:create, :update, :destroy], got: #{inspect(list)}"}
     end
   end
+
+  def validation_type, do: @validation_type
 end

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -42,6 +42,7 @@ defmodule Ash.Resource.Validation do
 
   @callback init(Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
   @callback validate(Ash.Changeset.t(), Keyword.t()) :: :ok | {:error, term}
+  @callback describe(Keyword.t()) :: [message: String.t(), vars: Keyword.t()]
 
   @validation_type {:spark_function_behaviour, Ash.Resource.Validation,
                     Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 1}}
@@ -102,6 +103,12 @@ defmodule Ash.Resource.Validation do
       def init(opts), do: {:ok, opts}
 
       defoverridable init: 1
+
+      def describe(opts), do: [message: inspect(__MODULE__), vars: []]
+
+      defoverridable describe: 1
+
+      def with_description(keyword, opts), do: keyword ++ describe(opts)
     end
   end
 

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -44,6 +44,8 @@ defmodule Ash.Resource.Validation do
   @callback validate(Ash.Changeset.t(), Keyword.t()) :: :ok | {:error, term}
   @callback describe(Keyword.t()) :: [message: String.t(), vars: Keyword.t()]
 
+  @optional_callbacks describe: 1
+
   @validation_type {:spark_function_behaviour, Ash.Resource.Validation,
                     Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 1}}
 
@@ -104,11 +106,13 @@ defmodule Ash.Resource.Validation do
 
       defoverridable init: 1
 
-      def describe(opts), do: [message: inspect(__MODULE__), vars: []]
-
-      defoverridable describe: 1
-
-      def with_description(keyword, opts), do: keyword ++ describe(opts)
+      defp with_description(keyword, opts) do
+        if Kernel.function_exported?(__MODULE__, :describe, 1) do
+          keyword ++ apply(__MODULE__, :describe, [opts])
+        else
+          keyword
+        end
+      end
     end
   end
 

--- a/lib/ash/resource/validation/action_is.ex
+++ b/lib/ash/resource/validation/action_is.ex
@@ -9,7 +9,14 @@ defmodule Ash.Resource.Validation.ActionIs do
     else
       # We use "unknown" here because it doesn't make sense to surface
       # this error to clients potentially (and this should really only be used as a condition anyway)
-      {:error, Ash.Error.Unknown.UnknownError.exception(error: "action must be #{opts[:action]}")}
+      [message: message, vars: vars] = describe(opts)
+
+      {:error, Ash.Error.Unknown.UnknownError.exception(error: message, vars: vars)}
     end
+  end
+
+  @impl true
+  def describe(opts) do
+    [message: "must be %{action}", vars: %{action: opts[:action]}]
   end
 end

--- a/lib/ash/resource/validation/attribute_does_not_equal.ex
+++ b/lib/ash/resource/validation/attribute_does_not_equal.ex
@@ -35,14 +35,19 @@ defmodule Ash.Resource.Validation.AttributeDoesNotEqual do
 
     if value == opts[:value] do
       {:error,
-       InvalidAttribute.exception(
-         field: opts[:attribute],
-         value: value,
-         message: "must not equal %{value}",
-         vars: [field: opts[:attribute], value: opts[:value]]
-       )}
+       [field: opts[:attribute], value: value]
+       |> with_description(opts)
+       |> InvalidAttribute.exception()}
     else
       :ok
     end
+  end
+
+  @impl true
+  def describe(opts) do
+    [
+      message: "must not equal %{value}",
+      vars: [field: opts[:attribute], value: opts[:value]]
+    ]
   end
 end

--- a/lib/ash/resource/validation/attribute_equals.ex
+++ b/lib/ash/resource/validation/attribute_equals.ex
@@ -34,14 +34,19 @@ defmodule Ash.Resource.Validation.AttributeEquals do
 
     if value != opts[:value] do
       {:error,
-       InvalidAttribute.exception(
-         value: value,
-         field: opts[:attribute],
-         message: "must equal %{value}",
-         vars: [field: opts[:attribute], value: opts[:value]]
-       )}
+       [field: opts[:attribute], value: value]
+       |> with_description(opts)
+       |> InvalidAttribute.exception()}
     else
       :ok
     end
+  end
+
+  @impl true
+  def describe(opts) do
+    [
+      message: "must equal %{value}",
+      vars: [field: opts[:attribute], value: opts[:value]]
+    ]
   end
 end

--- a/lib/ash/resource/validation/attribute_in.ex
+++ b/lib/ash/resource/validation/attribute_in.ex
@@ -36,12 +36,17 @@ defmodule Ash.Resource.Validation.AttributeIn do
       :ok
     else
       {:error,
-       InvalidAttribute.exception(
-         value: value,
-         field: opts[:attribute],
-         message: "must equal %{value}",
-         vars: [field: opts[:attribute], value: opts[:value]]
-       )}
+       [value: value, field: opts[:attribute]]
+       |> with_description(opts)
+       |> InvalidAttribute.exception()}
     end
+  end
+
+  @impl true
+  def describe(opts) do
+    [
+      message: "must equal %{value}",
+      vars: [field: opts[:attribute], value: opts[:value]]
+    ]
   end
 end

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -62,6 +62,17 @@ defmodule Ash.Resource.Validation.Builtins do
   end
 
   @doc """
+  Validates that other validation does not pass
+
+  ## Examples
+    validate negate(one_of(:status, [:closed, :finished]))
+  """
+  @spec negate(validation :: Validation.ref()) :: Validation.ref()
+  def negate(validation) do
+    {Validation.Negate, validation: validation}
+  end
+
+  @doc """
   Validates that the action is a specific action. Primarily meant for use in `where`.
 
   ## Examples

--- a/lib/ash/resource/validation/changing.ex
+++ b/lib/ash/resource/validation/changing.ex
@@ -31,11 +31,7 @@ defmodule Ash.Resource.Validation.Changing do
         if Ash.Changeset.changing_attribute?(changeset, opts[:field]) do
           :ok
         else
-          {:error,
-           InvalidAttribute.exception(
-             field: opts[:field],
-             message: "must be changing"
-           )}
+          {:error, exception(opts)}
         end
 
       %{type: :belongs_to, source_attribute: source_attribute} = relationship ->
@@ -43,23 +39,29 @@ defmodule Ash.Resource.Validation.Changing do
              Ash.Changeset.changing_relationship?(changeset, relationship.name) do
           :ok
         else
-          {:error,
-           InvalidAttribute.exception(
-             field: opts[:field],
-             message: "must be changing"
-           )}
+          {:error, exception(opts)}
         end
 
       relationship ->
         if Ash.Changeset.changing_relationship?(changeset, relationship.name) do
           :ok
         else
-          {:error,
-           InvalidAttribute.exception(
-             field: opts[:field],
-             message: "must be changing"
-           )}
+          {:error, exception(opts)}
         end
     end
+  end
+
+  @impl true
+  def describe(_opts) do
+    [
+      message: "must be changing",
+      vars: []
+    ]
+  end
+
+  defp exception(opts) do
+    [field: opts[:field]]
+    |> with_description(opts)
+    |> InvalidAttribute.exception()
   end
 end

--- a/lib/ash/resource/validation/compare.ex
+++ b/lib/ash/resource/validation/compare.ex
@@ -112,7 +112,7 @@ defmodule Ash.Resource.Validation.Compare do
       :greater_than_or_equal_to,
       :less_than_or_equal_to
     ])
-    |> Enum.map(fn {key, _value} ->
+    |> Enum.map_join(" and ", fn {key, _value} ->
       case key do
         :greater_than ->
           "must be greater than %{greater_than}"
@@ -127,6 +127,5 @@ defmodule Ash.Resource.Validation.Compare do
           "must be less than or equal to %{less_than_or_equal_to}"
       end
     end)
-    |> Enum.join(" and ")
   end
 end

--- a/lib/ash/resource/validation/confirm.ex
+++ b/lib/ash/resource/validation/confirm.ex
@@ -4,6 +4,7 @@ defmodule Ash.Resource.Validation.Confirm do
   alias Ash.Changeset
   alias Ash.Error.Changes.InvalidAttribute
 
+  @impl true
   def init(opts) do
     case opts[:field] do
       nil ->
@@ -26,6 +27,7 @@ defmodule Ash.Resource.Validation.Confirm do
     end
   end
 
+  @impl true
   def validate(changeset, opts) do
     confirmation_value =
       Changeset.get_argument(changeset, opts[:confirmation]) ||
@@ -39,11 +41,17 @@ defmodule Ash.Resource.Validation.Confirm do
       :ok
     else
       {:error,
-       InvalidAttribute.exception(
-         field: opts[:confirmation],
-         value: confirmation_value,
-         message: "confirmation did not match value"
-       )}
+       [field: opts[:confirmation], value: confirmation_value]
+       |> with_description(opts)
+       |> InvalidAttribute.exception()}
     end
+  end
+
+  @impl true
+  def describe(_opts) do
+    [
+      message: "confirmation did not match value",
+      vars: []
+    ]
   end
 end

--- a/lib/ash/resource/validation/function.ex
+++ b/lib/ash/resource/validation/function.ex
@@ -8,7 +8,16 @@ defmodule Ash.Resource.Validation.Function do
     apply(m, f, [changeset | a])
   end
 
+  @impl true
   def validate(changeset, [{:fun, fun}]) do
     fun.(changeset)
+  end
+
+  @impl true
+  def describe(opts) do
+    [
+      message: "must pass function %{function}",
+      vars: [function: opts[:fun]]
+    ]
   end
 end

--- a/lib/ash/resource/validation/match.ex
+++ b/lib/ash/resource/validation/match.ex
@@ -43,13 +43,7 @@ defmodule Ash.Resource.Validation.Match do
             if String.match?(changing_to, opts[:match]) do
               :ok
             else
-              {:error,
-               InvalidAttribute.exception(
-                 field: opts[:attribute],
-                 value: changing_to,
-                 message: opts[:message],
-                 vars: [match: opts[:match]]
-               )}
+              {:error, exception(opts)}
             end
 
           {:error, error} ->
@@ -61,16 +55,24 @@ defmodule Ash.Resource.Validation.Match do
     end
   end
 
+  @impl true
+  def describe(opts) do
+    [
+      message: opts[:message],
+      vars: [field: opts[:attribute], match: opts[:match]]
+    ]
+  end
+
   defp string_value(value, opts) do
     {:ok, to_string(value)}
   rescue
     _ ->
-      {:error,
-       InvalidAttribute.exception(
-         value: opts[:value],
-         field: opts[:attribute],
-         message: opts[:message],
-         vars: [match: opts[:match]]
-       )}
+      {:error, exception(opts)}
+  end
+
+  defp exception(opts) do
+    [value: opts[:value], field: opts[:attribute]]
+    |> with_description(opts)
+    |> InvalidAttribute.exception()
   end
 end

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -16,10 +16,18 @@ defmodule Ash.Resource.Validation.Negate do
   def init(opts) do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
+         true <- function_exported?(validation, :describe, 1),
          {:module, validation} <- Code.ensure_compiled(validation),
          {:ok, validation_opts} <- validation.init(validation_opts) do
       opts = Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}
+    else
+      false ->
+        {:error,
+         "#{opts[:validation]} must implement `describe/1` function to be used in #{__MODULE__}"}
+
+      error ->
+        error
     end
   end
 

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -1,8 +1,6 @@
 defmodule Ash.Resource.Validation.Negate do
   @moduledoc false
 
-  alias Ash.Error.Changes.InvalidAttribute
-
   @opt_schema [
     validation: [
       type: Ash.Resource.Validation.validation_type(),
@@ -12,6 +10,7 @@ defmodule Ash.Resource.Validation.Negate do
   ]
 
   use Ash.Resource.Validation
+  alias Ash.Error.Changes.InvalidAttribute
 
   @impl true
   def init(opts) do
@@ -33,10 +32,20 @@ defmodule Ash.Resource.Validation.Negate do
 
       :ok ->
         {:error,
-         InvalidAttribute.exception(
-           message: "must not pass validation %{validation}",
-           vars: [validation: opts[:validation]]
-         )}
+         opts
+         |> describe()
+         |> InvalidAttribute.exception()}
     end
+  end
+
+  @impl true
+  def describe(opts) do
+    {validation, validation_opts} = opts[:validation]
+    [message: message, vars: vars] = validation.describe(validation_opts)
+
+    [
+      message: "must not pass validation: \"#{message}\"",
+      vars: vars
+    ]
   end
 end

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -16,8 +16,8 @@ defmodule Ash.Resource.Validation.Negate do
   def init(opts) do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
-         true <- function_exported?(validation, :describe, 1),
          {:module, validation} <- Code.ensure_compiled(validation),
+         true <- function_exported?(validation, :describe, 1),
          {:ok, validation_opts} <- validation.init(validation_opts) do
       opts = Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -18,14 +18,8 @@ defmodule Ash.Resource.Validation.Negate do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
          {:ok, validation_opts} <- validation.init(validation_opts) do
-       Keyword.put(opts, :validation, {validation, validation_opts})
+      opts = Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}
-    else
-      {:error, exception} = error when is_binary(exception) ->
-        error
-
-      {:error, error} ->
-        {:error, Exception.message(error)}
     end
   end
 

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -1,0 +1,47 @@
+defmodule Ash.Resource.Validation.Negate do
+  @moduledoc false
+
+  alias Ash.Error.Changes.InvalidAttribute
+
+  @opt_schema [
+    validation: [
+      type: Ash.Resource.Validation.validation_type(),
+      required: true,
+      doc: "The validation module to negate another validation"
+    ]
+  ]
+
+  use Ash.Resource.Validation
+
+  @impl true
+  def init(opts) do
+    with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
+         {validation, validation_opts} = opts[:validation],
+         {:ok, _opts} <- validation.init(validation_opts) do
+      {:ok, opts}
+    else
+      {:error, exception} = error when is_binary(exception) ->
+        error
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  @impl true
+  def validate(changeset, opts) do
+    {validation, validation_opts} = opts[:validation]
+
+    case validation.validate(changeset, validation_opts) do
+      {:error, _} ->
+        :ok
+
+      :ok ->
+        {:error,
+         InvalidAttribute.exception(
+           message: "must not pass validation %{validation}",
+           vars: [validation: opts[:validation]]
+         )}
+    end
+  end
+end

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -16,6 +16,7 @@ defmodule Ash.Resource.Validation.Negate do
   def init(opts) do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
+         {:module, validation} <- Code.ensure_compiled(validation),
          {:ok, validation_opts} <- validation.init(validation_opts) do
       opts = Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -23,8 +23,13 @@ defmodule Ash.Resource.Validation.Negate do
       {:ok, opts}
     else
       false ->
-        {:error,
-         "#{opts[:validation]} must implement `describe/1` function to be used in #{__MODULE__}"}
+        module =
+          case opts[:validation] do
+            {module, _opts} -> module
+            module -> module
+          end
+
+        {:error, "#{module} must implement `describe/1` function to be used in #{__MODULE__}"}
 
       error ->
         error

--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -17,7 +17,8 @@ defmodule Ash.Resource.Validation.Negate do
   def init(opts) do
     with {:ok, opts} <- Spark.OptionsHelpers.validate(opts, @opt_schema),
          {validation, validation_opts} = opts[:validation],
-         {:ok, _opts} <- validation.init(validation_opts) do
+         {:ok, validation_opts} <- validation.init(validation_opts) do
+       Keyword.put(opts, :validation, {validation, validation_opts})
       {:ok, opts}
     else
       {:error, exception} = error when is_binary(exception) ->

--- a/lib/ash/resource/validation/one_of.ex
+++ b/lib/ash/resource/validation/one_of.ex
@@ -42,16 +42,21 @@ defmodule Ash.Resource.Validation.OneOf do
           :ok
         else
           {:error,
-           InvalidAttribute.exception(
-             value: changing_to,
-             field: opts[:attribute],
-             message: "expected one of %{values}",
-             vars: [values: Enum.map_join(opts[:values], ", ", &to_string/1)]
-           )}
+           [value: changing_to, field: opts[:attribute]]
+           |> with_description(opts)
+           |> InvalidAttribute.exception()}
         end
 
       _ ->
         :ok
     end
+  end
+
+  @impl true
+  def describe(opts) do
+    [
+      message: "expected one of %{values}",
+      vars: [values: Enum.map_join(opts[:values], ", ", &to_string/1)]
+    ]
   end
 end

--- a/lib/ash/resource/validation/string_length.ex
+++ b/lib/ash/resource/validation/string_length.ex
@@ -55,13 +55,7 @@ defmodule Ash.Resource.Validation.StringLength do
     if String.length(value) == exact do
       :ok
     else
-      {:error,
-       InvalidAttribute.exception(
-         value: value,
-         field: opts[:attribute],
-         message: "must have length of exactly %{exact}",
-         vars: [exact: exact]
-       )}
+      {:error, exception(value, opts)}
     end
   end
 
@@ -71,13 +65,7 @@ defmodule Ash.Resource.Validation.StringLength do
     if string_length >= min and string_length <= max do
       :ok
     else
-      {:error,
-       InvalidAttribute.exception(
-         value: value,
-         field: opts[:attribute],
-         message: "must have length of between %{min} and %{max}",
-         vars: [min: min, max: max]
-       )}
+      {:error, exception(value, opts)}
     end
   end
 
@@ -85,13 +73,7 @@ defmodule Ash.Resource.Validation.StringLength do
     if String.length(value) >= min do
       :ok
     else
-      {:error,
-       InvalidAttribute.exception(
-         value: value,
-         field: opts[:attribute],
-         message: "must have length of at least %{min}",
-         vars: [min: min]
-       )}
+      {:error, exception(value, opts)}
     end
   end
 
@@ -99,13 +81,28 @@ defmodule Ash.Resource.Validation.StringLength do
     if String.length(value) <= max do
       :ok
     else
-      {:error,
-       InvalidAttribute.exception(
-         value: value,
-         field: opts[:attribute],
-         message: "must have length of no more than %{max}",
-         vars: [max: max]
-       )}
+      {:error, exception(value, opts)}
     end
   end
+
+  defp exception(value, opts) do
+    [value: value, field: opts[:attribute]]
+    |> with_description(opts)
+    |> InvalidAttribute.exception()
+  end
+
+  @impl true
+  def describe(%{exact: exact}),
+    do: [message: "must have length of exactly %{exact}", vars: [exact: exact]]
+
+  def describe(%{min: min, max: max}),
+    do: [message: "must have length of between %{min} and %{max}", vars: [min: min, max: max]]
+
+  def describe(%{min: min}),
+    do: [message: "must have length of at least %{min}", vars: [min: min]]
+
+  def describe(%{max: max}),
+    do: [message: "must have length of no more than %{max}", vars: [max: max]]
+
+  def describe(_opts), do: [message: inspect(__MODULE__), vars: []]
 end

--- a/test/policy/field_policy_test.exs
+++ b/test/policy/field_policy_test.exs
@@ -1,4 +1,4 @@
-defmodule Ash.Test.Policy.RbacTest do
+defmodule Ash.Test.Policy.FieldPolicyTest do
   @doc false
   use ExUnit.Case
 

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -1,0 +1,37 @@
+defmodule Ash.Test.Resource.Validation.NegateTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Resource.Validation.Negate
+
+  @moduletag :wip
+
+  defmodule Post do
+    use Ash.Resource
+
+    attributes do
+      uuid_primary_key :id
+      attribute :status, :atom
+    end
+  end
+
+  describe "Negate validation" do
+    test "passes when inner validation fails" do
+      {:ok, opts} =
+        Negate.init(validation: Ash.Resource.Validation.Builtins.one_of(:status, [:canceled]))
+
+      changeset = Post |> Ash.Changeset.new(%{status: :valid})
+
+      assert :ok = Negate.validate(changeset, opts)
+    end
+
+    test "fails when inner validation passes" do
+      {:ok, opts} =
+        Negate.init(validation: Ash.Resource.Validation.Builtins.one_of(:status, [:canceled]))
+
+      changeset = Post |> Ash.Changeset.new(%{status: :canceled})
+
+      assert {:error, %Ash.Error.Changes.InvalidAttribute{}} = Negate.validate(changeset, opts)
+    end
+  end
+end

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -18,6 +18,16 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
 
     @impl true
     def validate(_, _), do: {:error, :some_error}
+
+    @impl true
+    def describe(opts), do: [message: "Custom validation error message", vars: []]
+  end
+
+  defmodule CustomValidationNoDescribe do
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(_, _), do: {:error, :some_error}
   end
 
   describe "Negate validation" do
@@ -45,6 +55,13 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
       changeset = Post |> Ash.Changeset.new(%{status: :valid})
 
       assert :ok = Negate.validate(changeset, opts)
+    end
+
+    test "returns error on init if validation do not export `describe/1`" do
+      expected_message =
+        "#{CustomValidationNoDescribe} must implement `describe/1` function to be used in #{Negate}"
+
+      {:error, ^expected_message} = Negate.init(validation: CustomValidationNoDescribe)
     end
   end
 end

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -4,8 +4,6 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
 
   alias Ash.Resource.Validation.Negate
 
-  @moduletag :wip
-
   defmodule Post do
     use Ash.Resource
 

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -20,7 +20,7 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
     def validate(_, _), do: {:error, :some_error}
 
     @impl true
-    def describe(opts), do: [message: "Custom validation error message", vars: []]
+    def describe(_opts), do: [message: "Custom validation error message", vars: []]
   end
 
   defmodule CustomValidationNoDescribe do

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -13,6 +13,13 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
     end
   end
 
+  defmodule CustomValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(_, _), do: {:error, :some_error}
+  end
+
   describe "Negate validation" do
     test "passes when inner validation fails" do
       {:ok, opts} =
@@ -30,6 +37,14 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
       changeset = Post |> Ash.Changeset.new(%{status: :canceled})
 
       assert {:error, %Ash.Error.Changes.InvalidAttribute{}} = Negate.validate(changeset, opts)
+    end
+
+    test "support custom validations" do
+      {:ok, opts} = Negate.init(validation: CustomValidation)
+
+      changeset = Post |> Ash.Changeset.new(%{status: :valid})
+
+      assert :ok = Negate.validate(changeset, opts)
     end
   end
 end


### PR DESCRIPTION
Continue of work done in https://github.com/ash-project/ash/pull/587

> This PR adds negate validation that negates other validations. This allows to do things like negate(one_of(:attr, [:val1, :val2]).
> 
> Originally I wanted to name it not but when adding a builtin I've found that it might conflict with Kernel.not so I've renamed it to negate