### PR TITLE
feat: Expand upsert_fields option

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.cheatmd
+++ b/documentation/dsls/DSL:-Ash.Resource.cheatmd
@@ -4771,7 +4771,7 @@ end
       
   </td>
   <td style="text-align: left">
-    <code class="inline">list(atom)</code>
+    <code class="inline">:replace_all | {:replace, atom | list(atom)} | {:replace_all_except, atom | list(atom)} | atom | list(atom)</code>
   </td>
   <td style="text-align: left">
     

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -365,7 +365,7 @@ defmodule Ash.Api do
                             "The identity to use when detecting conflicts for `upsert?`, e.g. `upsert_identity: :full_name`. By default, the primary key is used. Has no effect if `upsert?: true` is not provided"
                         ],
                         upsert_fields: [
-                          type: {:list, :atom},
+                          type: :any,
                           doc:
                             "The fields to upsert. If not set, the action's upsert_fields is used, and if that is not set, then any fields not being set to defaults are written."
                         ]
@@ -409,7 +409,7 @@ defmodule Ash.Api do
                                doc: "Context to set on each changeset"
                              ],
                              upsert_fields: [
-                               type: {:list, :atom},
+                               type: :any,
                                doc:
                                  "The fields to upsert. If not set, the action's `upsert_fields` is used. Unlike singular `create`, `bulk_create` with `upsert?` requires that `upsert_fields` be specified explicitly in one of these two locations."
                              ],

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -365,7 +365,14 @@ defmodule Ash.Api do
                             "The identity to use when detecting conflicts for `upsert?`, e.g. `upsert_identity: :full_name`. By default, the primary key is used. Has no effect if `upsert?: true` is not provided"
                         ],
                         upsert_fields: [
-                          type: :any,
+                          type:
+                            {:or,
+                             [
+                               {:literal, :replace_all},
+                               {:tuple, [{:literal, :replace}, {:wrap_list, :atom}]},
+                               {:tuple, [{:literal, :replace_all_except}, {:wrap_list, :atom}]},
+                               {:wrap_list, :atom}
+                             ]},
                           doc:
                             "The fields to upsert. If not set, the action's upsert_fields is used, and if that is not set, then any fields not being set to defaults are written."
                         ]
@@ -409,7 +416,15 @@ defmodule Ash.Api do
                                doc: "Context to set on each changeset"
                              ],
                              upsert_fields: [
-                               type: :any,
+                               type:
+                                 {:or,
+                                  [
+                                    {:literal, :replace_all},
+                                    {:tuple, [{:literal, :replace}, {:wrap_list, :atom}]},
+                                    {:tuple,
+                                     [{:literal, :replace_all_except}, {:wrap_list, :atom}]},
+                                    {:wrap_list, :atom}
+                                  ]},
                                doc:
                                  "The fields to upsert. If not set, the action's `upsert_fields` is used. Unlike singular `create`, `bulk_create` with `upsert?` requires that `upsert_fields` be specified explicitly in one of these two locations."
                              ],

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -769,6 +769,9 @@ defmodule Ash.Changeset do
   @spec set_on_upsert(t(), list(atom)) :: Keyword.t()
   def set_on_upsert(changeset, upsert_keys) do
     case changeset.context[:private][:upsert_fields] do
+      fields when is_list(fields) ->
+        create_upsert_list(fields, changeset)
+
       {:replace, fields} ->
         create_upsert_list(fields, changeset)
 

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -167,7 +167,11 @@ defmodule Ash.DataLayer do
           upsert?: boolean,
           upsert_keys: nil | list(atom),
           upsert_fields:
-            nil | :replace_all | {:replace, list(atom)} | {:replace_all_except, list(atom)},
+            nil
+            | list(atom)
+            | :replace_all
+            | {:replace, list(atom)}
+            | {:replace_all_except, list(atom)},
           tenant: String.t() | nil
         }
 

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -166,7 +166,8 @@ defmodule Ash.DataLayer do
           return_records?: boolean,
           upsert?: boolean,
           upsert_keys: nil | list(atom),
-          upsert_fields: nil | list(atom),
+          upsert_fields:
+            nil | :replace_all | {:replace, list(atom)} | {:replace_all_except, list(atom)},
           tenant: String.t() | nil
         }
 

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -886,7 +886,7 @@ defmodule Ash.DataLayer.Ets do
       |> Enum.reduce_while({:ok, []}, fn changeset, {:ok, results} ->
         changeset =
           Ash.Changeset.set_context(changeset, %{
-            private: %{upsert_fields: options[:upsert_fields] || []}
+            private: %{upsert_fields: options[:upsert_fields] || {:replace, []}}
           })
 
         case upsert(resource, changeset, options.upsert_keys) do

--- a/lib/ash/resource/actions/create.ex
+++ b/lib/ash/resource/actions/create.ex
@@ -32,7 +32,8 @@ defmodule Ash.Resource.Actions.Create do
           delay_global_validations?: boolean,
           skip_global_validations?: boolean,
           upsert_identity: atom | nil,
-          upsert_fields: nil | list(atom),
+          upsert_fields:
+            nil | :replace_all | {:replace, list(atom)} | {:replace_all_except, list(atom)},
           allow_nil_input: list(atom),
           touches_resources: list(atom),
           arguments: list(Ash.Resource.Actions.Argument.t()),
@@ -74,7 +75,7 @@ defmodule Ash.Resource.Actions.Create do
                   """
                 ],
                 upsert_fields: [
-                  type: {:list, :atom},
+                  type: :any,
                   doc: """
                   The fields to overwrite in the case of an upsert. If not provided, all fields except for fields set by defaults will be overwritten.
                   """

--- a/lib/ash/resource/actions/create.ex
+++ b/lib/ash/resource/actions/create.ex
@@ -33,7 +33,11 @@ defmodule Ash.Resource.Actions.Create do
           skip_global_validations?: boolean,
           upsert_identity: atom | nil,
           upsert_fields:
-            nil | :replace_all | {:replace, list(atom)} | {:replace_all_except, list(atom)},
+            nil
+            | list(atom)
+            | :replace_all
+            | {:replace, list(atom)}
+            | {:replace_all_except, list(atom)},
           allow_nil_input: list(atom),
           touches_resources: list(atom),
           arguments: list(Ash.Resource.Actions.Argument.t()),
@@ -75,7 +79,14 @@ defmodule Ash.Resource.Actions.Create do
                   """
                 ],
                 upsert_fields: [
-                  type: :any,
+                  type:
+                    {:or,
+                     [
+                       {:literal, :replace_all},
+                       {:tuple, [{:literal, :replace}, {:wrap_list, :atom}]},
+                       {:tuple, [{:literal, :replace_all_except}, {:wrap_list, :atom}]},
+                       {:wrap_list, :atom}
+                     ]},
                   doc: """
                   The fields to overwrite in the case of an upsert. If not provided, all fields except for fields set by defaults will be overwritten.
                   """

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -226,7 +226,7 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                return_records?: true,
                upsert?: true,
                upsert_identity: :unique_title,
-               upsert_fields: [:title2],
+               upsert_fields: {:replace, [:title2]},
                sorted?: true
              )
   end

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -192,7 +192,46 @@ defmodule Ash.Test.Actions.BulkCreateTest do
              )
   end
 
-  test "can upsert" do
+  test "can upsert with list" do
+    assert %Ash.BulkResult{
+             records: [
+               %{title: "title1", title2: "changes", title3: "wont"},
+               %{title: "title2", title2: "changes", title3: "wont"}
+             ]
+           } =
+             Api.bulk_create!(
+               [
+                 %{title: "title1", title2: "changes", title3: "wont"},
+                 %{title: "title2", title2: "changes", title3: "wont"}
+               ],
+               Post,
+               :create,
+               return_records?: true,
+               sorted?: true
+             )
+
+    assert %Ash.BulkResult{
+             records: [
+               %{title: "title1", title2: "did_change", title3: "wont"},
+               %{title: "title2", title2: "did_change", title3: "wont"}
+             ]
+           } =
+             Api.bulk_create!(
+               [
+                 %{title: "title1", title2: "did_change", title3: "oh no"},
+                 %{title: "title2", title2: "did_change", title3: "what happened"}
+               ],
+               Post,
+               :create,
+               return_records?: true,
+               upsert?: true,
+               upsert_identity: :unique_title,
+               upsert_fields: [:title2],
+               sorted?: true
+             )
+  end
+
+  test "can upsert with :replace" do
     assert %Ash.BulkResult{
              records: [
                %{title: "title1", title2: "changes", title3: "wont"},
@@ -227,6 +266,84 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                upsert?: true,
                upsert_identity: :unique_title,
                upsert_fields: {:replace, [:title2]},
+               sorted?: true
+             )
+  end
+
+  test "can upsert with :replace_all" do
+    assert %Ash.BulkResult{
+             records: [
+               %{title: "title1", title2: "changes", title3: "changes"},
+               %{title: "title2", title2: "changes", title3: "changes"}
+             ]
+           } =
+             Api.bulk_create!(
+               [
+                 %{title: "title1", title2: "changes", title3: "changes"},
+                 %{title: "title2", title2: "changes", title3: "changes"}
+               ],
+               Post,
+               :create,
+               return_records?: true,
+               sorted?: true
+             )
+
+    assert %Ash.BulkResult{
+             records: [
+               %{title: "title1", title2: "did_change", title3: "did_change"},
+               %{title: "title2", title2: "did_change", title3: "did_change"}
+             ]
+           } =
+             Api.bulk_create!(
+               [
+                 %{title: "title1", title2: "did_change", title3: "did_change"},
+                 %{title: "title2", title2: "did_change", title3: "did_change"}
+               ],
+               Post,
+               :create,
+               return_records?: true,
+               upsert?: true,
+               upsert_identity: :unique_title,
+               upsert_fields: :replace_all,
+               sorted?: true
+             )
+  end
+
+  test "can upsert with :replace_all_except" do
+    assert %Ash.BulkResult{
+             records: [
+               %{title: "title1", title2: "changes", title3: "wont"},
+               %{title: "title2", title2: "changes", title3: "wont"}
+             ]
+           } =
+             Api.bulk_create!(
+               [
+                 %{title: "title1", title2: "changes", title3: "wont"},
+                 %{title: "title2", title2: "changes", title3: "wont"}
+               ],
+               Post,
+               :create,
+               return_records?: true,
+               sorted?: true
+             )
+
+    assert %Ash.BulkResult{
+             records: [
+               %{title: "title1", title2: "did_change", title3: "wont"},
+               %{title: "title2", title2: "did_change", title3: "wont"}
+             ]
+           } =
+             Api.bulk_create!(
+               [
+                 %{title: "title1", title2: "did_change", title3: "oh no"},
+                 %{title: "title2", title2: "did_change", title3: "what happened"}
+               ],
+               Post,
+               :create,
+               return_records?: true,
+               upsert?: true,
+               upsert_identity: :unique_title,
+               upsert_fields: {:replace_all_except, [:title, :title3]},
                sorted?: true
              )
   end

--- a/test/resource/upsert_test.exs
+++ b/test/resource/upsert_test.exs
@@ -190,5 +190,65 @@ defmodule Ash.Test.Resource.UpsertTest do
       product = Product.upsert!(%{name: "fred", other: "malfoy"})
       assert product.other == "george"
     end
+
+    test "upsert with :replace_all" do
+      product = Product.upsert!(%{name: "fred", other: "george", other_2: "hagrid"})
+      assert product.name == "fred"
+      assert product.other == "george"
+
+      product =
+        Product
+        |> Ash.Changeset.for_create(:upsert, %{name: "fred", other: "malfoy", other_2: "harry"},
+          upsert_fields: :replace_all
+        )
+        |> ProductCatalog.create!()
+
+      assert product.other == "malfoy"
+    end
+
+    test "upsert with replace list" do
+      product = Product.upsert!(%{name: "fred", other: "george"})
+      assert product.name == "fred"
+      assert product.other == "george"
+
+      product =
+        Product
+        |> Ash.Changeset.for_create(:upsert, %{name: "fred", other: "malfoy"},
+          upsert_fields: [:name]
+        )
+        |> ProductCatalog.create!()
+
+      assert product.other == "george"
+    end
+
+    test "upsert with :replace" do
+      product = Product.upsert!(%{name: "fred", other: "george"})
+      assert product.name == "fred"
+      assert product.other == "george"
+
+      product =
+        Product
+        |> Ash.Changeset.for_create(:upsert, %{name: "fred", other: "malfoy"},
+          upsert_fields: {:replace, [:name]}
+        )
+        |> ProductCatalog.create!()
+
+      assert product.other == "george"
+    end
+
+    test "upsert with :replace_all_except" do
+      product = Product.upsert!(%{name: "fred", other: "george"})
+      assert product.name == "fred"
+      assert product.other == "george"
+
+      product =
+        Product
+        |> Ash.Changeset.for_create(:upsert, %{name: "fred", other: "malfoy"},
+          upsert_fields: {:replace_all_except, [:other]}
+        )
+        |> ProductCatalog.create!()
+
+      assert product.other == "george"
+    end
   end
 end

--- a/test/resource/upsert_test.exs
+++ b/test/resource/upsert_test.exs
@@ -73,7 +73,7 @@ defmodule Ash.Test.Resource.UpsertTest do
       create :upsert do
         upsert? true
         upsert_identity :unique_name
-        upsert_fields([:name])
+        upsert_fields({:replace, [:name]})
       end
     end
 


### PR DESCRIPTION
With this change, upsert_fields accepts the following options:

* `nil`: upsert fields not set;
* `:replace_all`: all fields from resource will be updated;
* `{:replace_all_except, [fields]}`: all fields from resource except fields inside `fields` will be updated;
* `{:replace, [fields]}`: only fields inside `fields` will be updated.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
