### PR TITLE
docs: Remove formatting note from Getting Started guide in favour of giving it its own guide

### DIFF
--- a/documentation/how_to/auto-format-code.md
+++ b/documentation/how_to/auto-format-code.md
@@ -1,0 +1,51 @@
+# Auto-formatting Ash code
+
+Ash comes with several utilities that can help keep your modules consistently formatted and organized.
+
+## Basic setup
+
+Add `:ash` (and any other Ash libraries you are using) to your `.formatter.exs` file:
+
+```elixir
+[
+  # ...
+  import_deps: [..., :ash],
+  # ...
+]
+```
+
+This means that when you autoformat your code, either via `mix format` or via an integration in your code editor, the exported data from Ash's `.formatter.exs` will be included and followed.
+
+It includes definitions for `locals_without_parens`, meaning that your DSL builder code such as `attribute :name, :string` won't have parentheses added (to make it `attribute(:name, :string)`) when formatting the file. The parentheses won't be removed if they currently exist, but they won't be added if missing when formatting.
+
+## Spark.Formatter
+
+For more granular formatting, you can use `Spark.Formatter`, from the `spark` library.
+
+> #### What is `spark`? {: .info}
+>
+> [`spark`](https://hexdocs.pm/spark) is a small library for building domain-specific languages (DSLs), and is what Ash itself uses internally. It provides the secret sauce to allow you to write your resources declaratively, and the editor integration so you get full autocomplete and documentation for free.
+
+Add `Spark.Formatter` as a plugin in your `.formatter.exs` file:
+
+```elixir
+[
+  # ...
+  plugins: [..., Spark.Formatter]
+  # ...
+]
+```
+
+By itself, `Spark.Formatter` doesn't do much - but it is configurable.
+
+The most common configuration is to remove _all_ extra parentheses from your DSL builder code - this is how the examples within Ash documentation is formatted.
+
+To enable this, add the following line to your application config in `config.exs`:
+
+```elixir
+config :spark, :formatter, remove_parens?: true, "Ash.Resource": []
+```
+
+This tells Spark that it should remove parenthesis from all modules that use `Ash.Resource`, following the `locals_without_parens` rules exported from all your dependencies (and any you may have added yourself).
+
+`Spark.Formatter` has more configuration available - check the documentation for more details!

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -1,6 +1,7 @@
 # Get Started
 
 <!--- ash-hq-hide-start --> <!--- -->
+
 > #### HexDocs {: .tip}
 >
 > Hexdocs does not support multi-package search. To assist with this, we provide a mirror of this documentation at [ash-hq.org](https://ash-hq.org). Use Ctrl+K or Cmd+K to search all packages on that site. For the best way to use the hex documentation, see the [hexdocs guide](/documentation/tutorials/using-hexdocs.md).
@@ -14,7 +15,7 @@ The Livebook tutorial is self contained and separate from the documentation belo
 
 [![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fash-project%2Fash_tutorial%2Fblob%2Fmaster%2Foverview.livemd)
 
-##  Watch the ElixirConf Talk
+## Watch the ElixirConf Talk
 
 <iframe width="560" height="315" class="rounded-xl w-full aspect-video" src="https://www.youtube.com/embed/c4iou77kOFc?si=gxPdzGng5cQTrr7P" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
@@ -89,19 +90,6 @@ defp deps do
     {:ash, "~> 2.17.7"} # <-- add this line
   ]
 end
-```
-
-Add `:ash` to your `.formatter.exs` file
-
-```elixir
-# Used by "mix format"
-[
-  import_deps: [:ash], # <-- add this line, if you have more import_deps, just add it within the list
-  inputs: [
-    "{mix,.formatter}.exs",
-    "{config,lib,test}/**/*.{ex,exs}"
-  ]
-]
 ```
 
 And run `mix deps.get`

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -80,7 +80,7 @@ Open the project in your text editor, and we'll get started.
 
 ### Add Ash to your application
 
-Add the ash dependency to your `mix.exs`
+Add the `ash` dependency to your `mix.exs`
 
 ```elixir
 defp deps do
@@ -92,7 +92,21 @@ defp deps do
 end
 ```
 
-And run `mix deps.get`
+To ensure that your code stays formatted like the examples here, you can add `:ash` as an import dependency in your `.formatter.exs`:
+
+```elixir
+[
+  # ...
+  import_deps: [..., :ash],
+  # ...
+]
+```
+
+> #### Note {: .neutral}
+>
+> For more auto-formatting options, see the [Auto-Format Code guide](/how_to/auto-format-code.md).
+
+And run `mix deps.get`, to install the dependency.
 
 ### Building your first Ash API
 


### PR DESCRIPTION
After getting tripped up on this several times, I figured it was worthy of its own guide! (I always forget to add the formatter config)

I figure other Ash library documentation can be updated to point to this guide, to be the source of truth for how to auto-format stuff.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
