### PR TITLE
fix: incorrect error for casting some binary UUIDs

### DIFF
--- a/lib/ash/type/uuid.ex
+++ b/lib/ash/type/uuid.ex
@@ -23,7 +23,10 @@ defmodule Ash.Type.UUID do
   def cast_input(nil, _), do: {:ok, nil}
 
   def cast_input(value, _) when is_binary(value) do
-    Ecto.Type.cast(Ecto.UUID, String.trim(value))
+    case String.valid?(value) do
+      true -> Ecto.Type.cast(Ecto.UUID, String.trim(value))
+      false -> Ecto.Type.cast(Ecto.UUID, value)
+    end
   end
 
   def cast_input(value, _) do

--- a/test/type/uuid_test.exs
+++ b/test/type/uuid_test.exs
@@ -1,0 +1,11 @@
+defmodule Ash.Test.Type.UUIDTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  test "it casts binary UUIDs to string" do
+    uuid = "a7cec9ba-15de-4c56-99e4-c2abc91a2209"
+
+    assert {:ok, binary_uuid} = Ash.Type.dump_to_native(Ash.Type.UUID, uuid)
+    assert {:ok, ^uuid} = Ash.Type.cast_input(Ash.Type.UUID, binary_uuid)
+  end
+end


### PR DESCRIPTION
This fixes `Ash.Type.cast_input/2` returning an error on certain UUIDs coming out of raw queries represented in binary/bitstrings. `String.trim/1` removes the last byte if it's less than 14, causing the cast to fail.

```elixir
Ecto.Type.cast(Ecto.UUID, <<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 14>>)
#=> {:ok, "a7cec9ba-15de-4c56-99e4-c2abc91a220e"}

Ash.Type.cast_input(Ash.Type.UUID, <<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 14>>)
#=> {:ok, "a7cec9ba-15de-4c56-99e4-c2abc91a220e"}

Ecto.Type.cast(Ecto.UUID, <<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 13>>)
#=> {:ok, "a7cec9ba-15de-4c56-99e4-c2abc91a220d"}

Ash.Type.cast_input(Ash.Type.UUID, <<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 13>>)
#=> {:error, "is invalid"}

String.trim(<<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 13>>)
#=> <<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34>>

String.trim(<<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 14>>)
#=> <<167, 206, 201, 186, 21, 222, 76, 86, 153, 228, 194, 171, 201, 26, 34, 14>>
```