### PR TITLE
fix: return unions as is if load is empty

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -834,6 +834,7 @@ defmodule Ash.Type do
           {:ok, list(term)} | {:error, Ash.Error.t()}
   def load(_, [], _, _, _), do: {:ok, []}
   def load(_, nil, _, _, _), do: {:ok, nil}
+  def load(_, %Ash.ForbiddenField{} = value, _, _, _), do: {:ok, value}
 
   def load({:array, type}, values, loads, constraints, context) do
     load(type, values, loads, constraints[:items] || [], context)

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -122,6 +122,9 @@ defmodule Ash.Type.Union do
   def storage_type(_), do: :map
 
   @impl true
+  def load(unions, [], _, _), do: {:ok, unions}
+
+  @impl true
   def load(unions, load, constraints, context) do
     unions
     |> Stream.with_index()


### PR DESCRIPTION
After the change you made to fix the permissions when loading through unions, I got another error.

This might not be the right place to fix this issue, but it got rid of the error.

What happened was that I tried to execute an update on a resource, and the resource I put in had a %Ash.ForbiddenField{} struct in place for the union. Ash then tried to go through the load function and failed
because the Enum function couldn't handle the %Ash.ForbiddenField{} value. 

This is not actually fixing this, but because I didn't need to load anything from the union in this action, the load was empty, and I could circumvent the problem like this. 