### PR TITLE
improvement: add "filename" parameter to the livebook generator.

### DIFF
--- a/lib/mix/tasks/generate_livebook.ex
+++ b/lib/mix/tasks/generate_livebook.ex
@@ -4,16 +4,24 @@ defmodule Mix.Tasks.Ash.GenerateLivebook do
 
   ## Command line options
 
-    * `--only` - only generates the given API file
+    * `--filename` - Specify the name of the generated Livebook file. Default: `livebook.livemd`
 
   """
   use Mix.Task
 
   @shortdoc "Generates a Livebook for each Ash API"
-  def run(_argv) do
+  def run(argv) do
     Mix.Task.run("compile")
 
-    File.write!("livebook.livemd", Ash.Api.Info.Livebook.overview(apis()))
+    {opts, _} =
+      OptionParser.parse!(argv,
+        strict: [filename: :string],
+        aliases: [f: :filename]
+      )
+
+    filename = Keyword.get(opts, :filename, "livebook.livemd")
+
+    File.write!(filename, Ash.Api.Info.Livebook.overview(apis()))
 
     Mix.shell().info("Generated Livebook")
   end


### PR DESCRIPTION
Solves #739

The documentation of the mix task mentioned the `--only` command line option, but this options doesn't seem to exist so I've removed it from the documentation for now.