### PR TITLE
docs: fix Ash.Resource.Preparation moduledoc

### DIFF
--- a/lib/ash/resource/preparation/preparation.ex
+++ b/lib/ash/resource/preparation/preparation.ex
@@ -5,8 +5,8 @@ defmodule Ash.Resource.Preparation do
   `c:init/1` is defined automatically by `use Ash.Resource.Preparation`, but can be implemented if you want to validate/transform any
   options passed to the module.
 
-  The main function is `c:prepare/3`. It takes the changeset, any options that were provided
-  when this change was configured on a resource, and the context, which currently only has
+  The main function is `c:prepare/3`. It takes the query, any options that were provided
+  when this preparation was configured on a resource, and the context, which currently only has
   the actor.
 
   To access any query arguments from within a preparation, make sure you are using `Ash.Query.get_argument/2`


### PR DESCRIPTION
It mentioned changeset and change instead of query and preparation

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
