### PR TITLE
docs: Fill out shortdoc for `generate_policy_charts` mix task

### DIFF
--- a/lib/mix/tasks/generate_policy_chart.ex
+++ b/lib/mix/tasks/generate_policy_chart.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Ash.GeneratePolicyCharts do
 
   @recursive true
 
-  @shortdoc "Generates "
+  @shortdoc "Generates a Mermaid Flow Chart for a given resource's policies."
   def run(argv) do
     Mix.Task.run("compile")
 


### PR DESCRIPTION
This is the one-liner that is shown when running `mix help` to list tasks

Currently it looks like:

<img width="858" alt="Screenshot 2023-12-20 at 11 45 15 am" src="https://github.com/ash-project/ash/assets/543859/07507a3d-621e-4f81-9c26-c8adeb83bda7">

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
