### PR TITLE
improvement: support an `api` option to `use Ash.Resource`

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -5,6 +5,14 @@ defmodule Ash do
   Currently only contains setters/getters for process context.
   """
 
+  for {function, arity} <- Ash.Api.Functions.functions() do
+    unless function in Ash.Api.Functions.no_opts_functions() do
+      args = Macro.generate_arguments(arity, __MODULE__)
+
+      defdelegate unquote(function)(unquote_splicing(args)), to: Ash.Api.GlobalInterface
+    end
+  end
+
   @doc """
   Converts a context map to opts to be passed into an action.
   """

--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -1,8 +1,6 @@
 defmodule Ash do
   @moduledoc """
-  General purpose tools for working with Ash.
-
-  Currently only contains setters/getters for process context.
+  General purpose tools for working with Ash and Ash resources.
   """
 
   for {function, arity} <- Ash.Api.Functions.functions() do

--- a/lib/ash/api/functions.ex
+++ b/lib/ash/api/functions.ex
@@ -1,0 +1,57 @@
+defmodule Ash.Api.Functions do
+  @moduledoc false
+
+  @functions [
+    stream!: 1,
+    count: 1,
+    count!: 1,
+    first: 2,
+    first!: 2,
+    sum: 2,
+    sum!: 2,
+    min: 2,
+    min!: 2,
+    max: 2,
+    max!: 2,
+    avg: 2,
+    avg!: 2,
+    exists: 1,
+    exists?: 1,
+    list: 2,
+    list!: 2,
+    aggregate: 2,
+    aggregate!: 2,
+    can?: 2,
+    can: 2,
+    calculate: 2,
+    calculate!: 2,
+    run_action: 1,
+    run_action!: 1,
+    get: 2,
+    get!: 2,
+    read_one: 1,
+    read_one!: 1,
+    read: 1,
+    read!: 1,
+    page: 2,
+    load: 2,
+    load!: 2,
+    create: 1,
+    create!: 1,
+    bulk_create: 3,
+    bulk_create!: 3,
+    update: 1,
+    update!: 1,
+    destroy: 1,
+    destroy!: 1,
+    reload: 1
+  ]
+
+  @no_opts_functions [
+    :page,
+    :reload
+  ]
+
+  def functions, do: @functions
+  def no_opts_functions, do: @no_opts_functions
+end

--- a/lib/ash/api/global_interface.ex
+++ b/lib/ash/api/global_interface.ex
@@ -1,0 +1,241 @@
+defmodule Ash.Api.GlobalInterface do
+  @moduledoc false
+  for {function, arity} <- Ash.Api.Functions.functions() do
+    if function == :load do
+      def load({:ok, result}, load) do
+        load(result, load)
+      end
+
+      def load({:error, error}, _), do: {:error, error}
+
+      def load([], _), do: {:ok, []}
+      def load(nil, _), do: {:ok, nil}
+
+      def load(%page_struct{results: []} = page, _)
+          when page_struct in [Ash.Page.Keyset, Ash.Page.Offset] do
+        {:ok, page}
+      end
+    end
+
+    if function == :load! do
+      def load!({:ok, result}, load) do
+        {:ok, load!(result, load)}
+      end
+
+      def load!({:error, error}, _), do: raise(Ash.Error.to_error_class(error))
+      def load!([], _), do: []
+      def load!(nil, _), do: nil
+
+      def load!(%page_struct{results: []} = page, _)
+          when page_struct in [Ash.Page.Keyset, Ash.Page.Offset] do
+        page
+      end
+    end
+
+    args = Macro.generate_arguments(arity, __MODULE__)
+
+    docs_arity =
+      if function in Ash.Api.Functions.no_opts_functions() do
+        arity
+      else
+        arity + 1
+      end
+
+    @doc "Calls `c:Ash.Api.#{function}/#{docs_arity}` on the resource's configured api. See those callback docs for more."
+    def unquote(function)(unquote_splicing(args)) do
+      resource = resource_from_args!(unquote(function), unquote(arity), [unquote_splicing(args)])
+
+      api = Ash.Resource.Info.api(resource)
+
+      if !api do
+        raise_no_api_error!(resource, unquote(function), unquote(arity))
+      end
+
+      apply(api, unquote(function), [unquote_splicing(args)])
+    end
+
+    unless function in Ash.Api.Functions.no_opts_functions() do
+      args = Macro.generate_arguments(arity + 1, __MODULE__)
+
+      if function == :load! do
+        def load!({:ok, result}, load, opts) do
+          {:ok, load(result, load, opts)}
+        end
+
+        def load!({:error, error}, _, _), do: raise(Ash.Error.to_error_class(error))
+
+        def load!(nil, _, _), do: nil
+        def load!([], _, _), do: []
+
+        def load!(%page_struct{results: []} = page, _, _)
+            when page_struct in [Ash.Page.Keyset, Ash.Page.Offset] do
+          page
+        end
+      end
+
+      if function == :load do
+        def load({:ok, result}, load, opts) do
+          load(result, load, opts)
+        end
+
+        def load({:error, error}, _, _), do: {:error, error}
+        def load([], _, _), do: {:ok, []}
+        def load(nil, _, _), do: {:ok, nil}
+
+        def load(%page_struct{results: []} = page, _, _)
+            when page_struct in [Ash.Page.Keyset, Ash.Page.Offset] do
+          {:ok, page}
+        end
+      end
+
+      @doc "Calls `c:Ash.Api.#{function}/#{arity + 1}` on the resource's configured api. See those callback docs for more."
+      def unquote(function)(unquote_splicing(args)) do
+        resource =
+          resource_from_args!(unquote(function), unquote(arity), [unquote_splicing(args)])
+
+        api = Ash.Resource.Info.api(resource)
+
+        if !api do
+          raise_no_api_error!(resource, unquote(function), unquote(arity))
+        end
+
+        apply(api, unquote(function), [unquote_splicing(args)])
+      end
+    end
+  end
+
+  defp raise_no_api_error!(resource, function, arity) do
+    raise ArgumentError, """
+    No api configured for resource #{inspect(resource)}.
+
+    To configure one, use `api: MyApi` in the resource's options, for example: `use Ash.Resource, api: YourApi`.
+
+    If the resource is meant to be used with multiple Apis (a rare case), call that api direction instead of using `Ash.#{function}/#{arity}`.
+    """
+  end
+
+  defp resource_from_args!(fun, _, [data | _]) when fun in [:load, :load!] do
+    case data do
+      %struct{rerun: {%Ash.Query{resource: resource}, _}}
+      when struct in [Ash.Page.Keyset, Ash.Page.Offset] ->
+        resource
+
+      %struct{rerun: {resource, _}}
+      when struct in [Ash.Page.Keyset, Ash.Page.Offset] and is_atom(resource) ->
+        resource
+
+      %resource{} ->
+        resource
+
+      [%resource{} | _] ->
+        resource
+
+      {:ok, %resource{}} ->
+        resource
+
+      {:ok, [%resource{} | _]} ->
+        resource
+    end
+  end
+
+  defp resource_from_args!(:reload, _, [%resource{} | _]) do
+    resource
+  end
+
+  defp resource_from_args!(fun, _, [_, resource | _]) when fun in [:bulk_create, :bulk_create!] do
+    resource
+  end
+
+  defp resource_from_args!(fun, _, [resource | _]) when fun in [:calculate, :calculate!] do
+    resource
+  end
+
+  defp resource_from_args!(fun, _, [page | _]) when fun in [:page, :page!] do
+    case page do
+      %struct{rerun: {%Ash.Query{resource: resource}, _}}
+      when struct in [Ash.Page.Keyset, Ash.Page.Offset] ->
+        resource
+
+      %struct{rerun: {resource, _}}
+      when struct in [Ash.Page.Keyset, Ash.Page.Offset] and is_atom(resource) ->
+        resource
+
+      other ->
+        raise """
+        Could not determine resource. Expected an `Ash.Page.Keyset` or `Ash.Page.Offset`.
+
+        Got: #{inspect(other)}
+        """
+    end
+  end
+
+  defp resource_from_args!(fun, _, [query_or_changeset_or_action | _])
+       when fun in [:can, :can?] do
+    case query_or_changeset_or_action do
+      %struct{resource: resource} when struct in [Ash.Changeset, Ash.Query, Ash.ActionInput] ->
+        resource
+
+      {resource, _} ->
+        resource
+
+      {resource, _, _} ->
+        resource
+    end
+  end
+
+  defp resource_from_args!(fun, _arity, [changeset_or_query | _])
+       when fun in [
+              :destroy,
+              :update,
+              :destroy!,
+              :update!,
+              :read,
+              :read!,
+              :stream,
+              :stream!,
+              :create,
+              :create!,
+              :run_action,
+              :run_action!,
+              :read_one,
+              :read_one!,
+              :get,
+              :count,
+              :count!,
+              :first,
+              :first!,
+              :sum,
+              :sum!,
+              :min,
+              :min!,
+              :max,
+              :max!,
+              :avg,
+              :avg!,
+              :exists,
+              :exists?,
+              :list,
+              :list!,
+              :aggregate,
+              :aggregate!
+            ] do
+    case changeset_or_query do
+      %struct{resource: resource} when struct in [Ash.Changeset, Ash.Query, Ash.ActionInput] ->
+        resource
+
+      resource when is_atom(resource) and not is_nil(resource) ->
+        resource
+
+      other ->
+        raise """
+        Could not determine resource. Expected a changeset, query, action input, or resource.
+
+        Got: #{inspect(other)}
+        """
+    end
+  end
+
+  defp resource_from_args!(fun, arity, _args) do
+    raise ArgumentError, "Could not determine resource from arguments to `Ash.#{fun}/#{arity}`"
+  end
+end

--- a/lib/ash/resource.ex
+++ b/lib/ash/resource.ex
@@ -22,6 +22,11 @@ defmodule Ash.Resource do
       validate_api_inclusion?: [
         type: :boolean,
         default: true
+      ],
+      api: [
+        type: :atom,
+        doc:
+          "The api to use when interacting with this resource. Also sets defaults for various options that ask for an api."
       ]
     ]
 
@@ -76,8 +81,13 @@ defmodule Ash.Resource do
   @impl Spark.Dsl
   def handle_opts(opts) do
     quote bind_quoted: [
-            embedded?: opts[:embedded?]
+            embedded?: opts[:embedded?],
+            api: opts[:api]
           ] do
+      if api do
+        @persist {:api, api}
+      end
+
       if embedded? do
         @persist {:embedded?, true}
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1329,7 +1329,7 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Transformers.DefaultPrimaryKey,
     Ash.Resource.Transformers.DefaultAccept,
     Ash.Resource.Transformers.RequireUniqueFieldNames,
-    Ash.Resource.Transformers.GetByReadActions
+    Ash.Resource.Transformers.SetDefineFor
   ]
 
   @verifiers [
@@ -1346,7 +1346,8 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Verifiers.ValidateEagerIdentities,
     Ash.Resource.Verifiers.ValidateManagedRelationshipOpts,
     Ash.Resource.Verifiers.ValidateMultitenancy,
-    Ash.Resource.Verifiers.ValidatePrimaryKey
+    Ash.Resource.Verifiers.ValidatePrimaryKey,
+    Ash.Resource.Verifiers.VerifyAcceptedByApi
   ]
 
   @moduledoc false

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -21,6 +21,10 @@ defmodule Ash.Resource.Info do
   @deprecated "Use `Ash.Resource.selected?/2` instead"
   defdelegate selected?(record, field), to: Ash.Resource
 
+  def api(resource) do
+    Spark.Dsl.Extension.get_persisted(resource, :api)
+  end
+
   @doc """
   Retrieves a relationship path from the resource related by path, to the provided resource.
   """

--- a/lib/ash/resource/transformers/set_define_for.ex
+++ b/lib/ash/resource/transformers/set_define_for.ex
@@ -1,0 +1,21 @@
+defmodule Ash.Resource.Transformers.SetDefineFor do
+  @moduledoc false
+  use Spark.Dsl.Transformer
+
+  def transform(dsl) do
+    api = Spark.Dsl.Transformer.get_persisted(dsl, :api)
+
+    if api do
+      dsl =
+        Spark.Dsl.Transformer.persist(dsl, :api, api)
+
+      if Ash.Resource.Info.define_interface_for(dsl) do
+        {:ok, dsl}
+      else
+        {:ok, Spark.Dsl.Transformer.set_option(dsl, [:code_interface], :define_for, api)}
+      end
+    else
+      {:ok, dsl}
+    end
+  end
+end

--- a/lib/ash/resource/verifiers/verify_accepted_by_api.ex
+++ b/lib/ash/resource/verifiers/verify_accepted_by_api.ex
@@ -1,0 +1,28 @@
+defmodule Ash.Resource.Verifiers.VerifyAcceptedByApi do
+  @moduledoc false
+  use Spark.Dsl.Verifier
+
+  def verify(dsl) do
+    api = Spark.Dsl.Transformer.get_persisted(dsl, :api)
+
+    if api do
+      resource = Spark.Dsl.Verifier.get_persisted(dsl, :module)
+
+      case Ash.Api.Info.resource(api, resource) do
+        {:ok, _} ->
+          :ok
+
+        _ ->
+          raise """
+          Resource #{inspect(resource)} declared that its api is #{inspect(api)}, but that
+          api does not accept this resource.
+
+          The most likely cause for this is missing a call to `resource #{inspect(resource)}`
+          in the `resources` block of #{inspect(api)}.
+          """
+      end
+    else
+      :ok
+    end
+  end
+end

--- a/test/api/api_test.exs
+++ b/test/api/api_test.exs
@@ -2,14 +2,46 @@ defmodule Ash.Test.Resource.ApiTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
-  defmacrop defposts(do: body) do
-    quote do
-      defmodule Post do
-        @moduledoc false
-        use Ash.Resource
+  defmodule Api do
+    use Ash.Api
 
-        unquote(body)
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  defmodule Foo do
+    use Ash.Resource, api: Api
+
+    actions do
+      defaults [:create, :read]
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  test "cannot define a resource that points to an api that doesn't accept it" do
+    assert_raise RuntimeError, ~r/api does not accept this resource/, fn ->
+      defmodule NoResourcesApi do
+        use Ash.Api
+      end
+
+      defmodule Bar do
+        use Ash.Resource, api: NoResourcesApi
+
+        attributes do
+          uuid_primary_key :id
+        end
       end
     end
+  end
+
+  test "a resource defined with an api can be used with functions in `Ash`" do
+    assert %Foo{} =
+             Foo
+             |> Ash.Changeset.for_create(:create)
+             |> Ash.create!()
   end
 end


### PR DESCRIPTION
improvement: add functions to `Ash` for resources w/ configured apis
improvement: default code_interface.define_for to resource's ash api

So what does this give us?

```elixir
defmodule Resource do
  use Ash.Resource,
    api: YourApi
end
```

Given that resource, you can then use the functions defined in `Ash` that mirror the functions defined in the api module,

```elixir
Resource
|> Ash.Changeset.for_create()
|> Ash.create!()
```

Additionally, options like `code_interface.define_for` default to the value of that api, allowing you to omit them.
