### PR TITLE
fix: use `:wrap_list` type where appropriate

### DIFF
--- a/documentation/dsls/DSL:-Ash.Flow.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Flow.cheatmd
@@ -255,7 +255,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The name of the step. Will be used when expressing dependencies, and step inputs. |
-| `resource` | `module \| list(module)` |  | The Ash resource to use for the transaction. |
+| `resource` | `list(module) \| module` |  | The Ash resource to use for the transaction. |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
@@ -496,7 +496,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `record` | ``any`` |  | The record to be created/updated/destroyed. If the value is `nil` and would be required by the action type, the step is skipped and `nil` is the result of the step. |
-| `only_keys` | `list(atom \| list(atom))` |  | A list of keys or paths to keys that should be validated. Others will be ignored, and errors generated for other fields will be ignored. |
+| `only_keys` | `list(list(atom) \| atom)` |  | A list of keys or paths to keys that should be validated. Others will be ignored, and errors generated for other fields will be ignored. |
 | `short_name` | `String.t` |  | Set a short name for the step. Will be used when building things like mermaid charts. |
 | `wait_for` | ``any`` |  | Ensures that the step happens after the configured step or steps. This is a template who's results are not used, only awaited. |
 | `touches_resources` | `list(atom)` |  | A list of resources touched by any custom logic in this step. This is used in the case that this step is run in a transaction. This is primarily only needed for `custom` steps. |

--- a/documentation/dsls/DSL:-Ash.Resource.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Resource.cheatmd
@@ -950,7 +950,7 @@ validate changing(:email)
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
-| `where` | `(any -> any) \| module \| list((any -> any) \| module)` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
+| `where` | `list((any -> any) \| module) \| (any -> any) \| module` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
 | `only_when_valid?` | `boolean` | false | If the validation should only run on valid changes. Useful for expensive validations or validations that depend on valid data. |
 | `message` | `String.t` |  | If provided, overrides any message set by the validation error |
 | `description` | `String.t` |  | An optional description for the validation |
@@ -1372,7 +1372,7 @@ validate changing(:email)
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
-| `where` | `(any -> any) \| module \| list((any -> any) \| module)` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
+| `where` | `list((any -> any) \| module) \| (any -> any) \| module` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
 | `only_when_valid?` | `boolean` | false | If the validation should only run on valid changes. Useful for expensive validations or validations that depend on valid data. |
 | `message` | `String.t` |  | If provided, overrides any message set by the validation error |
 | `description` | `String.t` |  | An optional description for the validation |
@@ -1598,7 +1598,7 @@ validate changing(:email)
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
-| `where` | `(any -> any) \| module \| list((any -> any) \| module)` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
+| `where` | `list((any -> any) \| module) \| (any -> any) \| module` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
 | `only_when_valid?` | `boolean` | false | If the validation should only run on valid changes. Useful for expensive validations or validations that depend on valid data. |
 | `message` | `String.t` |  | If provided, overrides any message set by the validation error |
 | `description` | `String.t` |  | An optional description for the validation |
@@ -2100,7 +2100,7 @@ validate at_least_one_of_present([:first_name, :last_name])
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
-| `where` | `(any -> any) \| module \| list((any -> any) \| module)` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
+| `where` | `list((any -> any) \| module) \| (any -> any) \| module` | [] | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
 | `on` | ``any`` | [:create, :update] | The action types the validation should run on. Many validations don't make sense in the context of deletion, so by default it is not included. |
 | `only_when_valid?` | `boolean` | false | If the validation should only run on valid changes. Useful for expensive validations or validations that depend on valid data. |
 | `message` | `String.t` |  | If provided, overrides any message set by the validation error |

--- a/lib/ash/flow/step/transaction.ex
+++ b/lib/ash/flow/step/transaction.ex
@@ -16,8 +16,7 @@ defmodule Ash.Flow.Step.Transaction do
           doc: "A timeout to apply to the transaction."
         ],
         resource: [
-          type:
-            {:or, [Ash.OptionsHelpers.ash_resource(), {:list, Ash.OptionsHelpers.ash_resource()}]},
+          type: {:wrap_list, Ash.OptionsHelpers.ash_resource()},
           doc: """
           The Ash resource to use for the transaction.
           """

--- a/lib/ash/flow/step/validate.ex
+++ b/lib/ash/flow/step/validate.ex
@@ -14,7 +14,7 @@ defmodule Ash.Flow.Step.Validate do
           """
         ],
         only_keys: [
-          type: {:list, {:or, [:atom, {:list, :atom}]}},
+          type: {:list, {:wrap_list, :atom}},
           doc: """
           A list of keys or paths to keys that should be validated. Others will be ignored, and errors generated for other fields will be ignored.
           """

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -58,7 +58,7 @@ defmodule Ash.Resource.Validation do
         "The module (or module and opts) that implements the `Ash.Resource.Validation` behaviour. Also accepts a one argument function that takes the changeset."
     ],
     where: [
-      type: {:or, [@validation_type, {:list, @validation_type}]},
+      type: {:wrap_list, @validation_type},
       required: false,
       default: [],
       doc: """


### PR DESCRIPTION
Saw three places where `:wrap_list` can be used. 

So instead of:
```elixir
{:or, [Ash.OptionsHelpers.ash_resource(), {:list, Ash.OptionsHelpers.ash_resource()}]}
{:or, [@validation_type, {:list, @validation_type}]}
{:list, {:or, [:atom, {:list, :atom}]}}
```
It will be:
```elixir
{:wrap_list, Ash.OptionsHelpers.ash_resource()}
{:wrap_list, @validation_type}
{:list, {:wrap_list, :atom}}
```
