### PR TITLE
Add 'use Ash.Resource.Validation' to Custom Validation example

### DIFF
--- a/documentation/topics/validations.md
+++ b/documentation/topics/validations.md
@@ -24,6 +24,10 @@ end
 ```elixir
 defmodule MyApp.Validations.IsPrime do
   # transform and validate opts
+
+  use Ash.Resource.Validation
+
+  @impl true
   def init(opts) do
     if is_atom(opts[:attribute]) do
       {:ok, opts}
@@ -32,6 +36,7 @@ defmodule MyApp.Validations.IsPrime do
     end
   end
 
+  @impl true
   def validate(changeset, opts) do
     value = Ash.Changeset.get_attribute(changeset, opts[:attribute])
     # this is a function I made up for example


### PR DESCRIPTION
Save others a few minutes of confusion when they copy the example and it eventually bombs out when used by a custom action
