### PR TITLE
fix: read argument value in `ArgumentEquals` validation

### DIFF
--- a/lib/ash/resource/validation/argument_equals.ex
+++ b/lib/ash/resource/validation/argument_equals.ex
@@ -30,7 +30,7 @@ defmodule Ash.Resource.Validation.ArgumentEquals do
 
   @impl true
   def validate(changeset, opts) do
-    value = Ash.Changeset.get_attribute(changeset, opts[:argument])
+    value = Ash.Changeset.get_argument(changeset, opts[:argument])
 
     if value != opts[:value] do
       {:error,


### PR DESCRIPTION
We had an almost-identical `ArgumentEquals` validation in our codebase, and when I removed it in favour of the new built-in one, some of our tests started failing. 

Upon comparing them, I noticed this issue - it wasn't reading the actual argument, instead looking for an attribute with the same name!