### PR TITLE
Format code examples in `Ash.Resource.Change.Builtins.set_attribute/3`

### DIFF
--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -158,10 +158,10 @@ defmodule Ash.Resource.Change.Builtins do
 
   ## Examples
 
-  change set_attribute(:active, false)
-  change set_attribute(:opened_at, &DateTime.utc_now/0)
-  change set_attribute(:status, arg(:status))
-  change set_attribute(:encrypted_data, arg(:data), set_when_nil?: false)
+      change set_attribute(:active, false)
+      change set_attribute(:opened_at, &DateTime.utc_now/0)
+      change set_attribute(:status, arg(:status))
+      change set_attribute(:encrypted_data, arg(:data), set_when_nil?: false)
   """
   @spec set_attribute(
           relationship :: atom,


### PR DESCRIPTION
I just noticed that the indentation for the code examples were not properly set.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
