### PR TITLE
improvement: add `join_keys` option to `manage_relationship`

### DIFF
--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -1441,6 +1441,10 @@ defmodule Ash.Actions.ManagedRelationships do
     {metadata[:join_keys] || %{}, input}
   end
 
+  defp split_join_keys(input, []) do
+    {%{}, input}
+  end
+
   defp split_join_keys(input, :all) do
     {input, %{}}
   end

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -3277,7 +3277,7 @@ defmodule Ash.Changeset do
       * `:ignore` (default) - those inputs are ignored
       * `:destroy` - the record is destroyed using the destination's primary destroy action
       * `{:destroy, :action_name}` - the record is destroyed using the specified action on the destination resource
-      * `{:destroy, :action_name, :join_resource_action_name, [:join, :keys]}` - the record is destroyed using the specified action on the destination resource,
+      * `{:destroy, :action_name, :join_resource_action_name}` - the record is destroyed using the specified action on the destination resource,
         but first the join resource is destroyed with its specified action
       * `:error`  - an error is returned indicating that a record would have been updated
       * `:unrelate` - the related item is not destroyed, but the data is "unrelated", making this behave like `remove_from_relationship/3`. The action should be:
@@ -3299,6 +3299,14 @@ defmodule Ash.Changeset do
       If you want to modify this path, you can specify `error_path`, e.g if had a `change` on an action that takes an argument
       and uses that argument data to call `manage_relationship`, you may want any generated errors to appear under the name of that
       argument, so you could specify `error_path: :argument_name` when calling `manage_relationship`.
+      """
+    ],
+    join_keys: [
+      type: {:list, :atom},
+      doc: """
+      For many to many relationships specifies the parameters to pick from the input and pass into a join resource action.
+      Applicable in cases like `on_no_match: :create`, `on_match: :update` and `on_lookup: :relate`.
+      Can be overwritten by a full form instruction tuple which contains join parameters at the end.
       """
     ],
     meta: [


### PR DESCRIPTION
Idea is to allow this for many to many:
```elixir
[
  on_match: :update,
  on_lookup: :relate,
  on_no_match: :create,
  join_keys: [:some, :key],
]
```
With the same meaning as this:
```elixir
[
  on_match: {:update, :update, :update, [:some, :key]},
  on_lookup: {:relate, :create, :read, [:some, :key]},
  on_no_match: {:create, :create, :create, [:some, :key]},
]
```

Additional things:

- Cleaned up `ManagedRelationshipHelpers.sanitize_opts` - made variable names and white space usage consistent. Added a missing case for `on_no_match: {:create, create, join_create}` and removed one redundant case in `on_lookup`. In  `:on_lookup` `primary_action_name` method was used to get an action name unlike other ones which were using `Ash.Resource.Info.primary_action!`. The difference is that the latter is throwing and former is not. For consistency I converted all calls to throwing ones. Except for update action in `on_lookup: :relate` for `belongs_to` relationship. Seems like that combo does not actually need an update action. Or does it?

- Added clause for `defp split_join_keys(input, [])` - I assume it is most common one so makes sense to simplify.

- Removed mention of `[:join, :keys]` from `on_missing: :destroy` full form documentation. It does not support it.
