### PR TITLE
fix: usage of `get_by` with `belongs_to` attribute

### DIFF
--- a/lib/ash/resource/transformers/get_by_read_actions.ex
+++ b/lib/ash/resource/transformers/get_by_read_actions.ex
@@ -14,6 +14,7 @@ defmodule Ash.Resource.Transformers.GetByReadActions do
 
   @doc false
   @spec after?(module) :: boolean
+  def after?(Ash.Resource.Transformers.BelongsToAttribute), do: true
   def after?(_), do: false
 
   @doc false


### PR DESCRIPTION
`get_by` transform should happen after `belongs_to` attributes are generated.

Closes #637. 