### PR TITLE
fix: Change heading levels in generated livebook to have only one H1

### DIFF
--- a/lib/ash/api/info/livebook.ex
+++ b/lib/ash/api/info/livebook.ex
@@ -29,27 +29,29 @@ defmodule Ash.Api.Info.Livebook do
 
   def overview(apis) do
     """
+    # API Documentation
+
     #{for api <- apis, do: api_section(api)}
     """
   end
 
   def api_section(api) do
     """
-    # API #{module_name(api)}
+    ## API #{module_name(api)}
 
-    ## Class Diagram
+    ### Class Diagram
 
     ```mermaid
     #{Ash.Api.Info.Diagram.mermaid_class_diagram(api) |> String.trim()}
     ```
 
-    ## ER Diagram
+    ### ER Diagram
 
     ```mermaid
     #{Ash.Api.Info.Diagram.mermaid_er_diagram(api) |> String.trim()}
     ```
 
-    ## Resources
+    ### Resources
 
     #{for resource <- Ash.Api.Info.resources(api) do
       """
@@ -64,18 +66,18 @@ defmodule Ash.Api.Info.Livebook do
 
   def resource_section(resource) do
     """
-    ## #{resource_name(resource)}
+    ### #{resource_name(resource)}
 
     #{Ash.Resource.Info.description(resource)}
 
-    ### Attributes
+    #### Attributes
 
     #{attr_header() |> String.trim()}
     #{for attr <- Ash.Resource.Info.attributes(resource) do
       attr_section(attr)
     end |> Enum.join("\n")}
 
-    ### Actions
+    #### Actions
 
     #{action_header() |> String.trim()}
     #{for action <- Ash.Resource.Info.actions(resource) do

--- a/test/api/livebook_test.exs
+++ b/test/api/livebook_test.exs
@@ -5,9 +5,9 @@ defmodule Ash.Test.Api.Info.LivebookTest do
   test "generate a livebook API section from a given API" do
     assert Ash.Api.Info.Livebook.api_section(Ash.Test.Flow.Api) ==
              """
-             # API Ash.Test.Flow.Api
+             ## API Ash.Test.Flow.Api
 
-             ## Class Diagram
+             ### Class Diagram
 
              ```mermaid
              classDiagram
@@ -40,7 +40,7 @@ defmodule Ash.Test.Api.Info.LivebookTest do
                  Org -- User
              ```
 
-             ## ER Diagram
+             ### ER Diagram
 
              ```mermaid
              erDiagram
@@ -58,16 +58,16 @@ defmodule Ash.Test.Api.Info.LivebookTest do
                  Org ||--|| User : ""
              ```
 
-             ## Resources
+             ### Resources
 
              - [User](#user)
              - [Org](#org)
 
-             ## User
+             ### User
 
              User model
 
-             ### Attributes
+             #### Attributes
 
              | Name | Type | Description |
              | ---- | ---- | ----------- |
@@ -78,7 +78,7 @@ defmodule Ash.Test.Api.Info.LivebookTest do
              | **approved** | Boolean | Is the user approved? |
              | **org_id** | UUID |  |
 
-             ### Actions
+             #### Actions
 
              | Name | Type | Input | Description |
              | ---- | ---- | ----- | ----------- |
@@ -91,18 +91,18 @@ defmodule Ash.Test.Api.Info.LivebookTest do
              | **approve** | _update_ | <ul></ul> |  |
              | **unapprove** | _update_ | <ul></ul> |  |
 
-             ## Org
+             ### Org
 
              Org model
 
-             ### Attributes
+             #### Attributes
 
              | Name | Type | Description |
              | ---- | ---- | ----------- |
              | **id** | UUID |  |
              | **name** | String |  |
 
-             ### Actions
+             #### Actions
 
              | Name | Type | Input | Description |
              | ---- | ---- | ----- | ----------- |


### PR DESCRIPTION
Solves #740 

I've added a root H1 to the generated livebook and moved all section headings by one level.