### PR TITLE
fix: handle warning about incompatible types

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -2525,7 +2525,7 @@ defmodule Ash.Filter do
           nil ->
             add_expression_part({function, [args]}, context, expression)
 
-          resource_calculation ->
+          resource_calculation when tuple_size(args) == 2 ->
             {module, opts} = resource_calculation.calculation
             {args, nested_statement} = args
 


### PR DESCRIPTION
Saw a warning about incompatible types about changes in my previous PR - #891:

```
warning: incompatible types:

    tuple() !~ {var1, var2}

in expression:

    # lib/ash/filter/filter.ex:2530
    {args, nested_statement} = args

hint: use pattern matching or "is_tuple(args) and tuple_size(args) == 2" to guard a sized tuple.
```

Added a guard to address the warning.