### PR TITLE
improvement: add `on_match: :update_join` to `manage_relationship`

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -3249,7 +3249,10 @@ defmodule Ash.Changeset do
       * `:update` - the record is updated using the destination's primary update action
       * `{:update, :action_name}` - the record is updated using the specified action on the destination resource
       * `{:update, :action_name, :join_table_action_name, [:list, :of, :params]}` - Same as `{:update, :action_name}` but takes
-          the list of params specified out and applies them as an update to the join record (only valid for many to many).
+          the list of params specified out and applies them as an update to the join record (only valid for many to many)
+      * `:update_join` - update only the join record (only valid for many to many)
+      * `{:update_join, :join_table_action_name}` - use the specified update action on a join resource
+      * `{:update_join, :join_table_action_name, [:list, :of, :params]}` - pass specified params from input into a join resource update action
       * `{:destroy, :action_name}` - the record is destroyed using the specified action on the destination resource. The action should be:
         * `many_to_many` - a destroy action on the join record
         * `has_many` - a destroy action on the destination resource

--- a/lib/ash/changeset/managed_relationship_helpers.ex
+++ b/lib/ash/changeset/managed_relationship_helpers.ex
@@ -84,6 +84,16 @@ defmodule Ash.Changeset.ManagedRelationshipHelpers do
         update = primary_action_name!(relationship.destination, :update)
         {:update, update}
 
+      :update_join ->
+        join_update = primary_action_name!(relationship.through, :update)
+        {:update, nil, join_update, join_keys}
+
+      {:update_join, join_update} ->
+        {:update, nil, join_update, join_keys}
+
+      {:update_join, join_update, join_keys} ->
+        {:update, nil, join_update, join_keys}
+
       :unrelate when is_many_to_many ->
         join_destroy = primary_action_name!(relationship.through, :destroy)
         {:unrelate, join_destroy}


### PR DESCRIPTION
Support for updating only join resource in `manage_relationship` without updating destination one in many to many.

Can be specified as `:update_join`, `{:update_join, :action_name}` or `{:update_join, :action_name, [:join, :param]}`.

Under the hood it just gets transformed into `{:update, nil, :action_name, [:join, :param]}`. So the PR adds such alias and checks if an update action for destination is nil or not before doing it.

I will need to add it to documentation and ideally a test. But first want to confirm that such implementation is acceptable. Because it adds support for `{:update, nil}` (for many to many only, as an alternative way to do the same thing) but that's the least disrupting way to add the feature. The code is simple.

Note: saw [a wrong line](https://github.com/ash-project/ash/blob/d47eb086a254a4ada965ae1d90f0be4abc857deb/lib/ash/actions/managed_relationships.ex#L1301) and added a fix (at least in a way that I assume it is intended) for it here.