### PR TITLE
improvement(code interface): warn when `define_for` is missing

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -186,40 +186,36 @@ defmodule Ash.CodeInterface do
   @doc """
   Defines the code interface for a given resource + api combination in the current module. For example:
 
-  ```elixir
-  defmodule MyApp.Accounting do
-    require Ash.CodeInterface
+      defmodule MyApp.Accounting do
+        require Ash.CodeInterface
 
-    Ash.CodeInterface.define_interface(MyApp.Accounting, MyApp.Accounting.Transaction)
-    Ash.CodeInterface.define_interface(MyApp.Accounting, MyApp.Accounting.Account)
-    Ash.CodeInterface.define_interface(MyApp.Accounting, MyApp.Accounting.Invoice)
-  end
-  ```
+        Ash.CodeInterface.define_interface(MyApp.Accounting, MyApp.Accounting.Transaction)
+        Ash.CodeInterface.define_interface(MyApp.Accounting, MyApp.Accounting.Account)
+        Ash.CodeInterface.define_interface(MyApp.Accounting, MyApp.Accounting.Invoice)
+      end
 
   Keep in mind that you can have this "automatically" defined in your resources by using the `define_for`
   flag in a resource.
 
   For example:
 
-  ```elixir
-  defmodule MyApp.Accounting.Transaction do
-    use Ash.Resource
+      defmodule MyApp.Accounting.Transaction do
+        use Ash.Resource
 
-    ...
+        ...
 
-    code_interface do
-      define_for MyApp.Accounting
+        code_interface do
+          define_for MyApp.Accounting
 
-      define :start do
-        args [:invoice_id]
+          define :start do
+            args [:invoice_id]
+          end
+        end
       end
-    end
-  end
 
-  # Which can now be used like so:
+  Which can now be used like so:
 
-  MyApp.Accounting.Transaction.start!(invoice.id)
-  ```
+      MyApp.Accounting.Transaction.start!(invoice.id)
   """
   defmacro define_interface(api, resource) do
     quote bind_quoted: [api: api, resource: resource], generated: true, location: :keep do

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -863,6 +863,8 @@ defmodule Ash.Resource.Dsl do
     describe: """
     Functions that will be defined on the Api module to interact with this resource.
 
+    *Warning*: The Api module must be specified using `define_for` or no functions will be generated.
+
     See the [code interface guide](/documentation/topics/code-interface.md) for more.
     """,
     examples: [


### PR DESCRIPTION
When `define_for` is missing no `code_interface` functions are generated and no explanation is provided why.

# Contributor checklist

- [x] Documentation changes
- [x] Features include unit/acceptance tests