### PR TITLE
Should validate all actions and accept/reject fields at once.

### DIFF
--- a/lib/ash/resource/transformers/validate_accept.ex
+++ b/lib/ash/resource/transformers/validate_accept.ex
@@ -18,46 +18,117 @@ defmodule Ash.Resource.Transformers.ValidateAccept do
     public_attribute_names = MapSet.new(public_attributes, & &1.name)
     private_attribute_names = MapSet.new(private_attributes, & &1.name)
 
-    Transformer.get_entities(dsl_state, [:actions])
-    |> Enum.each(fn
-      %{name: action_name, accept: accept, reject: reject} ->
-        validate_attribute_name = fn attribute_name, type ->
-          cond do
-            MapSet.member?(private_attribute_names, attribute_name) ->
-              raise DslError,
-                path: [:actions, action_name, type, attribute_name],
-                message: "#{attribute_name} is a private attribute"
+    initial_errors = %{private: [], not_attribute: []}
 
-            MapSet.member?(public_attribute_names, attribute_name) ->
-              :ok
+    result =
+      Transformer.get_entities(dsl_state, [:actions])
+      |> Enum.reduce(%{}, fn
+        %{name: action_name, accept: accept, reject: reject}, acc ->
+          validate_attribute_name = fn attribute_name ->
+            cond do
+              MapSet.member?(private_attribute_names, attribute_name) ->
+                :private
 
-            true ->
-              raise DslError,
-                path: [:actions, action_name, type, attribute_name],
-                message: "#{attribute_name} is not an attribute"
+              MapSet.member?(public_attribute_names, attribute_name) ->
+                :ok
+
+              true ->
+                :not_attribute
+            end
           end
-        end
 
-        Enum.each(
-          accept,
-          &validate_attribute_name.(
-            &1,
-            :accept
-          )
-        )
+          accept_errors =
+            Enum.reduce(
+              accept,
+              initial_errors,
+              fn attribute, %{private: private, not_attribute: not_attribute} = acc ->
+                case validate_attribute_name.(attribute) do
+                  :ok ->
+                    acc
 
-        Enum.each(
-          reject,
-          &validate_attribute_name.(
-            &1,
-            :reject
-          )
-        )
+                  :private ->
+                    %{private: [attribute | private], not_attribute: not_attribute}
 
-      _ ->
-        :ok
-    end)
+                  :not_attribute ->
+                    %{private: private, not_attribute: [attribute | not_attribute]}
+                end
+              end
+            )
 
-    :ok
+          reject_errors =
+            Enum.reduce(
+              reject,
+              initial_errors,
+              fn attribute, %{private: private, not_attribute: not_attribute} = acc ->
+                case validate_attribute_name.(attribute) do
+                  :ok ->
+                    acc
+
+                  :private ->
+                    %{private: [attribute | private], not_attribute: not_attribute}
+
+                  :not_attribute ->
+                    %{private: private, not_attribute: [attribute | not_attribute]}
+                end
+              end
+            )
+
+          if accept_errors == initial_errors and reject_errors == initial_errors do
+            acc
+          else
+            Map.put(acc, action_name, %{
+              accept: accept_errors,
+              reject: reject_errors
+            })
+          end
+
+        _, acc ->
+          acc
+      end)
+      |> Enum.map(fn {action, %{accept: accept, reject: reject}} ->
+        accept_private = accept.private |> Enum.reverse()
+        accept_not_attribute = accept.not_attribute |> Enum.reverse()
+        reject_private = reject.private |> Enum.reverse()
+        reject_not_attribute = reject.not_attribute |> Enum.reverse()
+
+        [
+          message(accept_private, "are private attributes", [:actions, action, :accept]),
+          message(accept_not_attribute, "are not attributes", [:actions, action, :accept]),
+          message(reject_private, "are private attributes", [:actions, action, :reject]),
+          message(reject_not_attribute, "are not attributes", [:actions, action, :reject])
+        ]
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.join("\n")
+      end)
+
+    if result == [] do
+      :ok
+    else
+      raise DslError,
+        message: Enum.join(result, "\n"),
+        path: []
+    end
+  end
+
+  defp message(keys, _message, _path) when keys == [] do
+    ""
+  end
+
+  defp message(keys, message, path)
+       when is_nil(path) or path == [] do
+    "#{get_message(keys, message)}"
+  end
+
+  defp message(keys, message, path) do
+    dsl_path = Enum.join(path, " -> ")
+    "#{dsl_path}:\n  #{get_message(keys, message)}"
+  end
+
+  defp get_message(keys, message) when is_binary(message) do
+    "#{inspect(keys)} #{message}"
+  end
+
+  defp get_message(keys, message) do
+    "#{inspect(keys)} #{inspect(message)}"
   end
 end

--- a/test/resource/validate_accept_test.exs
+++ b/test/resource/validate_accept_test.exs
@@ -6,7 +6,7 @@ defmodule Ash.Test.Resource.ValidateAcceptTest do
   alias Spark.Error.DslError
 
   test "Accepting an attribute that does not exist raises an error" do
-    assert_raise DslError, ~r/invalid is not an attribute/, fn ->
+    assert_raise DslError, ~r/\[:invalid\] are not attributes/, fn ->
       defposts do
         actions do
           create :example_action, accept: [:invalid]
@@ -16,7 +16,7 @@ defmodule Ash.Test.Resource.ValidateAcceptTest do
   end
 
   test "Accepting an attribute that is private raises an error" do
-    assert_raise DslError, ~r/secret is a private attribute/, fn ->
+    assert_raise DslError, ~r/\[:secret\] are private attributes/, fn ->
       defposts do
         attributes do
           attribute :secret, :string, private?: true
@@ -30,7 +30,7 @@ defmodule Ash.Test.Resource.ValidateAcceptTest do
   end
 
   test "Rejecting an attribute that does not exist raises an error" do
-    assert_raise DslError, ~r/invalid is not an attribute/, fn ->
+    assert_raise DslError, ~r/\[:invalid\] are not attributes/, fn ->
       defposts do
         actions do
           create :example_action, reject: [:invalid]
@@ -40,7 +40,7 @@ defmodule Ash.Test.Resource.ValidateAcceptTest do
   end
 
   test "Rejecting an attribute that is private raises an error" do
-    assert_raise DslError, ~r/secret is a private attribute/, fn ->
+    assert_raise DslError, ~r/\[:secret\] are private attributes/, fn ->
       defposts do
         attributes do
           attribute :secret, :string, private?: true
@@ -48,6 +48,27 @@ defmodule Ash.Test.Resource.ValidateAcceptTest do
 
         actions do
           create :example_action, reject: [:secret]
+        end
+      end
+    end
+  end
+
+  test "Accepting and rejecting attributes that does not exist raises an error" do
+    assert_raise DslError, ~r/\[:invalid, :invalid_2\] are not attributes/, fn ->
+      defposts do
+        actions do
+          create :example_action, accept: [:invalid, :invalid_2], reject: [:invalid_reject]
+        end
+      end
+    end
+  end
+
+  test "Validating all actions accept and reject attributes that does not exist raises an error" do
+    assert_raise DslError, ~r/\[:update_invalid, :update_invalid_2\] are not attributes/, fn ->
+      defposts do
+        actions do
+          create :example_action, accept: [:invalid, :invalid_2], reject: [:invalid_reject]
+          update :update_example, accept: [:update_invalid, :update_invalid_2]
         end
       end
     end


### PR DESCRIPTION
`reject` and `accept` fields should be all validated at once, and all invalid fields should be listed all at once.

This solves this issue: https://github.com/ash-project/ash/issues/398

# Contributor checklist
- [x] Features include unit/acceptance tests
- [x] Refactoring
