### PR TITLE
improvement: set default many to many options

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Resource.cheatmd
@@ -3106,48 +3106,6 @@ belongs_to :word, Word, primary_key?: true, allow_nil?: false
   <tbody>
     <tr>
   <td style="text-align: left">
-    <a id="relationships-many_to_many-source_attribute_on_join_resource" href="#relationships-many_to_many-source_attribute_on_join_resource">
-      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
-        source_attribute_on_join_resource
-      </span>
-    </a>
-      <sup style="color: red">*</sup>
-
-  </td>
-  <td style="text-align: left">
-    <code class="inline">atom</code>
-  </td>
-  <td style="text-align: left">
-    
-  </td>
-  <td style="text-align: left" colspan=2>
-    The attribute on the join resource that should line up with `source_attribute` on this resource.
-  </td>
-</tr>
-
-<tr>
-  <td style="text-align: left">
-    <a id="relationships-many_to_many-destination_attribute_on_join_resource" href="#relationships-many_to_many-destination_attribute_on_join_resource">
-      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
-        destination_attribute_on_join_resource
-      </span>
-    </a>
-      <sup style="color: red">*</sup>
-
-  </td>
-  <td style="text-align: left">
-    <code class="inline">atom</code>
-  </td>
-  <td style="text-align: left">
-    
-  </td>
-  <td style="text-align: left" colspan=2>
-    The attribute on the join resource that should line up with `destination_attribute` on the related resource.
-  </td>
-</tr>
-
-<tr>
-  <td style="text-align: left">
     <a id="relationships-many_to_many-through" href="#relationships-many_to_many-through">
       <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
         through
@@ -3169,6 +3127,46 @@ belongs_to :word, Word, primary_key?: true, allow_nil?: false
 
 <tr>
   <td style="text-align: left">
+    <a id="relationships-many_to_many-source_attribute_on_join_resource" href="#relationships-many_to_many-source_attribute_on_join_resource">
+      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
+        source_attribute_on_join_resource
+      </span>
+    </a>
+      
+  </td>
+  <td style="text-align: left">
+    <code class="inline">atom</code>
+  </td>
+  <td style="text-align: left">
+    
+  </td>
+  <td style="text-align: left" colspan=2>
+    The attribute on the join resource that should line up with `source_attribute` on this resource. Defaults to `<snake_cased_last_part_of_source_module_name>_id`.
+  </td>
+</tr>
+
+<tr>
+  <td style="text-align: left">
+    <a id="relationships-many_to_many-destination_attribute_on_join_resource" href="#relationships-many_to_many-destination_attribute_on_join_resource">
+      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
+        destination_attribute_on_join_resource
+      </span>
+    </a>
+      
+  </td>
+  <td style="text-align: left">
+    <code class="inline">atom</code>
+  </td>
+  <td style="text-align: left">
+    
+  </td>
+  <td style="text-align: left" colspan=2>
+    The attribute on the join resource that should line up with `destination_attribute` on the related resource. Defaults to `<snake_cased_last_part_of_destination_module_name>_id`.
+  </td>
+</tr>
+
+<tr>
+  <td style="text-align: left">
     <a id="relationships-many_to_many-join_relationship" href="#relationships-many_to_many-join_relationship">
       <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
         join_relationship
@@ -3183,7 +3181,7 @@ belongs_to :word, Word, primary_key?: true, allow_nil?: false
     
   </td>
   <td style="text-align: left" colspan=2>
-    The has_many relationship to the join resource. Defaults to <relationship_name>_join_assoc
+    The has_many relationship to the join resource. Defaults to `<relationship_name>_join_assoc`.
   </td>
 </tr>
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1318,6 +1318,8 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Transformers.SetRelationshipSource,
     Ash.Resource.Transformers.BelongsToAttribute,
     Ash.Resource.Transformers.HasDestinationField,
+    Ash.Resource.Transformers.ManyToManySourceAttributeOnJoinResource,
+    Ash.Resource.Transformers.ManyToManyDestinationAttributeOnJoinResource,
     Ash.Resource.Transformers.CreateJoinRelationship,
     Ash.Resource.Transformers.CachePrimaryKey,
     Ash.Resource.Transformers.ValidatePrimaryActions,

--- a/lib/ash/resource/relationships/many_to_many.ex
+++ b/lib/ash/resource/relationships/many_to_many.ex
@@ -58,15 +58,15 @@ defmodule Ash.Resource.Relationships.ManyToMany do
                 [
                   source_attribute_on_join_resource: [
                     type: :atom,
-                    required: true,
+                    required: false,
                     doc:
-                      "The attribute on the join resource that should line up with `source_attribute` on this resource."
+                      "The attribute on the join resource that should line up with `source_attribute` on this resource. Defaults to `<snake_cased_last_part_of_source_module_name>_id`."
                   ],
                   destination_attribute_on_join_resource: [
                     type: :atom,
-                    required: true,
+                    required: false,
                     doc:
-                      "The attribute on the join resource that should line up with `destination_attribute` on the related resource."
+                      "The attribute on the join resource that should line up with `destination_attribute` on the related resource. Defaults to `<snake_cased_last_part_of_destination_module_name>_id`."
                   ],
                   through: [
                     type: Ash.OptionsHelpers.ash_resource(),
@@ -76,7 +76,7 @@ defmodule Ash.Resource.Relationships.ManyToMany do
                   join_relationship: [
                     type: :atom,
                     doc:
-                      "The has_many relationship to the join resource. Defaults to <relationship_name>_join_assoc"
+                      "The has_many relationship to the join resource. Defaults to `<relationship_name>_join_assoc`."
                   ]
                 ],
                 @global_opts,

--- a/lib/ash/resource/transformers/many_to_many_destination_attribute_on_join_resource.ex
+++ b/lib/ash/resource/transformers/many_to_many_destination_attribute_on_join_resource.ex
@@ -1,0 +1,52 @@
+defmodule Ash.Resource.Transformers.ManyToManyDestinationAttributeOnJoinResource do
+  @moduledoc """
+  Guesses the `destination_attribute_on_join_resource` for many to many relationships unless provided.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    new_dsl_state =
+      dsl_state
+      |> Transformer.get_entities([:relationships])
+      |> Enum.reduce(dsl_state, fn
+        %{
+          type: type,
+          destination: destination,
+          destination_attribute_on_join_resource: nil
+        } = relationship,
+        dsl_state
+        when type == :many_to_many ->
+          new_relationship = %{
+            relationship
+            | destination_attribute_on_join_resource: resource_id_field(destination)
+          }
+
+          Transformer.replace_entity(
+            dsl_state,
+            [:relationships],
+            new_relationship,
+            fn replacing ->
+              replacing.name == relationship.name
+            end
+          )
+
+        _relationship, dsl_state ->
+          dsl_state
+      end)
+
+    {:ok, new_dsl_state}
+  end
+
+  # sobelow_skip ["DOS.StringToAtom"]
+  defp resource_id_field(module) do
+    module
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+    |> Kernel.<>("_id")
+    |> String.to_atom()
+  end
+end

--- a/lib/ash/resource/transformers/many_to_many_source_attribute_on_join_resource.ex
+++ b/lib/ash/resource/transformers/many_to_many_source_attribute_on_join_resource.ex
@@ -1,0 +1,48 @@
+defmodule Ash.Resource.Transformers.ManyToManySourceAttributeOnJoinResource do
+  @moduledoc """
+  Guesses the `source_attribute_on_join_resource` for many to many relationships unless provided.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    new_dsl_state =
+      dsl_state
+      |> Transformer.get_entities([:relationships])
+      |> Enum.reduce(dsl_state, fn
+        %{type: type, source_attribute_on_join_resource: nil} = relationship, dsl_state
+        when type in [:many_to_many] ->
+          new_relationship = %{
+            relationship
+            | source_attribute_on_join_resource: resource_id_field(dsl_state)
+          }
+
+          Transformer.replace_entity(
+            dsl_state,
+            [:relationships],
+            new_relationship,
+            fn replacing ->
+              replacing.name == relationship.name
+            end
+          )
+
+        _relationship, dsl_state ->
+          dsl_state
+      end)
+
+    {:ok, new_dsl_state}
+  end
+
+  # sobelow_skip ["DOS.StringToAtom"]
+  defp resource_id_field(dsl_state) do
+    dsl_state
+    |> Transformer.get_persisted(:module)
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+    |> Kernel.<>("_id")
+    |> String.to_atom()
+  end
+end

--- a/test/resource/relationships/many_to_many_test.exs
+++ b/test/resource/relationships/many_to_many_test.exs
@@ -127,6 +127,48 @@ defmodule Ash.Test.Resource.Relationships.ManyToManyTest do
       end
     end
 
+    test "it guesses `source_attribute_on_join_resource` if not set" do
+      defposts do
+        relationships do
+          many_to_many :authors, Author do
+            through PostsJoinArticlesAuthors
+            destination_attribute_on_join_resource :manager_id
+          end
+        end
+      end
+
+      assert [
+               %HasMany{},
+               %ManyToMany{
+                 destination: Author,
+                 destination_attribute_on_join_resource: :manager_id,
+                 source_attribute_on_join_resource: :post_id,
+                 through: PostsJoinArticlesAuthors
+               }
+             ] = Ash.Resource.Info.relationships(Post)
+    end
+
+    test "it guesses `destination_attribute_on_join_resource` if not set" do
+      defposts do
+        relationships do
+          many_to_many :authors, ArticleAuthor do
+            through PostsJoinArticlesAuthors
+            source_attribute_on_join_resource :article_id
+          end
+        end
+      end
+
+      assert [
+               %HasMany{},
+               %ManyToMany{
+                 destination: ArticleAuthor,
+                 destination_attribute_on_join_resource: :article_author_id,
+                 source_attribute_on_join_resource: :article_id,
+                 through: PostsJoinArticlesAuthors
+               }
+             ] = Ash.Resource.Info.relationships(Post)
+    end
+
     test "it fails if you dont pass an atom for `source_attribute_on_join_resource`" do
       assert_raise(
         Spark.Error.DslError,


### PR DESCRIPTION
Many to many relationship `source_attribute_on_join_resource` and `destination_attribute_on_join_resource` are now guessed by there module name if not explicitly set in the relationship.

Solve issue #245.

# Contributor checklist

- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies