### PR TITLE
fix: do not check primary key fields in filter

### DIFF
--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -774,7 +774,7 @@ defmodule Ash.Policy.Authorizer do
 
     {expr, authorizer} =
       if field in Ash.Resource.Info.primary_key(resource) do
-        # primary key doesn't have policies on it, and so is nil here
+        # primary keys are always accessible
         {true, authorizer}
       else
         policies = Ash.Policy.Info.field_policies_for_field(resource, field)
@@ -838,7 +838,7 @@ defmodule Ash.Policy.Authorizer do
     pkey = Ash.Resource.Info.primary_key(query_or_changeset.resource)
 
     accessing_fields
-    # primary key doesn't are always accessible
+    # primary keys are always accessible
     |> Enum.reject(&(&1 in pkey))
     |> dbg()
     |> Enum.group_by(fn field ->

--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -840,7 +840,6 @@ defmodule Ash.Policy.Authorizer do
     accessing_fields
     # primary keys are always accessible
     |> Enum.reject(&(&1 in pkey))
-    |> dbg()
     |> Enum.group_by(fn field ->
       Ash.Policy.Info.field_policies_for_field(query_or_changeset.resource, field)
     end)

--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -827,12 +827,18 @@ defmodule Ash.Policy.Authorizer do
   @impl true
   def add_calculations(query_or_changeset, authorizer, _context) do
     accessing_fields =
-      case query_or_changeset do
-        %Ash.Query{} = query ->
-          Ash.Query.accessing(query, [:attributes, :calculations, :aggregates])
+      if Ash.Policy.Info.field_policies(query_or_changeset.resource) == [] do
+        # If there are no field policies, access is allowed by default
+        # and we don't need to add any calculations
+        []
+      else
+        case query_or_changeset do
+          %Ash.Query{} = query ->
+            Ash.Query.accessing(query, [:attributes, :calculations, :aggregates])
 
-        %Ash.Changeset{} = changeset ->
-          Ash.Changeset.accessing(changeset, [:attributes, :calculations, :aggregates])
+          %Ash.Changeset{} = changeset ->
+            Ash.Changeset.accessing(changeset, [:attributes, :calculations, :aggregates])
+        end
       end
 
     pkey = Ash.Resource.Info.primary_key(query_or_changeset.resource)


### PR DESCRIPTION
I had a test in my project error out because the pagination added the `id` as a filter `id > last_entry_from_last_page_id` and primary keys do not have field policies if I'm not mistaken. 
