### PR TITLE
Clarify how to use Enums in attributes

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -2,12 +2,12 @@ defmodule Ash.Type.Enum do
   @moduledoc """
   A type for abstracting enums into a single type.
 
-  For example, your existing app might look like:
+  For example, your existing attribute might look like:
   ```elixir
   attribute :status, :atom, constraints: [one_of: [:open, :closed]]
   ```
 
-  But as that starts to spread around your system you may find that you want
+  But as that starts to spread around your system, you may find that you want
   to centralize that logic. To do that, use this module to define an Ash type
   easily:
 
@@ -15,6 +15,12 @@ defmodule Ash.Type.Enum do
   defmodule MyApp.TicketStatus do
     use Ash.Type.Enum, values: [:open, :closed]
   end
+  ```
+
+  Then, you can rewrite your original attribute as follows:
+
+  ```elixir
+  attribute :status, MyApp.TicketStatus
   ```
 
   Valid values are:


### PR DESCRIPTION
I was struggling for a bit with using Enums for a reason that now seems trivial, so I wanted to clarify the documentation in case anyone else would find this non-intuitive. This PR just changes the documentation to include an example of Enum usage:

```elixir
attribute :status, MyApp.TicketStatus
```

(I was originally trying to just run `attribute :status, :atom, constraints: [one_of: MyApp.TicketStatus]` instead.)