### PR TITLE
fix: make sure query has action

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -155,6 +155,14 @@ defmodule Ash.Actions.Read.Relationships do
 
           through_query =
             relationship.through
+            |> Ash.Query.for_read(
+              relationship.read_action ||
+                Ash.Resource.Info.primary_action!(relationship.through, :read).name,
+              %{},
+              authorize?: source_query.context[:private][:authorize?],
+              actor: source_query.context[:private][:actor],
+              tracer: source_query.context[:private][:tracer]
+            )
             |> Ash.Query.set_context(%{
               accessing_from: %{source: relationship.source, name: relationship.join_relationship}
             })


### PR DESCRIPTION
Without the action name, I ran into an exception in the policy logger:

https://github.com/ash-project/ash/blob/189c6659c17baca46ab95a8e0fad6d88756849e8/lib/ash/policy/authorizer/authorizer.ex#L1182