### PR TITLE
chore: continue update validate_related_resource_inclusion.ex

### DIFF
--- a/lib/ash/registry/extensions/resource_validations/verifiers/validate_related_resource_inclusion.ex
+++ b/lib/ash/registry/extensions/resource_validations/verifiers/validate_related_resource_inclusion.ex
@@ -60,7 +60,7 @@ defmodule Ash.Registry.ResourceValidations.Verifiers.ValidateRelatedResourceIncl
 
                 many_to_many :#{relationship.name}, #{inspect(relationship.destination)} do
                   ...
-                  join_relationship_name :your_new_name
+                  join_relationship :your_new_name
                 end
             """
           else


### PR DESCRIPTION
Continues  #870.

Saw the PR - looked if `join_relationship_name` is mentioned anywhere else and the exact same thing was in another place.