### PR TITLE
fix: add missing usage of `:default_belongs_to_type`

### DIFF
--- a/lib/ash/resource/transformers/belongs_to_attribute.ex
+++ b/lib/ash/resource/transformers/belongs_to_attribute.ex
@@ -8,6 +8,7 @@ defmodule Ash.Resource.Transformers.BelongsToAttribute do
   alias Spark.Error.DslError
 
   @extension Ash.Resource.Dsl
+  @default_belongs_to_type Application.compile_env(:ash, :default_belongs_to_type, :uuid)
 
   def transform(dsl_state) do
     dsl_state
@@ -22,7 +23,7 @@ defmodule Ash.Resource.Transformers.BelongsToAttribute do
       entity =
         Transformer.build_entity(@extension, [:attributes], :attribute,
           name: relationship.source_attribute,
-          type: relationship.attribute_type || :uuid,
+          type: relationship.attribute_type || @default_belongs_to_type,
           allow_nil?:
             if relationship.primary_key? do
               false


### PR DESCRIPTION
In dsl default value for belongs to `attribute_type` was changed from `:uuid` to [`Application.compile_env(:ash, :default_belongs_to_type, :uuid)`](https://github.com/ash-project/ash/blob/05b9ac1f866d2470efacdc41fd957a3e7278ccd2/lib/ash/resource/relationships/belongs_to.ex#L91). But in `Ash.Resource.Transformers.BelongsToAttribute` it is still `relationship.attribute_type || :uuid`. Replaced `|| :uuid` with `:default_belongs_to_type` env fallback.