### PR TITLE
improvement: default `keys` in identity to its `name`

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Resource.cheatmd
@@ -1904,7 +1904,7 @@ identity :full_name, [:first_name, :last_name]
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |
 | `name`* | `atom` |  | The name of the identity. |
-| `keys`* | `list(atom) \| atom` |  | The names of the attributes that uniquely identify this resource. |
+| `keys` | `atom \| list(atom)` |  | The names of the attributes that uniquely identify this resource. Defaults to the name of the identity. |
 ### Options
 | Name | Type | Default | Docs |
 | ---  | ---  | ---     | ---  |

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -710,6 +710,7 @@ defmodule Ash.Resource.Dsl do
     ],
     target: Ash.Resource.Identity,
     schema: Ash.Resource.Identity.schema(),
+    transform: {Ash.Resource.Identity, :transform, []},
     no_depend_modules: [:pre_check_with, :eager_check_with],
     args: [:name, :keys]
   }

--- a/lib/ash/resource/identity.ex
+++ b/lib/ash/resource/identity.ex
@@ -18,9 +18,10 @@ defmodule Ash.Resource.Identity do
       doc: "The name of the identity."
     ],
     keys: [
-      type: {:wrap_list, :atom},
-      required: true,
-      doc: "The names of the attributes that uniquely identify this resource."
+      type: {:or, [:atom, {:list, :atom}]},
+      doc: """
+      The names of the attributes that uniquely identify this resource. Defaults to the name of the identity.
+      """
     ],
     eager_check_with: [
       type: {:behaviour, Ash.Api},
@@ -51,4 +52,9 @@ defmodule Ash.Resource.Identity do
           keys: list(atom()),
           description: String.t() | nil
         }
+
+  @doc false
+  def transform(%{name: name, keys: keys} = identity) do
+    {:ok, %{identity | keys: List.wrap(keys || name)}}
+  end
 end

--- a/test/resource/identities_test.exs
+++ b/test/resource/identities_test.exs
@@ -38,6 +38,23 @@ defmodule Ash.Test.Resource.IdentitiesTest do
                Ash.Resource.Info.identities(Post)
     end
 
+    test "defaults fields to a provided name" do
+      defposts do
+        actions do
+          read :read do
+            primary? true
+          end
+        end
+
+        identities do
+          identity :name, pre_check_with: Api
+        end
+      end
+
+      assert [%Ash.Resource.Identity{name: :name, keys: [:name]}] =
+               Ash.Resource.Info.identities(Post)
+    end
+
     test "eager_check_with requires a primary read action" do
       assert_raise Spark.Error.DslError,
                    ~r/but the resource has no primary read action./,


### PR DESCRIPTION
Allows to write `identity :email` instead of `identity :email, :email` or `identity :email, [:email]`.
