### PR TITLE
fix: convert upsert fields before passing to data layer

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -260,7 +260,11 @@ defmodule Ash.Actions.Create.Bulk do
       private: %{
         upsert?: opts[:upsert?] || action.upsert? || false,
         upsert_identity: opts[:upsert_identity] || action.upsert_identity,
-        upsert_fields: opts[:upsert_fields] || action.upsert_fields
+        upsert_fields:
+          Ash.Changeset.expand_upsert_fields(
+            opts[:upsert_fields] || action.upsert_fields,
+            resource
+          )
       }
     })
     |> Ash.Actions.Helpers.add_context(opts)
@@ -885,7 +889,11 @@ defmodule Ash.Actions.Create.Bulk do
                     api: api,
                     upsert?: opts[:upsert?] || action.upsert?,
                     upsert_keys: upsert_keys,
-                    upsert_fields: opts[:upsert_fields] || action.upsert_fields,
+                    upsert_fields:
+                      Ash.Changeset.expand_upsert_fields(
+                        opts[:upsert_fields] || action.upsert_fields,
+                        resource
+                      ),
                     return_records?:
                       opts[:return_records?] || must_return_records? ||
                         must_return_records_for_changes?,
@@ -931,7 +939,11 @@ defmodule Ash.Actions.Create.Bulk do
                           must_return_records_for_changes?,
                       upsert?: opts[:upsert?] || action.upsert? || false,
                       upsert_keys: upsert_keys,
-                      upsert_fields: opts[:upsert_fields] || action.upsert_fields,
+                      upsert_fields:
+                        Ash.Changeset.expand_upsert_fields(
+                          opts[:upsert_fields] || action.upsert_fields,
+                          resource
+                        ),
                       tenant: opts[:tenant]
                     }
                   )

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -901,7 +901,7 @@ defmodule Ash.DataLayer.Ets do
       |> Enum.reduce_while({:ok, []}, fn changeset, {:ok, results} ->
         changeset =
           Ash.Changeset.set_context(changeset, %{
-            private: %{upsert_fields: options[:upsert_fields] || {:replace, []}}
+            private: %{upsert_fields: options[:upsert_fields] || []}
           })
 
         case upsert(resource, changeset, options.upsert_keys) do


### PR DESCRIPTION
This should fix the issue I mentiond in https://github.com/ash-project/ash_postgres/pull/179

I reverted the change in set_on_upsert introduced in https://github.com/ash-project/ash/pull/761, which is used inside the ets data_layer but wasn't used in ash_postgres. I extracted the expansion of the options into its own function and ran the options/action settings through it before it was passed to the data layers.

There are already tests that check the behaviour, but they all used the ets data_layer that handled the upsert logic using the before-mentioned function. The tests still work but now they should also work if a different data_layer is used. 