### PR TITLE
feat: Allow `:self` as an option when requesting a relative page from a given page

### DIFF
--- a/documentation/topics/pagination.md
+++ b/documentation/topics/pagination.md
@@ -39,7 +39,7 @@ Next/previous page requests can also be made in memory, using an existing page o
 {:ok, third_page} = Resource.read(page: [limit: 10, offset: 20])
 
 # Use `:prev` and `:next` to go backwards and forwards.
-# `:first`, `:last` and specifying a page number are also supported.
+# `:first`, `:last`, `:self` and specifying a page number are also supported.
 {:ok, second_page} = Api.page(third_page, :prev)
 {:ok, fourth_page} = Api.page(third_page, :next)
 ```
@@ -91,7 +91,7 @@ Like offset pagination, next/previous page requests can also be made in memory, 
 {:ok, third_page} = Resource.read(page: [limit: 10])
 
 # Use `:prev` and `:next` to go backwards and forwards.
-# `:first` can also be used, but `:last` and specifying a page number are not supported.
+# `:first` and `:self` can also be used, but `:last` and specifying a page number are not supported.
 {:ok, second_page} = Api.page(third_page, :prev)
 {:ok, fourth_page} = Api.page(third_page, :next)
 ```

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -65,7 +65,7 @@ defmodule Ash.Api do
   @type t() :: module
 
   @type page_request ::
-          :next | :prev | :first | :last | integer
+          :next | :prev | :first | :last | :self | integer
 
   @global_opts [
     internal?: [
@@ -2065,6 +2065,10 @@ defmodule Ash.Api do
     read(api, query, Keyword.put(opts, :page, page_opts))
   end
 
+  def page(api, %Ash.Page.Keyset{rerun: {query, opts}}, :self) do
+    read(api, query, opts)
+  end
+
   def page(
         api,
         %Ash.Page.Offset{count: count, limit: limit, offset: offset, rerun: {query, opts}},
@@ -2087,6 +2091,9 @@ defmodule Ash.Api do
           else
             [offset: 0, limit: limit]
           end
+
+        :self ->
+          opts[:page]
 
         page_num when is_integer(page_num) ->
           [offset: (page_num - 1) * limit, limit: limit]

--- a/test/actions/pagination_test.exs
+++ b/test/actions/pagination_test.exs
@@ -269,6 +269,17 @@ defmodule Ash.Actions.PaginationTest do
 
       assert %{results: [%{name: "0"}]} = Api.page!(page, :last)
     end
+
+    test "the same page can be re-fetched" do
+      assert %{results: [%{name: "3"}]} =
+               page =
+               User
+               |> Ash.Query.sort(name: :desc)
+               |> Ash.Query.filter(name in ["4", "3", "2", "1", "0"])
+               |> Api.read!(page: [offset: 1, limit: 1, count: true])
+
+      assert %{results: [%{name: "3"}]} = Api.page!(page, :self)
+    end
   end
 
   describe "keyset pagination with nil fields" do
@@ -804,6 +815,18 @@ defmodule Ash.Actions.PaginationTest do
 
       assert %{results: [%{name: "3"}]} = page = Api.page!(page, :next)
       assert %{results: [%{name: "4"}]} = Api.page!(page, :first)
+    end
+
+    test "the same page can be re-fetched" do
+      assert %{results: [%{name: "4"}]} =
+               page =
+               User
+               |> Ash.Query.sort(name: :desc)
+               |> Ash.Query.filter(name in ["4", "3", "2", "1", "0"])
+               |> Api.read!(page: [limit: 1])
+
+      assert %{results: [%{name: "3"}]} = page = Api.page!(page, :next)
+      assert %{results: [%{name: "3"}]} = Api.page!(page, :self)
     end
 
     test "the prev request right after the initial query remains the same as the initial result (like offset pagination)" do


### PR DESCRIPTION
This will re-run the same query that was used to fetch the given page, updating the data in it

I was hoping there would be some tests for the existing options that I could copy and modify, but there were not :( I manually tested it with both offset and keyset pagination, and they both behaved as expected.

### Use case:

When viewing a page of data in a web browser, and then deleting a record on it, reloading the page (data page, not web page) will correctly shift the data up/down to fill the gap.