### PR TITLE
fix: native union changes

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: elixir:latest
+  
+tasks:
+  - init: mix deps.get && mix compile
+    command: iex -S mix

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -521,8 +521,12 @@ defmodule Ash.Type.Union do
          {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
          {:ok, type} <- Keyword.fetch(type_config, :type),
          type_constraints <- Keyword.get(type_config, :constraints, []),
-         {:ok, new_value} <- type.handle_change(nil, new_value, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: new_value}}
+         true <- :erlang.function_exported(type, :handle_change, 3),
+         {:ok, handled_new_value} <- type.handle_change(nil, new_value, type_constraints) do
+      {:ok, %Ash.Union{type: type_name, value: handled_new_value}}
+    else
+      _ ->
+        {:ok, %Ash.Union{type: type_name, value: new_value}}
     end
   end
 
@@ -574,8 +578,12 @@ defmodule Ash.Type.Union do
          {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
          {:ok, type} <- Keyword.fetch(type_config, :type),
          type_constraints <- Keyword.get(type_config, :constraints, []),
+         true <- :erlang.function_exported(type, :prepare_change, 3),
          {:ok, value} <- type.prepare_change(old_value, new_value, type_constraints) do
       {:ok, %Ash.Union{type: type_name, value: value}}
+    else
+      _ ->
+        {:ok, %Ash.Union{type: type_name, value: new_value}}
     end
   end
 end

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -521,12 +521,9 @@ defmodule Ash.Type.Union do
          {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
          {:ok, type} <- Keyword.fetch(type_config, :type),
          type_constraints <- Keyword.get(type_config, :constraints, []),
-         true <- :erlang.function_exported(type, :handle_change, 3),
-         {:ok, handled_new_value} <- type.handle_change(nil, new_value, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: handled_new_value}}
-    else
-      _ ->
-        {:ok, %Ash.Union{type: type_name, value: new_value}}
+         type <- Ash.Type.get_type(type),
+         {:ok, new_value} <- type.handle_change(nil, new_value, type_constraints) do
+      {:ok, %Ash.Union{type: type_name, value: new_value}}
     end
   end
 
@@ -578,12 +575,9 @@ defmodule Ash.Type.Union do
          {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
          {:ok, type} <- Keyword.fetch(type_config, :type),
          type_constraints <- Keyword.get(type_config, :constraints, []),
-         true <- :erlang.function_exported(type, :prepare_change, 3),
-         {:ok, changed_value} <- type.prepare_change(old_value, new_value, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: changed_value}}
-    else
-      _ ->
-        {:ok, %Ash.Union{type: type_name, value: new_value}}
+         type <- Ash.Type.get_type(type),
+         {:ok, value} <- type.prepare_change(old_value, new_value, type_constraints) do
+      {:ok, %Ash.Union{type: type_name, value: value}}
     end
   end
 end

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -579,8 +579,8 @@ defmodule Ash.Type.Union do
          {:ok, type} <- Keyword.fetch(type_config, :type),
          type_constraints <- Keyword.get(type_config, :constraints, []),
          true <- :erlang.function_exported(type, :prepare_change, 3),
-         {:ok, value} <- type.prepare_change(old_value, new_value, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: value}}
+         {:ok, changed_value} <- type.prepare_change(old_value, new_value, type_constraints) do
+      {:ok, %Ash.Union{type: type_name, value: changed_value}}
     else
       _ ->
         {:ok, %Ash.Union{type: type_name, value: new_value}}

--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -84,6 +84,23 @@ defmodule Ash.Test.Type.UnionTest do
     assert {:error, _} = Ash.Type.cast_input(:union, 11, constraints)
   end
 
+  test "it handles changes between native and embedded types" do
+    constraints = [
+      types: [
+        foo: [
+          type: Foo
+          tag: :type,
+          tag_value: :foo
+        ],
+        bar: [
+          type: :string
+        ]
+      ]
+    ]
+
+    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} = Ash.Type.handle_change(%Ash.Union{type: :foo, value: %{}}, %Ash.Union{type: :bar, value: "bar"}, constraints)
+  end
+
   test "it handles tagged types" do
     constraints = [
       types: [

--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -84,11 +84,38 @@ defmodule Ash.Test.Type.UnionTest do
     assert {:error, _} = Ash.Type.cast_input(:union, 11, constraints)
   end
 
-  test "it handles changes between native and embedded types" do
+  test "it handles changes between native types" do
     constraints = [
       types: [
         foo: [
-          type: Foo
+          type: :integer
+        ],
+        bar: [
+          type: :string
+        ]
+      ]
+    ]
+
+    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} =
+             Ash.Type.Union.prepare_change(
+               %Ash.Union{type: :foo, value: 1},
+               "bar",
+               constraints
+             )
+
+    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} =
+             Ash.Type.Union.handle_change(
+               %Ash.Union{type: :foo, value: 1},
+               %Ash.Union{type: :bar, value: "bar"},
+               constraints
+             )
+  end
+
+  test "it handles changes between native and tagged types" do
+    constraints = [
+      types: [
+        foo: [
+          type: Foo,
           tag: :type,
           tag_value: :foo
         ],
@@ -98,7 +125,19 @@ defmodule Ash.Test.Type.UnionTest do
       ]
     ]
 
-    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} = Ash.Type.handle_change(%Ash.Union{type: :foo, value: %{}}, %Ash.Union{type: :bar, value: "bar"}, constraints)
+    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} =
+             Ash.Type.Union.prepare_change(
+               %Ash.Union{type: :foo, value: %Foo{}},
+               "bar",
+               constraints
+             )
+
+    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} =
+             Ash.Type.Union.handle_change(
+               %Ash.Union{type: :foo, value: %{}},
+               %Ash.Union{type: :bar, value: "bar"},
+               constraints
+             )
   end
 
   test "it handles tagged types" do


### PR DESCRIPTION
This fixes an issue that I ran into while writing edge case tests for ash_paper_trail's full diff feature.  Updating a union value to a native type (:string) error will error when calling `prepare_change` and `handle_change`.

```
     ** (UndefinedFunctionError) function :string.prepare_change/3 is undefined or private
     code: ctx.resource.update!(res, %{
     stacktrace:
       (stdlib 5.1.1) :string.prepare_change(nil, "https://www.just-a-link.com", [])
       (ash 2.15.8) lib/ash/type/union.ex:589: Ash.Type.Union.do_prepare_change/4
       (ash 2.15.8) lib/ash/changeset/changeset.ex:3433: Ash.Changeset.change_attribute/3
       (stdlib 5.1.1) maps.erl:416: :maps.fold_1/4
       (ash 2.15.8) lib/ash/changeset/changeset.ex:913: Ash.Changeset.prepare_changeset_for_action/4
       (ash 2.15.8) lib/ash/changeset/changeset.ex:875: Ash.Changeset.do_for_action/4
       (ash_paper_trail 0.1.0) deps/ash/lib/ash/code_interface.ex:562: AshPaperTrail.Test.Posts.Page.update!/3
```

Discussed briefly in Discord: https://discord.com/channels/711271361523351632/955933117573652563/1164034328548884480

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
