### PR TITLE
fix more handle change use cases

### DIFF
--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -478,51 +478,33 @@ defmodule Ash.Type.Union do
   end
 
   @impl true
-  def handle_change(nil, %Ash.Union{type: type_name, value: new_value}, constraints) do
-    with {:ok, type_configs} <- Keyword.fetch(constraints, :types),
-         {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
-         {:ok, type} <- Keyword.fetch(type_config, :type),
-         type_constraints <- Keyword.get(type_config, :constraints, []),
-         {:ok, new_value} <- type.handle_change(nil, new_value, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: new_value}}
-    end
-  end
+  def handle_change(nil, %Ash.Union{type: type_name, value: new_value}, constraints),
+    do: do_handle_change(type_name, nil, new_value, constraints)
 
-  def handle_change(%Ash.Union{type: type_name, value: old_value}, nil, constraints) do
-    with {:ok, type_configs} <- Keyword.fetch(constraints, :types),
-         {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
-         {:ok, type} <- Keyword.fetch(type_config, :type),
-         type_constraints <- Keyword.get(type_config, :constraints, []),
-         {:ok, new_value} <- type.handle_change(old_value, nil, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: new_value}}
-    end
-  end
+  def handle_change(%Ash.Union{type: type_name, value: old_value}, nil, constraints),
+    do: do_handle_change(type_name, old_value, nil, constraints)
 
   def handle_change(
         %Ash.Union{type: type_name, value: old_value},
         %Ash.Union{type: type_name, value: new_value},
         constraints
-      ) do
-    with {:ok, type_configs} <- Keyword.fetch(constraints, :types),
-         {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
-         {:ok, type} <- Keyword.fetch(type_config, :type),
-         type_constraints <- Keyword.get(type_config, :constraints, []),
-         {:ok, new_value} <- type.handle_change(old_value, new_value, type_constraints) do
-      {:ok, %Ash.Union{type: type_name, value: new_value}}
-    end
-  end
+      ),
+      do: do_handle_change(type_name, old_value, new_value, constraints)
 
   def handle_change(
         %Ash.Union{},
         %Ash.Union{type: type_name, value: new_value},
         constraints
-      ) do
+      ),
+      do: do_handle_change(type_name, nil, new_value, constraints)
+
+  defp do_handle_change(type_name, old_value, new_value, constraints) do
     with {:ok, type_configs} <- Keyword.fetch(constraints, :types),
          {:ok, type_config} <- Keyword.fetch(type_configs, type_name),
          {:ok, type} <- Keyword.fetch(type_config, :type),
          type_constraints <- Keyword.get(type_config, :constraints, []),
          type <- Ash.Type.get_type(type),
-         {:ok, new_value} <- type.handle_change(nil, new_value, type_constraints) do
+         {:ok, new_value} <- type.handle_change(old_value, new_value, type_constraints) do
       {:ok, %Ash.Union{type: type_name, value: new_value}}
     end
   end

--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -109,6 +109,27 @@ defmodule Ash.Test.Type.UnionTest do
                %Ash.Union{type: :bar, value: "bar"},
                constraints
              )
+
+    assert {:ok, %Ash.Union{type: :bar, value: "bar"}} =
+             Ash.Type.Union.handle_change(
+               nil,
+               %Ash.Union{type: :bar, value: "bar"},
+               constraints
+             )
+
+    assert {:ok, %Ash.Union{type: :bar, value: "bar2"}} =
+             Ash.Type.Union.handle_change(
+               %Ash.Union{type: :bar, value: "bar1"},
+               %Ash.Union{type: :bar, value: "bar2"},
+               constraints
+             )
+
+    assert {:ok, %Ash.Union{value: nil, type: :bar}} =
+             Ash.Type.Union.handle_change(
+               %Ash.Union{type: :bar, value: "bar1"},
+               nil,
+               constraints
+             )
   end
 
   test "it handles changes between native and tagged types" do


### PR DESCRIPTION
In my previous PR, I missed a few instances of calling `type.handle_change`.   After implementing fixes, I followed the pattern of `do_prepare_change` and DRY'd up the various scenarios.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
