### PR TITLE
fix: more usages of `:wrap_list` type

### DIFF
--- a/documentation/dsls/DSL:-Ash.Notifier.PubSub.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Notifier.PubSub.cheatmd
@@ -70,7 +70,7 @@ publish :assign, "assigned"
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `action`* | `atom` |  | The name of the action that should be published |
-| `topic`* | ``any`` |  | The topic to publish |
+| `topic`* | `list(String.t \| atom) \| String.t \| atom` |  | The topic to publish |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
@@ -110,7 +110,7 @@ publish_all :create, "created"
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `type` | `:create \| :update \| :destroy` |  | Publish on all actions of a given type |
-| `topic`* | ``any`` |  | The topic to publish |
+| `topic`* | `list(String.t \| atom) \| String.t \| atom` |  | The topic to publish |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |

--- a/documentation/dsls/DSL:-Ash.Resource.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Resource.cheatmd
@@ -1904,7 +1904,7 @@ identity :full_name, [:first_name, :last_name]
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The name of the identity. |
-| `keys`* | ``any`` |  | The names of the attributes that uniquely identify this resource. |
+| `keys`* | `list(atom) \| atom` |  | The names of the attributes that uniquely identify this resource. |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
@@ -1977,7 +1977,7 @@ change {MyCustomChange, :foo}
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
-| `on` | ``any`` | `[:create, :update]` | The action types the validation should run on. Destroy actions are omitted by default as most changes don't make sense for a destroy. |
+| `on` | `list(:create \| :update \| :destroy) \| :create \| :update \| :destroy` | `[:create, :update]` | The action types the validation should run on. Destroy actions are omitted by default as most changes don't make sense for a destroy. |
 | `only_when_valid?` | `boolean` | `false` | If the change should only be run on valid changes. By default, all changes are run unless stated otherwise here. |
 | `description` | `String.t` |  | An optional description for the change |
 | `where` | `list((any -> any) \| module)` | `[]` | Validations that should pass in order for this validation to apply. These validations failing will result in this validation being ignored. |
@@ -2101,7 +2101,7 @@ validate at_least_one_of_present([:first_name, :last_name])
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `where` | `list((any -> any) \| module) \| (any -> any) \| module` | `[]` | Validations that should pass in order for this validation to apply. Any of these validations failing will result in this validation being ignored. |
-| `on` | ``any`` | `[:create, :update]` | The action types the validation should run on. Many validations don't make sense in the context of deletion, so by default it is not included. |
+| `on` | `list(:create \| :update \| :destroy) \| :create \| :update \| :destroy` | `[:create, :update]` | The action types the validation should run on. Many validations don't make sense in the context of deletion, so by default it is not included. |
 | `only_when_valid?` | `boolean` | `false` | If the validation should only run on valid changes. Useful for expensive validations or validations that depend on valid data. |
 | `message` | `String.t` |  | If provided, overrides any message set by the validation error |
 | `description` | `String.t` |  | An optional description for the validation |
@@ -2181,7 +2181,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
@@ -2231,7 +2231,7 @@ exists :has_ticket, :assigned_tickets
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
@@ -2283,7 +2283,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `field` | `atom` |  | The field to aggregate. Defaults to the first field in the primary key of the resource |
 ### Options
 | Name | Type | Default | Docs |
@@ -2335,7 +2335,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `field` | `atom` |  | The field to aggregate. Defaults to the first field in the primary key of the resource |
 ### Options
 | Name | Type | Default | Docs |
@@ -2387,7 +2387,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `field` | `atom` |  | The field to aggregate. Defaults to the first field in the primary key of the resource |
 ### Options
 | Name | Type | Default | Docs |
@@ -2440,7 +2440,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `field` | `atom` |  | The field to aggregate. Defaults to the first field in the primary key of the resource |
 ### Options
 | Name | Type | Default | Docs |
@@ -2491,7 +2491,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `field` | `atom` |  | The field to aggregate. Defaults to the first field in the primary key of the resource |
 ### Options
 | Name | Type | Default | Docs |
@@ -2542,7 +2542,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `field` | `atom` |  | The field to aggregate. Defaults to the first field in the primary key of the resource |
 ### Options
 | Name | Type | Default | Docs |
@@ -2595,7 +2595,7 @@ end
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The field to place the aggregate in |
-| `relationship_path`* | ``any`` |  | The relationship or relationship path to use for the aggregate |
+| `relationship_path`* | `list(atom) \| atom` |  | The relationship or relationship path to use for the aggregate |
 | `type`* | `module` |  | The type of the value returned by the aggregate |
 ### Options
 | Name | Type | Default | Docs |

--- a/lib/ash/notifier/pub_sub/publication.ex
+++ b/lib/ash/notifier/pub_sub/publication.ex
@@ -16,7 +16,7 @@ defmodule Ash.Notifier.PubSub.Publication do
       required: true
     ],
     topic: [
-      type: {:custom, __MODULE__, :topic, []},
+      type: {:wrap_list, {:or, [:string, :atom]}},
       doc: "The topic to publish",
       required: true
     ],
@@ -40,35 +40,4 @@ defmodule Ash.Notifier.PubSub.Publication do
 
   def schema, do: @schema
   def publish_all_schema, do: @publish_all_schema
-
-  @doc false
-  def topic(topic) when is_binary(topic) do
-    {:ok, [topic]}
-  end
-
-  def topic(topic) when is_list(topic) do
-    if nested_list_of_binaries_or_atoms?(topic) do
-      {:ok, topic}
-    else
-      {:error,
-       "Expected topic to be a string or a list of strings or attribute names (as atoms), got: #{inspect(topic)}"}
-    end
-  end
-
-  def topic(other) do
-    {:error,
-     "Expected topic to be a string or a list of strings or attribute names (as atoms), got: #{inspect(other)}"}
-  end
-
-  defp nested_list_of_binaries_or_atoms?(list) when is_list(list) do
-    Enum.all?(list, &nested_list_of_binaries_or_atoms?/1)
-  end
-
-  defp nested_list_of_binaries_or_atoms?(value) when is_binary(value) or is_atom(value) do
-    true
-  end
-
-  defp nested_list_of_binaries_or_atoms?(_) do
-    false
-  end
 end

--- a/lib/ash/resource/aggregate/aggregate.ex
+++ b/lib/ash/resource/aggregate/aggregate.ex
@@ -32,7 +32,7 @@ defmodule Ash.Resource.Aggregate do
       """
     ],
     relationship_path: [
-      type: {:custom, __MODULE__, :relationship_path, []},
+      type: {:wrap_list, :atom},
       doc: "The relationship or relationship path to use for the aggregate",
       required: true
     ],
@@ -104,14 +104,4 @@ defmodule Ash.Resource.Aggregate do
 
   @doc false
   def schema, do: @schema
-
-  def relationship_path(value) do
-    value = List.wrap(value)
-
-    if Enum.all?(value, &is_atom/1) do
-      {:ok, value}
-    else
-      {:error, "relationship path must be atoms"}
-    end
-  end
 end

--- a/lib/ash/resource/change/change.ex
+++ b/lib/ash/resource/change/change.ex
@@ -18,7 +18,7 @@ defmodule Ash.Resource.Change do
   def schema do
     [
       on: [
-        type: {:custom, __MODULE__, :on, []},
+        type: {:wrap_list, {:in, [:create, :update, :destroy]}},
         default: [:create, :update],
         doc: """
         The action types the validation should run on. Destroy actions are omitted by default as most changes don't make sense for a destroy.
@@ -89,20 +89,6 @@ defmodule Ash.Resource.Change do
 
   def change(other) do
     {:error, "Expected a module and opts, got: #{inspect(other)}"}
-  end
-
-  @doc false
-  def on(list) do
-    list
-    |> List.wrap()
-    |> Enum.all?(&(&1 in [:create, :update, :destroy]))
-    |> case do
-      true ->
-        {:ok, List.wrap(list)}
-
-      false ->
-        {:error, "Expected items of [:create, :update, :destroy], got: #{inspect(list)}"}
-    end
   end
 
   @type context :: %{

--- a/lib/ash/resource/identity.ex
+++ b/lib/ash/resource/identity.ex
@@ -18,7 +18,7 @@ defmodule Ash.Resource.Identity do
       doc: "The name of the identity."
     ],
     keys: [
-      type: {:custom, __MODULE__, :keys, []},
+      type: {:wrap_list, :atom},
       required: true,
       doc: "The names of the attributes that uniquely identify this resource."
     ],
@@ -51,14 +51,4 @@ defmodule Ash.Resource.Identity do
           keys: list(atom()),
           description: String.t() | nil
         }
-
-  def keys(keys) do
-    keys = List.wrap(keys)
-
-    if Enum.all?(keys, &is_atom/1) do
-      {:ok, keys}
-    else
-      {:error, "Expected a list of atoms for the identity keys"}
-    end
-  end
 end

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -66,7 +66,7 @@ defmodule Ash.Resource.Validation do
       """
     ],
     on: [
-      type: {:custom, __MODULE__, :on, []},
+      type: {:wrap_list, {:in, [:create, :update, :destroy]}},
       default: [:create, :update],
       doc: """
       The action types the validation should run on. Many validations don't make sense in the context of deletion, so by default it is not included.
@@ -128,19 +128,5 @@ defmodule Ash.Resource.Validation do
 
   def opt_schema, do: @schema
   def action_schema, do: @action_schema
-
-  def on(list) do
-    list
-    |> List.wrap()
-    |> Enum.all?(&(&1 in [:create, :update, :destroy]))
-    |> case do
-      true ->
-        {:ok, List.wrap(list)}
-
-      false ->
-        {:error, "Expected items of [:create, :update, :destroy], got: #{inspect(list)}"}
-    end
-  end
-
   def validation_type, do: @validation_type
 end

--- a/lib/ash/resource/validation/present.ex
+++ b/lib/ash/resource/validation/present.ex
@@ -9,7 +9,7 @@ defmodule Ash.Resource.Validation.Present do
     case Spark.OptionsHelpers.validate(
            opts,
            Keyword.put(Ash.Resource.Validation.Builtins.present_opts(), :attributes,
-             type: {:custom, __MODULE__, :attributes, []},
+             type: {:wrap_list, :atom},
              required: true
            )
          ) do
@@ -107,16 +107,5 @@ defmodule Ash.Resource.Validation.Present do
        |> with_description(opts)
        |> InvalidAttribute.exception()
      end)}
-  end
-
-  @doc false
-  def attributes(attributes) do
-    attributes = List.wrap(attributes)
-
-    if Enum.all?(attributes, &is_atom/1) do
-      {:ok, attributes}
-    else
-      {:error, "Expected all attributes provided to be atoms."}
-    end
   end
 end


### PR DESCRIPTION
Saw that type for `keys` in `identity` was document as `any`. Thought why wouldn't it show `atom | list(atom)`? Found out that there are custom type validations that just do what `:wrap_list` handles. Replaced them.

In one case of `Ash.Notifier.PubSub.Publication.topic` there was even a small bug - it would allow a single string or a list of string/atoms, but not a single atom.

Note: `{:wrap_list, x}` produces type documentation `list(x) | x`. Personally I would find it more conventional for it to be `x | list(x)` instead - from simpler to more complex.