### PR TITLE
add Ash.Policy.Check.Expr to builtin checks

### DIFF
--- a/lib/ash/policy/check/built_in_checks.ex
+++ b/lib/ash/policy/check/built_in_checks.ex
@@ -268,4 +268,9 @@ defmodule Ash.Policy.Check.Builtins do
   def changing_relationships(relationships) do
     {Ash.Policy.Check.ChangingRelationships, relationships: relationships}
   end
+
+  @doc "Applies an expression as a check"
+  def check_expr(expr) do
+    {Ash.Policy.Check.Expr, expr: expr}
+  end
 end


### PR DESCRIPTION
I needed to add an expr to a policy condition, and the helper would have been nice to have. 
