### PR TITLE
Update Ash.Type.Float to accommodate constraints/0

### DIFF
--- a/lib/ash/type/float.ex
+++ b/lib/ash/type/float.ex
@@ -24,7 +24,8 @@ defmodule Ash.Type.Float do
   @impl true
   def storage_type(_), do: :float
 
-  def constraints(_), do: @constraints
+  @impl true
+  def constraints, do: @constraints
 
   @doc false
   def float(value) do


### PR DESCRIPTION
Update Ash.Type.Float to accommodate `constraints/0` instead of `constraints/1`