### PR TITLE
fix: add page opts to context again

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -255,7 +255,7 @@ defmodule Ash.Actions.Read do
           count,
           query.sort,
           query,
-          opts
+          Keyword.put(opts, :page, query.context[:page_opts])
         )
         |> add_query(query, opts)
       else

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -254,7 +254,7 @@ defmodule Ash.Actions.Read do
           count,
           query.sort,
           query,
-          Keyword.put(opts, :page, query.context[:page_opts] || opts[:page])
+          opts
         )
         |> add_query(query, opts)
       else

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -254,7 +254,7 @@ defmodule Ash.Actions.Read do
           query.action,
           count,
           query.sort,
-          Map.get(query.context[:page_opts] || %{}, inital_query, query),
+          Map.get(query.context[:page_opts] || %{}, :inital_query, query),
           Keyword.put(opts, :page, query.context[:page_opts] || opts[:page])
         )
         |> add_query(query, opts)

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -254,7 +254,7 @@ defmodule Ash.Actions.Read do
           query.action,
           count,
           query.sort,
-          Map.get(query.context[:page_opts] || %{}, :inital_query, query),
+          query,
           Keyword.put(opts, :page, query.context[:page_opts] || opts[:page])
         )
         |> add_query(query, opts)

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -136,7 +136,6 @@ defmodule Ash.Actions.Read do
       )
 
     page_opts = page_opts(action, opts)
-    opts = Keyword.put(opts, :page, page_opts)
 
     query =
       if opts[:page] do
@@ -154,6 +153,8 @@ defmodule Ash.Actions.Read do
       else
         query
       end
+
+    opts = Keyword.put(opts, :page, page_opts)
 
     query =
       if opts[:page] && opts[:page][:limit] &&

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -254,8 +254,8 @@ defmodule Ash.Actions.Read do
           query.action,
           count,
           query.sort,
-          query,
-          Keyword.put(opts, :page, query.context[:page_opts])
+          Map.get(query.context[:page_opts] || %{}, inital_query, query),
+          Keyword.put(opts, :page, query.context[:page_opts] || opts[:page])
         )
         |> add_query(query, opts)
       else


### PR DESCRIPTION
Add the pagination info to the context again, like in the old implementation:

* https://github.com/ash-project/ash/blob/ff1a590f46e750422920b4dc200fc6d3329b420c/lib/ash/actions/read.ex#L386
*  https://github.com/ash-project/ash/blob/ff1a590f46e750422920b4dc200fc6d3329b420c/lib/ash/actions/read.ex#L498

I don't know if this is right in the new implementation, especially the call to add_page and passing the values there.

I do not understand the code completely at the moment, to be honest ;)  I'm a bit confused about the context values only being used for add_page and not the pagination itself, but that was already the case in the old implementation.

I need to familiarise myself with the code a bit more in the future. 