### PR TITLE
Improve example update_timestamp docu

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Resource.cheatmd
@@ -185,7 +185,7 @@ allow_nil? false
 
 ### Examples
 ```
-update_timestamp :inserted_at
+update_timestamp :updated_at
 ```
 
 
@@ -2795,9 +2795,3 @@ end
 | `attribute` | `atom` |  | If using the `attribute` strategy, the attribute to use, e.g `org_id` |
 | `global?` | `boolean` | false | Whether or not the data also exists outside of each tenant. |
 | `parse_attribute` | `mfa` | {Ash.Resource.Dsl, :identity, []} | An mfa ({module, function, args}) pointing to a function that takes a tenant and returns the attribute value |
-
-
-
-
-
-

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -59,7 +59,7 @@ defmodule Ash.Resource.Dsl do
         allow_nil? false
     """,
     examples: [
-      "update_timestamp :inserted_at"
+      "update_timestamp :updated_at"
     ],
     target: Ash.Resource.Attribute,
     schema: Ash.Resource.Attribute.update_timestamp_schema(),


### PR DESCRIPTION
Changes the example for `update_timestamp` to 

`update_timestamp :updated_at`

Before screenshot of the documentation:

<img width="677" alt="Bildschirmfoto 2023-09-16 um 12 39 02" src="https://github.com/ash-project/ash/assets/69770/a45ae2c5-ebd9-40ed-b5f1-0a9264acd742">
