### PR TITLE
fix(Ash.Filter): Don't overly constrain related references.

### DIFF
--- a/lib/ash/actions/read.ex
+++ b/lib/ash/actions/read.ex
@@ -3395,7 +3395,10 @@ defmodule Ash.Actions.Read do
   defp filter_with_related(relationship_filter_paths, filter_expr, data, prefix) do
     paths_to_global_filter_on =
       filter_expr
-      |> Ash.Filter.relationship_paths(true)
+      |> Ash.Filter.list_refs()
+      |> Enum.filter(& &1.input?)
+      |> Enum.map(& &1.relationship_path)
+      |> Enum.uniq()
       |> Enum.filter(&([:data, :filter, prefix ++ &1] in relationship_filter_paths))
 
     paths_to_global_filter_on

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -249,6 +249,8 @@ defmodule Ash.Query do
   See `Ash.Filter` for more.
   """
   def filter_input(query, filter) do
+    query = to_query(query)
+
     case Ash.Filter.parse_input(query.resource, filter) do
       {:ok, filter} ->
         do_filter(query, filter)

--- a/test/policy/complex_test.exs
+++ b/test/policy/complex_test.exs
@@ -86,7 +86,9 @@ defmodule Ash.Test.Policy.ComplexTest do
 
     assert [] =
              Post
-             |> Ash.Query.filter(comments.text == "comment by a friend of a friend on my post")
+             |> Ash.Query.filter_input(
+               comments: [text: "comment by a friend of a friend on my post"]
+             )
              |> Api.read!(actor: me)
   end
 


### PR DESCRIPTION
We now only apply related policies to filter statements based on references that are explicitly annotated as inputs.  This is the same logic that backs protecting access in filters for field policies.

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
