### PR TITLE
improvement: implement atomics, expression-based changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -189,6 +189,8 @@ spark_locals_without_parens = [
   run_flow: 3,
   select: 1,
   sensitive?: 1,
+  set: 2,
+  set: 3,
   short_name: 1,
   simple_notifiers: 1,
   skip_global_validations?: 1,

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -975,7 +975,7 @@ defmodule Ash.Api do
           end
 
         with {:ok, expr} <- expr do
-          case Ash.Expr.eval(expr, record: record) do
+          case Ash.Expr.eval(expr, record: record, resource: resource) do
             {:ok, result} ->
               {:ok, result}
 

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -47,6 +47,7 @@ defmodule Ash.DataLayer do
   @type feature() ::
           :transact
           | :multitenancy
+          | {:atomic, :update}
           | {:lateral_join, list(Ash.Resource.t())}
           | {:join, Ash.Resource.t()}
           | {:aggregate, Ash.Query.Aggregate.kind()}

--- a/lib/ash/error/changes/stale_record.ex
+++ b/lib/ash/error/changes/stale_record.ex
@@ -15,7 +15,7 @@ defmodule Ash.Error.Changes.StaleRecord do
           "#{key}: #{inspect(value)}"
         end)
 
-      "record of #{inspect(error.resource)} with filter `#{filter}`"
+      "Attempted to update stale record of #{inspect(error.resource)} with filter `#{filter}`"
     end
   end
 end

--- a/lib/ash/error/invalid/atomics_not_supported.ex
+++ b/lib/ash/error/invalid/atomics_not_supported.ex
@@ -1,0 +1,16 @@
+defmodule Ash.Error.Invalid.AtomicsNotSupported do
+  @moduledoc "Used when atomics for the given action type are not not supported by the data layer, but one is used."
+  use Ash.Error.Exception
+
+  def_ash_error([:resource, :action_type], class: :invalid)
+
+  defimpl Ash.ErrorKind do
+    def id(_), do: Ash.UUID.generate()
+
+    def code(_), do: "atomics_not_supported"
+
+    def message(%{resource: resource, action_type: action_type}) do
+      "The data layer for #{inspect(resource)} does not support atomics on #{action_type} actions"
+    end
+  end
+end

--- a/lib/ash/filter/runtime.ex
+++ b/lib/ash/filter/runtime.ex
@@ -687,15 +687,19 @@ defmodule Ash.Filter.Runtime do
       # once per expanded result. I'm not sure what that will
       # look like though.
 
-      case module.calculate([record], opts, context) do
-        [result] ->
-          {:ok, result}
+      if record do
+        case module.calculate([record], opts, context) do
+          [result] ->
+            {:ok, result}
 
-        {:ok, [result]} ->
-          {:ok, result}
+          {:ok, [result]} ->
+            {:ok, result}
 
-        _ ->
-          {:ok, nil}
+          _ ->
+            {:ok, nil}
+        end
+      else
+        :unknown
       end
     end
   end

--- a/lib/ash/resource/actions/update.ex
+++ b/lib/ash/resource/actions/update.ex
@@ -9,6 +9,7 @@ defmodule Ash.Resource.Actions.Update do
     accept: nil,
     manual: nil,
     manual?: false,
+    atomics: [],
     require_attributes: [],
     delay_global_validations?: false,
     skip_global_validations?: false,

--- a/lib/ash/resource/change/atomic.ex
+++ b/lib/ash/resource/change/atomic.ex
@@ -1,0 +1,8 @@
+defmodule Ash.Resource.Change.Atomic do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  def change(changeset, opts, _) do
+    Ash.Changeset.atomic(changeset, opts[:attribute], opts[:expr])
+  end
+end

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -399,6 +399,37 @@ defmodule Ash.Resource.Dsl do
     args: [:change]
   }
 
+  defmodule Set do
+    @moduledoc false
+    defstruct [:description, :where, :attribute, :expr]
+
+    def transform(set) do
+      {:ok,
+       %Ash.Resource.Change{
+         change: {Ash.Resource.Change.Atomic, attribute: set.attribute, expr: set.expr}
+       }
+       |> Map.merge(Map.take(set, [:description, :where]))}
+    end
+  end
+
+  @set %Spark.Dsl.Entity{
+    name: :set,
+    describe: """
+    Set an attribute to the result of an expression.
+
+    This as a thin wrapper over create an `Ash.Resource.Change` that defines
+    `atomic/2`.
+    """,
+    examples: [
+      "set :score, expr(score + 1)",
+      "set :title, expr(some_calc(some_arg: :foo))"
+    ],
+    target: Set,
+    schema: Ash.Resource.Change.atomic_schema(),
+    transform: {Set, :transform, []},
+    args: [:attribute, :expr]
+  }
+
   @validate %Spark.Dsl.Entity{
     name: :validate,
     describe: """
@@ -583,7 +614,8 @@ defmodule Ash.Resource.Dsl do
     entities: [
       changes: [
         @action_change,
-        @action_validate
+        @action_validate,
+        @set
       ],
       metadata: [
         @metadata
@@ -626,7 +658,8 @@ defmodule Ash.Resource.Dsl do
     entities: [
       changes: [
         @action_change,
-        @action_validate
+        @action_validate,
+        @set
       ],
       metadata: [
         @metadata

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -43,6 +43,7 @@ defmodule Ash.Resource.Validation do
   @callback init(Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
   @callback validate(Ash.Changeset.t(), Keyword.t()) :: :ok | {:error, term}
   @callback describe(Keyword.t()) :: [message: String.t(), vars: Keyword.t()]
+  @callback atomic?(Keyword.t()) :: boolean
 
   @optional_callbacks describe: 1
 
@@ -103,8 +104,7 @@ defmodule Ash.Resource.Validation do
       @behaviour Ash.Resource.Validation
 
       def init(opts), do: {:ok, opts}
-
-      defoverridable init: 1
+      def atomic?(_), do: false
 
       defp with_description(keyword, opts) do
         if Kernel.function_exported?(__MODULE__, :describe, 1) do
@@ -113,6 +113,8 @@ defmodule Ash.Resource.Validation do
           keyword
         end
       end
+
+      defoverridable init: 1, atomic?: 1
     end
   end
 

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -728,19 +728,23 @@ defmodule Ash.Type do
     if is_atom(type) && :erlang.function_exported(type, :dump_to_native_array, 2) do
       type.dump_to_native_array(term, constraints)
     else
-      single_constraints = constraints[:items] || []
+      if is_nil(term) do
+        {:ok, nil}
+      else
+        single_constraints = constraints[:items] || []
 
-      term
-      |> Enum.reverse()
-      |> Enum.reduce_while({:ok, []}, fn item, {:ok, dumped} ->
-        case dump_to_native(type, item, single_constraints) do
-          :error ->
-            {:halt, :error}
+        term
+        |> Enum.reverse()
+        |> Enum.reduce_while({:ok, []}, fn item, {:ok, dumped} ->
+          case dump_to_native(type, item, single_constraints) do
+            :error ->
+              {:halt, :error}
 
-          {:ok, value} ->
-            {:cont, {:ok, [value | dumped]}}
-        end
-      end)
+            {:ok, value} ->
+              {:cont, {:ok, [value | dumped]}}
+          end
+        end)
+      end
     end
   end
 

--- a/test/actions/update_test.exs
+++ b/test/actions/update_test.exs
@@ -5,6 +5,7 @@ defmodule Ash.Test.Actions.UpdateTest do
   import Ash.Changeset
   import Ash.Test
   require Ash.Query
+  require Ash.Expr
 
   defmodule Authorized do
     @moduledoc false
@@ -346,6 +347,23 @@ defmodule Ash.Test.Actions.UpdateTest do
         |> new(%{bio: "bio"})
         |> Api.update!(action: :only_allow_name)
       end
+    end
+  end
+
+  describe "atomics" do
+    test "atomics can be added to a changeset" do
+      author =
+        Author
+        |> new(%{name: "fred"})
+        |> Api.create!()
+
+      author =
+        author
+        |> Ash.Changeset.for_update(:only_allow_name)
+        |> Ash.Changeset.atomic(:name, Ash.Expr.expr(name <> " weasley"))
+        |> Api.update!()
+
+      assert author.name == "fred weasley"
     end
   end
 


### PR DESCRIPTION
there is still a lot of potential work that needs to be on this front.
1. allowing changes to have an atomic and a non-atomic implementation
2. supporting atomics on create actions.
3. supporting atomics in upserts (this one may actually be much easier than the first one, for postgres specifically, due to ecto implementation details)
4. discovering places atomics can be more nicely integrated into existing changes, validations, policies
