### PR TITLE
fix: union merge load logic

### DIFF
--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -244,6 +244,9 @@ defmodule Ash.Type.Union do
         end
 
       case merged do
+        {:ok, ^acc} ->
+          {:cont, {:ok, acc}}
+
         {:ok, merged} ->
           {:cont, {:ok, Keyword.put(acc, name, merged)}}
 


### PR DESCRIPTION
before it was adding the acc as the load for a union type that had no loads. 
