### PR TITLE
fix: only put keywords to be interpolated in message in error vars

### DIFF
--- a/lib/ash/error/exception.ex
+++ b/lib/ash/error/exception.ex
@@ -55,7 +55,11 @@ defmodule Ash.Error.Exception do
             }
           end)
 
-        super(opts)
+        super(opts) |> Map.update(:vars, [], &clean_vars/1)
+      end
+
+      defp clean_vars(vars) do
+        vars |> Keyword.drop([:field, :message, :path])
       end
 
       defoverridable exception: 1, message: 1

--- a/lib/ash/error/exception.ex
+++ b/lib/ash/error/exception.ex
@@ -59,7 +59,7 @@ defmodule Ash.Error.Exception do
       end
 
       defp clean_vars(vars) do
-        vars |> Keyword.drop([:field, :message, :path])
+        vars |> Kernel.||([]) |> Keyword.drop([:field, :message, :path])
       end
 
       defoverridable exception: 1, message: 1

--- a/lib/ash/type/keyword.ex
+++ b/lib/ash/type/keyword.ex
@@ -175,7 +175,7 @@ defmodule Ash.Type.Keyword do
             {:ok, [{field, field_value} | result]}
 
           {:error, errors} ->
-            {:error, Enum.map(errors, fn error -> [field: field, message: error[:message]] end)}
+            {:error, Enum.map(errors, fn error -> Keyword.put(error, :field, field) end)}
         end
 
       :error ->

--- a/lib/ash/type/map.ex
+++ b/lib/ash/type/map.ex
@@ -154,7 +154,7 @@ defmodule Ash.Type.Map do
             {:ok, Map.put(result, field, field_value)}
 
           {:error, errors} ->
-            {:error, Enum.map(errors, fn error -> [field: field, message: error[:message]] end)}
+            {:error, Enum.map(errors, fn error -> Keyword.put(error, :field, field) end)}
         end
 
       :error ->

--- a/test/calculations/calculation_test.exs
+++ b/test/calculations/calculation_test.exs
@@ -978,7 +978,6 @@ defmodule Ash.Test.CalculationTest do
              |> Enum.map(& &1.active)
   end
 
-  @tag :focus
   test "aggregates using calculations pass actor to calculations", %{
     user1: user,
     actor1: actor,

--- a/test/type/keyword_test.exs
+++ b/test/type/keyword_test.exs
@@ -122,7 +122,7 @@ defmodule Type.KeywordTest do
                changeset: nil,
                query: nil,
                error_context: [],
-               vars: [field: :foo, message: "field must be present", path: [:metadata]],
+               vars: [],
                path: [:metadata]
              }
            ] = changeset.errors
@@ -146,11 +146,7 @@ defmodule Type.KeywordTest do
                changeset: nil,
                query: nil,
                error_context: [],
-               vars: [
-                 field: :bar,
-                 message: "must be more than or equal to %{min}",
-                 path: [:metadata]
-               ],
+               vars: [min: 0],
                path: [:metadata]
              }
            ] = changeset.errors
@@ -200,7 +196,7 @@ defmodule Type.KeywordTest do
                changeset: nil,
                query: nil,
                error_context: [],
-               vars: [field: :foo, message: "value must not be nil", path: [:metadata]],
+               vars: [],
                path: [:metadata]
              }
            ] = changeset.errors

--- a/test/type/map_test.exs
+++ b/test/type/map_test.exs
@@ -124,7 +124,7 @@ defmodule Type.MapTest do
                changeset: nil,
                query: nil,
                error_context: [],
-               vars: [field: :foo, message: "field must be present", path: [:metadata]],
+               vars: [],
                path: [:metadata]
              }
            ] = changeset.errors
@@ -148,11 +148,7 @@ defmodule Type.MapTest do
                changeset: nil,
                query: nil,
                error_context: [],
-               vars: [
-                 field: :bar,
-                 message: "must be more than or equal to %{min}",
-                 path: [:metadata]
-               ],
+               vars: [min: 0],
                path: [:metadata]
              }
            ] = changeset.errors
@@ -202,7 +198,7 @@ defmodule Type.MapTest do
                changeset: nil,
                query: nil,
                error_context: [],
-               vars: [field: :foo, message: "value must not be nil", path: [:metadata]],
+               vars: [],
                path: [:metadata]
              }
            ] = changeset.errors


### PR DESCRIPTION
This PR resolves #820 – I think I found and fixed this in all places it was occurring.

During the course of this work, I [discovered](https://github.com/ash-project/ash/compare/main...ahey:error-vars?expand=1#diff-32cc05145e05358ce83d202848ab062c4748ca83784a0f6a7e1854f5aac02594R151) and fixed another issue ([here](https://github.com/ash-project/ash/compare/main...ahey:error-vars?expand=1#diff-5c6d681025e312c3caa3d2600b733fa250caa0878be36aa94a6f49b5aeeaa078R157) and [here](https://github.com/ash-project/ash/compare/main...ahey:error-vars?expand=1#diff-9b75dd399fae543dfa8cd09e97e8e6c11a969c91aa1f7d83b85631ff0cc52670R178)) where `vars` was missing a keyword to be interpolated into the error string.

A few tests were incorrectly expecting the superflouous keywords to be included in vars. These have been updated, and the suite is now passing, as well as our product's test suite.