### PR TITLE
docs: Correct example used for manual actions

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.md
+++ b/documentation/dsls/DSL:-Ash.Resource.md
@@ -776,7 +776,7 @@ For calling this action, see the `Ash.Api` documentation.
 action :top_user_emails, {:array, :string} do
   argument :limit, :integer, default: 10, allow_nil?: false
   run fn input, context ->
-    with {:ok, top_users} <- top_users(input.limit) do
+    with {:ok, top_users} <- top_users(input.arguments.limit) do
       {:ok, Enum.map(top_users, &(&1.email))}
     end
   end

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -437,7 +437,7 @@ defmodule Ash.Resource.Dsl do
       action :top_user_emails, {:array, :string} do
         argument :limit, :integer, default: 10, allow_nil?: false
         run fn input, context ->
-          with {:ok, top_users} <- top_users(input.limit) do
+          with {:ok, top_users} <- top_users(input.arguments.limit) do
             {:ok, Enum.map(top_users, &(&1.email))}
           end
         end


### PR DESCRIPTION
In my testing, arguments to a manual action are part of the `arguments` in the input to the `run` function - which is the action struct itself.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
