### PR TITLE
feat: Add unknown argument error when passing an unknown key to an action.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,10 +30,4 @@ if Mix.env() == :test do
 
   config :ash, :validate_api_resource_inclusion?, false
   config :ash, :validate_api_config_inclusion?, false
-
-  config :ash,
-    flags: [
-      read_uses_flow?: false,
-      ash_three?: true
-    ]
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,10 @@
 import Config
 
 config :ash,
-  flags: [read_uses_flow?: System.get_env("FLAG_READ_USES_FLOW", "false") == "true"]
+  flags: [
+    read_uses_flow?: System.get_env("FLAG_READ_USES_FLOW", "false") == "true",
+    ash_three?: System.get_env("FLAG_ASH_THREE", "false") == "true"
+  ]
 
 if Mix.env() == :dev do
   config :git_ops,
@@ -27,4 +30,10 @@ if Mix.env() == :test do
 
   config :ash, :validate_api_resource_inclusion?, false
   config :ash, :validate_api_config_inclusion?, false
+
+  config :ash,
+    flags: [
+      read_uses_flow?: false,
+      ash_three?: true
+    ]
 end

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -5,6 +5,8 @@ defmodule Ash.ActionInput do
 
   alias Ash.Error.Action.InvalidArgument
 
+  require Ash.Flags
+
   defstruct [
     :action,
     :api,
@@ -169,9 +171,15 @@ defmodule Ash.ActionInput do
       if has_argument?(input.action, name) do
         set_argument(input, name, value)
       else
-        input = %{input | invalid_keys: MapSet.put(input.invalid_keys, name)}
-        error = InvalidArgument.exception(field: name, value: value, message: "Unknown argument")
-        add_error(input, Ash.Error.set_path(error, name))
+        if Ash.Flags.ash_three?() do
+          error =
+            InvalidArgument.exception(field: name, value: value, message: "Unknown argument")
+
+          input = %{input | invalid_keys: MapSet.put(input.invalid_keys, name)}
+          add_error(input, Ash.Error.set_path(error, name))
+        else
+          input
+        end
       end
     end)
   end

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -169,7 +169,9 @@ defmodule Ash.ActionInput do
       if has_argument?(input.action, name) do
         set_argument(input, name, value)
       else
-        input
+        input = %{input | invalid_keys: MapSet.put(input.invalid_keys, name)}
+        error = InvalidArgument.exception(field: name, value: value, message: "Unknown argument")
+        add_error(input, Ash.Error.set_path(error, name))
       end
     end)
   end

--- a/lib/ash/flags.ex
+++ b/lib/ash/flags.ex
@@ -7,7 +7,8 @@ defmodule Ash.Flags do
   """
 
   @flags [
-    read_uses_flow?: false
+    read_uses_flow?: false,
+    ash_three?: false
   ]
 
   @flag_config Application.compile_env(:ash, :flags, [])
@@ -23,6 +24,14 @@ defmodule Ash.Flags do
   defmacro read_uses_flow? do
     quote do
       unquote(Map.get(@flag_values, :read_uses_flow?))
+    end
+  end
+
+  @doc "Should we activate Ash 3.0 features?"
+  @spec ash_three? :: Macro.t()
+  defmacro ash_three? do
+    quote do
+      unquote(Map.get(@flag_values, :ash_three?))
     end
   end
 

--- a/test/actions/generic_actions_test.exs
+++ b/test/actions/generic_actions_test.exs
@@ -84,6 +84,19 @@ defmodule Ash.Test.Actions.GenericActionsTest do
         |> Api.run_action!()
       end
     end
+
+    test "generic actions don't accept unknown keys" do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Post
+               |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+               |> Api.run_action()
+
+      assert_raise Ash.Error.Invalid, ~r/Input Invalid/, fn ->
+        Post
+        |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+        |> Api.run_action!()
+      end
+    end
   end
 
   describe "authorization" do

--- a/test/actions/generic_actions_test.exs
+++ b/test/actions/generic_actions_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Actions.GenericActionsTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  require Ash.Flags
+
   defmodule PassingFredOrGeorge do
     use Ash.Policy.SimpleCheck
 
@@ -85,16 +87,23 @@ defmodule Ash.Test.Actions.GenericActionsTest do
       end
     end
 
-    test "generic actions don't accept unknown keys" do
-      assert {:error, %Ash.Error.Invalid{}} =
-               Post
-               |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
-               |> Api.run_action()
+    test "generic actions don't accept unknown keys in Ash 3.0" do
+      if Ash.Flags.ash_three?() do
+        assert {:error, %Ash.Error.Invalid{}} =
+                 Post
+                 |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+                 |> Api.run_action()
 
-      assert_raise Ash.Error.Invalid, ~r/Input Invalid/, fn ->
-        Post
-        |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
-        |> Api.run_action!()
+        assert_raise Ash.Error.Invalid, ~r/Input Invalid/, fn ->
+          Post
+          |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+          |> Api.run_action!()
+        end
+      else
+        assert "Hello fred" =
+                 Post
+                 |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+                 |> Api.run_action!()
       end
     end
   end

--- a/test/actions/generic_actions_test.exs
+++ b/test/actions/generic_actions_test.exs
@@ -2,8 +2,6 @@ defmodule Ash.Test.Actions.GenericActionsTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
-  require Ash.Flags
-
   defmodule PassingFredOrGeorge do
     use Ash.Policy.SimpleCheck
 
@@ -87,23 +85,17 @@ defmodule Ash.Test.Actions.GenericActionsTest do
       end
     end
 
+    @tag :ash_three
     test "generic actions don't accept unknown keys in Ash 3.0" do
-      if Ash.Flags.ash_three?() do
-        assert {:error, %Ash.Error.Invalid{}} =
-                 Post
-                 |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
-                 |> Api.run_action()
+      assert {:error, %Ash.Error.Invalid{}} =
+               Post
+               |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+               |> Api.run_action()
 
-        assert_raise Ash.Error.Invalid, ~r/Input Invalid/, fn ->
-          Post
-          |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
-          |> Api.run_action!()
-        end
-      else
-        assert "Hello fred" =
-                 Post
-                 |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
-                 |> Api.run_action!()
+      assert_raise Ash.Error.Invalid, ~r/Input Invalid/, fn ->
+        Post
+        |> Ash.ActionInput.for_action(:hello, %{name: "fred", one: 1})
+        |> Api.run_action!()
       end
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,8 @@
-ExUnit.start(stacktrace_depth: 100)
+exclude = [
+  ash_three: System.get_env("FLAG_ASH_THREE", "false") != "true"
+]
+
+ExUnit.start(stacktrace_depth: 100, exclude: exclude)
 Logger.configure(level: :debug)
 
 # We compile modules with the same name often while testing the DSL


### PR DESCRIPTION
Solves #725 

When encountering unknown arguments, unknown keys are added to the `invalid_keys` set and an `Ash.Error.Action.InvalidArgument` with a custom message is added to the ActionInput.

Running the action will then return an `Ash.Error.Invalid` error.