### PR TITLE
improvement: Allow resources to opt out of the primary key requirement.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -180,6 +180,7 @@ spark_locals_without_parens = [
   relationship_context: 1,
   require_actor?: 1,
   require_attributes: 1,
+  require_primary_key?: 1,
   required?: 1,
   resource: 1,
   resource: 2,

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -210,10 +210,16 @@ defmodule Ash.DataLayer.Ets do
   def can?(_, {:aggregate, :min}), do: true
   def can?(_, {:aggregate, :avg}), do: true
   def can?(_, {:aggregate, :exists}), do: true
+
   def can?(_, :create), do: true
   def can?(_, :read), do: true
-  def can?(_, :update), do: true
-  def can?(_, :destroy), do: true
+
+  def can?(resource, action_type) when action_type in ~w[update destroy]a do
+    resource
+    |> Ash.Resource.Info.primary_key()
+    |> Enum.any?()
+  end
+
   def can?(_, :sort), do: true
   def can?(_, :filter), do: true
   def can?(_, :limit), do: true

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -811,6 +811,22 @@ defmodule Ash.Resource.Dsl do
         type: {:list, :module},
         doc:
           "A list of notifiers that require no DSL. Can be used to avoid compile time dependencies on notifiers"
+      ],
+      require_primary_key?: [
+        type: :boolean,
+        required: false,
+        default: true,
+        doc: """
+        Allow the resource to be used without any primary key fields.
+
+        ### Warning
+
+        Lots of Ash and Ash extensions assume that every resource has a primary key and this is likely to break a lot of features.
+
+        If you run into a breakage please [open an issue](https://github.com/ash-project/ash/issues/new) and we'll take a look at it.
+
+        Disable at your peril.
+        """
       ]
     ]
   }

--- a/lib/ash/resource/transformers/cache_primary_key.ex
+++ b/lib/ash/resource/transformers/cache_primary_key.ex
@@ -6,46 +6,71 @@ defmodule Ash.Resource.Transformers.CachePrimaryKey do
   alias Spark.Error.DslError
 
   def transform(dsl_state) do
-    primary_key_attribute =
+    attributes =
       dsl_state
       |> Transformer.get_entities([:attributes])
       |> Enum.filter(& &1.primary_key?)
 
-    pk_allows_nil? = Enum.any?(primary_key_attribute, & &1.allow_nil?)
-    simple_equality? = Enum.all?(primary_key_attribute, &Ash.Type.simple_equality?(&1.type))
+    with :ok <- validate_attributes_not_nil(attributes, dsl_state),
+         :ok <- maybe_validate_pk_present(attributes, dsl_state) do
+      dsl_state =
+        dsl_state
+        |> Transformer.persist(:primary_key, Enum.map(attributes, & &1.name))
+        |> Transformer.persist(
+          :primary_key_simple_equality?,
+          Enum.all?(attributes, &Ash.Type.simple_equality?(&1.type))
+        )
 
-    primary_key =
-      if pk_allows_nil? == false do
-        Enum.map(primary_key_attribute, & &1.name)
-      else
-        :error_pk_allows_nil
-      end
-
-    case primary_key do
-      :error_pk_allows_nil ->
-        {:error, DslError.exception(message: "Primary keys must not be allowed to be nil")}
-
-      [] ->
-        {:error,
-         DslError.exception(message: "Resources without a primary key are not yet supported")}
-
-      [field] ->
-        dsl_state =
-          dsl_state
-          |> Transformer.persist(:primary_key, [field])
-          |> Transformer.persist(:primary_key_simple_equality?, simple_equality?)
-
-        {:ok, dsl_state}
-
-      fields ->
-        dsl_state =
-          dsl_state
-          |> Transformer.persist(:primary_key, fields)
-          |> Transformer.persist(:primary_key_simple_equality?, simple_equality?)
-
-        {:ok, dsl_state}
+      {:ok, dsl_state}
     end
   end
+
+  defp validate_attributes_not_nil(attributes, dsl_state) do
+    Enum.reduce_while(attributes, :ok, fn attribute, :ok ->
+      case validate_attribute_not_nil(attribute, dsl_state) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp validate_attribute_not_nil(attribute, dsl_state) when attribute.allow_nil? do
+    message = """
+    Primary keys must not be allowed to be nil.
+
+    The attribute `#{attribute.name}` is set as a primary key and allows nil values.
+    """
+
+    {:error,
+     DslError.exception(
+       module: Transformer.get_persisted(dsl_state, :module),
+       path: [:attributes],
+       message: message
+     )}
+  end
+
+  defp validate_attribute_not_nil(_, _), do: :ok
+
+  defp maybe_validate_pk_present([], dsl_state) do
+    if Transformer.get_option(dsl_state, [:resource], :require_primary_key?, true) do
+      message = """
+      By default, resources must have a primary key.
+
+      See `d:Ash.Resource.Dsl.resource.require_primary_key?` for more information.
+      """
+
+      {:error,
+       DslError.exception(
+         module: Transformer.get_persisted(dsl_state, :module),
+         path: [:attributes],
+         message: message
+       )}
+    else
+      :ok
+    end
+  end
+
+  defp maybe_validate_pk_present(_, _), do: :ok
 
   def after?(Ash.Resource.Transformers.BelongsToAttribute), do: true
   def after?(Ash.Resource.Transformers.DefaultPrimaryKey), do: true

--- a/lib/ash/resource/transformers/validate_action_types_supported.ex
+++ b/lib/ash/resource/transformers/validate_action_types_supported.ex
@@ -18,10 +18,15 @@ defmodule Ash.Resource.Transformers.ValidateActionTypesSupported do
       resource = Transformer.get_persisted(dsl_state, :module)
 
       unless data_layer && data_layer.can?(resource, action.type) do
+        message = """
+        `#{inspect(data_layer)}` does not support `#{action.type}` actions on this resource.
+
+        This is either because of a limitation in the data layer, or specific configuration of the resource.
+        """
+
         raise DslError,
           module: resource,
-          message:
-            "Data layer #{Ash.DataLayer.data_layer(resource)} for #{inspect(resource)} does not support #{action.type} actions",
+          message: message,
           path: [:actions, action.type, action.name]
       end
     end)

--- a/test/resource/no_pk_test.exs
+++ b/test/resource/no_pk_test.exs
@@ -1,0 +1,94 @@
+defmodule Ash.Test.Resource.NoPkTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Ash.Changeset
+
+  defmodule Temperature do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    resource do
+      require_primary_key? false
+    end
+
+    ets do
+      private? true
+    end
+
+    actions do
+      defaults [:create, :read]
+    end
+
+    attributes do
+      attribute :time, :utc_datetime_usec
+      attribute :temperature, :float
+    end
+
+    relationships do
+      belongs_to :location, Location do
+        attribute_writable? true
+      end
+    end
+  end
+
+  defmodule Location do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      defaults [:create, :read, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :location, :string
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      resource Temperature
+      resource Location
+    end
+  end
+
+  test "records can be written and read" do
+    assert {:ok, expected} =
+             Temperature
+             |> Changeset.for_action(:create, %{
+               temperature: :rand.uniform()
+             })
+             |> Api.create()
+
+    assert {:ok, [actual]} = Api.read(Temperature)
+    assert expected.time == actual.time
+    assert expected.temperature == actual.temperature
+  end
+
+  test "records can belong to other resources" do
+    assert {:ok, location} =
+             Location
+             |> Changeset.for_action(:create, %{
+               location:
+                 "Taumata­whakatangihanga­koauau­o­tamatea­turi­pukaka­piki­maunga­horo­nuku­pokai­whenua­ki­tana­tahu"
+             })
+             |> Api.create()
+
+    assert {:ok, actual} =
+             Temperature
+             |> Changeset.for_action(:create, %{
+               temperature: :rand.uniform(),
+               location_id: location.id
+             })
+             |> Api.create()
+
+    assert actual.location_id == location.id
+  end
+end


### PR DESCRIPTION
This is experimental and will likely cause breakages. It's to support time series tables.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
