### PR TITLE
Misc metadata doc improvement

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.md
+++ b/documentation/dsls/DSL:-Ash.Resource.md
@@ -1048,7 +1048,7 @@ metadata name, type
 
 
 A special kind of attribute that is only added to specific actions. Nothing sets this value, it must be set in a custom
-change via `Ash.Resource.Info.put_metadata/3`.
+change via `Ash.Resource.put_metadata/3`.
 
 
 
@@ -1256,7 +1256,7 @@ metadata name, type
 
 
 A special kind of attribute that is only added to specific actions. Nothing sets this value, it must be set in a custom
-change via `Ash.Resource.Info.put_metadata/3`.
+change via `Ash.Resource.put_metadata/3`.
 
 
 
@@ -1447,7 +1447,7 @@ metadata name, type
 
 
 A special kind of attribute that is only added to specific actions. Nothing sets this value, it must be set in a custom
-change via `Ash.Resource.Info.put_metadata/3`.
+change via `Ash.Resource.put_metadata/3`.
 
 
 
@@ -1685,7 +1685,7 @@ metadata name, type
 
 
 A special kind of attribute that is only added to specific actions. Nothing sets this value, it must be set in a custom
-change via `Ash.Resource.Info.put_metadata/3`.
+change via `Ash.Resource.put_metadata/3`.
 
 
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -357,7 +357,7 @@ defmodule Ash.Resource.Dsl do
     name: :metadata,
     describe: """
     A special kind of attribute that is only added to specific actions. Nothing sets this value, it must be set in a custom
-    change via `Ash.Resource.Info.put_metadata/3`.
+    change after_action hook via `Ash.Resource.put_metadata/3`.
     """,
     examples: [
       """


### PR DESCRIPTION
The `Ash.Resource.Info.put_metadata` => `Ash.Resource.put_metadata`, and noting that you'll most likely want to set metadata in a change `after_action` hook when the result is present.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
