### PR TITLE
improvement: Set api field for ActionInput when running action

### DIFF
--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -900,6 +900,8 @@ defmodule Ash.Api do
   def run_action(api, input, opts \\ []) do
     case Spark.OptionsHelpers.validate(opts, @run_action_opts) do
       {:ok, opts} ->
+        input = %{input | api: api}
+
         Ash.Actions.Action.run(api, input, opts)
 
       {:error, error} ->


### PR DESCRIPTION
This PR adds the api used during an action run inside the ActionInput struct.

This change was discussed in this topic in Discord: https://discord.com/channels/711271361523351632/1119369920807960726
