### PR TITLE
fix(Ash.Type.Binary): Base64 encode binaries when embedding.

### DIFF
--- a/lib/ash/type/binary.ex
+++ b/lib/ash/type/binary.ex
@@ -24,7 +24,13 @@ defmodule Ash.Type.Binary do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, _) do
-    Ecto.Type.load(:binary, value)
+    case Ecto.Type.load(:binary, value) do
+      {:ok, value} -> case Base.decode64(value) do
+        {:ok, value} -> {:ok, value}
+        :error -> {:ok, value}
+      end
+      :error -> :error
+    end
   end
 
   @impl true
@@ -33,4 +39,9 @@ defmodule Ash.Type.Binary do
   def dump_to_native(value, _) do
     Ecto.Type.dump(:binary, value)
   end
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(binary, _), do: {:ok, Base.encode64(binary)}
 end

--- a/test/type/binary_test.exs
+++ b/test/type/binary_test.exs
@@ -1,0 +1,78 @@
+defmodule Ash.Test.Type.Binary do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  import Ash.Changeset
+  require Ash.Query
+
+  @binary <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0, 1>>
+
+  defmodule Embedded do
+    @moduledoc false
+    use Ash.Resource, data_layer: :embedded
+
+    actions do
+      defaults [:create, :read, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :value, :binary
+    end
+  end
+
+  defmodule Normal do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      defaults [:create, :read, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :value, :binary
+      attribute :embedded, Embedded
+    end
+  end
+
+  defmodule Registry do
+    @moduledoc false
+    use Ash.Registry
+
+    entries do
+      entry Normal
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      registry Registry
+    end
+  end
+
+  test "it handles normal resources" do
+    normal =
+      Normal
+      |> new(%{value: @binary})
+      |> Api.create!()
+
+    assert normal.value == @binary
+  end
+
+  test "it handles embedded resources" do
+    embedded =
+      Normal
+      |> new(%{embedded: %{value: @binary}})
+      |> Api.create!()
+
+    assert embedded.embedded.value == @binary
+  end
+end


### PR DESCRIPTION
So when we serialise an embedded type into JSON we can't just throw a blob in, or it fails.

Example from trying to store a small PNG:

```
** (Jason.EncodeError) invalid byte 0xFF in <<255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0, 1, 2, 0, 0, 1, 0, 1, 0, 0, 255, 192, 0, 17, 8, 1, 0, 1, 0, 3, 1, 17, 0, 2, 17, 1, 3, 17, 1, 255, 219, 0, 67, 0, 8, 6, 6, 7, 6, 5, ...>>
  (jason 1.4.1) lib/jason.ex:213: Jason.encode_to_iodata!/2
```

Now, I am not sure if this is a good solution (actually I'm pretty sure it's not). It'd be cool if there was a `cast_embedded/2` callback specifically.

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
