### PR TITLE
2023 ww41 srcrr 679 code gen interfaces check type first argument

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -550,7 +550,7 @@ defmodule Ash.CodeInterface do
 
             :update ->
               subject = quote do: changeset
-              subject_args = quote do: [%{__struct__: unquote(resource)} = record]
+              subject_args = quote do: [record]
 
               resolve_subject =
                 quote do
@@ -569,7 +569,7 @@ defmodule Ash.CodeInterface do
 
             :destroy ->
               subject = quote do: changeset
-              subject_args = quote do: [%{__struct__: unquote(resource)} = record]
+              subject_args = quote do: [record]
 
               resolve_subject =
                 quote do

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -1,5 +1,6 @@
 defmodule Ash.Test.CodeInterfaceTest do
   @moduledoc false
+  alias Ash.Error.Exception
   use ExUnit.Case, async: true
 
   defmodule User do
@@ -130,7 +131,7 @@ defmodule Ash.Test.CodeInterfaceTest do
         |> Ash.Changeset.for_create(:create, %{first_name: "Zach2", last_name: "Daniel2"})
         |> Api.create!()
       ]
-      assert_raise Ash.Error.InvalidArgument, fn ->
+      assert_raise ArgumentError, ~r/^Initial must be a changeset with the action type of.+/i, fn ->
         User.update([], %{first_name: "Zack3", last_name: "Daniel3"})
       end
     end

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -19,6 +19,8 @@ defmodule Ash.Test.CodeInterfaceTest do
       define :create, args: [{:optional, :first_name}]
       define :hello, args: [:name]
 
+      define :update, action: :update
+
       define_calculation(:full_name, args: [:first_name, :last_name])
 
       define_calculation(:full_name_opt,
@@ -35,6 +37,8 @@ defmodule Ash.Test.CodeInterfaceTest do
       end
 
       create :create
+
+      update :update
 
       read :by_id do
         argument :id, :uuid, allow_nil?: false
@@ -114,6 +118,21 @@ defmodule Ash.Test.CodeInterfaceTest do
       assert {:ok, true} == User.can_get_by_id(nil, "some uuid")
       assert User.can_read_users?(nil)
       assert User.can_get_by_id?(nil, "some uuid")
+    end
+
+    test "code interface-generated functions should check the type of their first argument and return an expressive error" do
+      # create a few users
+      users = [
+        User
+        |> Ash.Changeset.for_create(:create, %{first_name: "Zach", last_name: "Daniel"})
+        |> Api.create!(),
+        User
+        |> Ash.Changeset.for_create(:create, %{first_name: "Zach2", last_name: "Daniel2"})
+        |> Api.create!()
+      ]
+      assert_raise Ash.Error.InvalidArgument, fn ->
+        User.update([], %{first_name: "Zack3", last_name: "Daniel3"})
+      end
     end
   end
 


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Issue was that there was an unclear error message when passing a list (or other type) to a code interface action function (e.g. update).

This is to close out https://github.com/ash-project/ash/issues/679

I first added a unit test to verify the fix worked (retroactively modifying the caught error message in the unit test once I determined what it was). For the unit test I added an `update` action to the User resource in `code_interface_test` and passed in an empty list to the `User.update` code interface action.

The fix was relatively simple: removing the pattern matching in the code_interface switch action block resulted in a clearer error message.