### PR TITLE
fix: revert `:wrap_list` usage for `topic` in PubSub, needs recursion

### DIFF
--- a/documentation/dsls/DSL:-Ash.Notifier.PubSub.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Notifier.PubSub.cheatmd
@@ -70,7 +70,7 @@ publish :assign, "assigned"
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `action`* | `atom` |  | The name of the action that should be published |
-| `topic`* | `list(String.t \| atom) \| String.t \| atom` |  | The topic to publish |
+| `topic`* | ``any`` |  | The topic to publish |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
@@ -110,7 +110,7 @@ publish_all :create, "created"
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `type` | `:create \| :update \| :destroy` |  | Publish on all actions of a given type |
-| `topic`* | `list(String.t \| atom) \| String.t \| atom` |  | The topic to publish |
+| `topic`* | ``any`` |  | The topic to publish |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |

--- a/lib/ash/notifier/pub_sub/publication.ex
+++ b/lib/ash/notifier/pub_sub/publication.ex
@@ -16,7 +16,7 @@ defmodule Ash.Notifier.PubSub.Publication do
       required: true
     ],
     topic: [
-      type: {:wrap_list, {:or, [:string, :atom]}},
+      type: {:custom, __MODULE__, :topic, []},
       doc: "The topic to publish",
       required: true
     ],
@@ -40,4 +40,35 @@ defmodule Ash.Notifier.PubSub.Publication do
 
   def schema, do: @schema
   def publish_all_schema, do: @publish_all_schema
+
+  @doc false
+  def topic(topic) when is_binary(topic) do
+    {:ok, [topic]}
+  end
+
+  def topic(topic) when is_list(topic) do
+    if nested_list_of_binaries_or_atoms?(topic) do
+      {:ok, topic}
+    else
+      {:error,
+       "Expected topic to be a string or a list of strings or attribute names (as atoms), got: #{inspect(topic)}"}
+    end
+  end
+
+  def topic(other) do
+    {:error,
+     "Expected topic to be a string or a list of strings or attribute names (as atoms), got: #{inspect(other)}"}
+  end
+
+  defp nested_list_of_binaries_or_atoms?(list) when is_list(list) do
+    Enum.all?(list, &nested_list_of_binaries_or_atoms?/1)
+  end
+
+  defp nested_list_of_binaries_or_atoms?(value) when is_binary(value) or is_atom(value) do
+    true
+  end
+
+  defp nested_list_of_binaries_or_atoms?(_) do
+    false
+  end
 end

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -115,14 +115,13 @@ defmodule Ash.Resource.Validation do
   end
 
   @doc false
-  def transform(%{validation: {module, opts}, where: where} = validation) do
+  def transform(%{validation: {module, opts}} = validation) do
     {:ok,
      %{
        validation
        | validation: {module, opts},
          module: module,
-         opts: opts,
-         where: List.wrap(where)
+         opts: opts
      }}
   end
 


### PR DESCRIPTION
Revert one of the changes in #700. I've missed that the custom function supports recursion.

Also in that PR I've made remark that with custom function `topic` supports `"string"` or `["string"]` or `[:atom]` but not `:atom`. I've kept it like it was before, I assume this is because atoms represent changing parts and it is not advisable for topic to consist only of an attribute value. Though there is a potential `prefix`, so maybe single atom is ok.

Also on topic of `:wrap_list` removed `List.wrap` call `Ash.Resource.Validation` that is not needed anymore because `:wrap_list` does that now.