### PR TITLE
chore: format some `with` clauses to be on a single line

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -278,8 +278,7 @@ defmodule Ash.Actions.Read do
 
   defp do_read(%{action: action} = query, calculations_at_runtime, calculations_in_query, opts) do
     maybe_in_transaction(query, opts, fn ->
-      with %{valid?: true} = query <-
-             handle_attribute_multitenancy(query),
+      with %{valid?: true} = query <- handle_attribute_multitenancy(query),
            :ok <- validate_multitenancy(query),
            {:ok, sort} <-
              Ash.Actions.Sort.process(
@@ -293,8 +292,7 @@ defmodule Ash.Actions.Read do
            pre_authorization_query <- query,
            {:ok, query} <- authorize_query(query, opts),
            query_before_pagination <- query,
-           {:ok, query} <-
-             paginate(query, action, opts[:page], opts[:skip_pagination?]),
+           {:ok, query} <- paginate(query, action, opts[:page], opts[:skip_pagination?]),
            query <-
              Ash.Actions.Read.Calculations.deselect_known_forbidden_fields(
                query,
@@ -368,13 +366,10 @@ defmodule Ash.Actions.Read do
                query.resource,
                query
              ),
-           :ok <-
-             validate_get(results, query.action, query),
+           :ok <- validate_get(results, query.action, query),
            results <- add_keysets(query, results, query.sort),
-           {:ok, results} <-
-             run_authorize_results(query, results),
-           {:ok, results, after_notifications} <-
-             run_after_action(query, results),
+           {:ok, results} <- run_authorize_results(query, results),
+           {:ok, results, after_notifications} <- run_after_action(query, results),
            {:ok, count} <- maybe_await(count) do
         {:ok, results, count, before_notifications ++ after_notifications}
       else
@@ -1997,10 +1992,8 @@ defmodule Ash.Actions.Read do
          path_filters,
          prefix
        ) do
-    with {:ok, left} <-
-           do_filter_with_related(resource, left, path_filters, prefix),
-         {:ok, right} <-
-           do_filter_with_related(resource, right, path_filters, prefix) do
+    with {:ok, left} <- do_filter_with_related(resource, left, path_filters, prefix),
+         {:ok, right} <- do_filter_with_related(resource, right, path_filters, prefix) do
       {:ok, Ash.Query.BooleanExpression.optimized_new(:or, left, right)}
     end
   end

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -1431,8 +1431,7 @@ defmodule Ash.Api do
             calculation: {module, calc_opts},
             type: type,
             constraints: constraints
-          }} <-
-           {:calc, Ash.Resource.Info.calculation(resource, calculation)},
+          }} <- {:calc, Ash.Resource.Info.calculation(resource, calculation)},
          record <- struct(record || resource, opts[:refs] || %{}) do
       calc_context =
         opts[:context]

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -525,8 +525,7 @@ defmodule Ash.Changeset do
         )
 
       with :ok <- verify_notifiers_support_atomic(resource, action),
-           %Ash.Changeset{} = changeset <-
-             atomic_update(changeset, opts[:atomic_update] || []),
+           %Ash.Changeset{} = changeset <- atomic_update(changeset, opts[:atomic_update] || []),
            %Ash.Changeset{} = changeset <- atomic_params(changeset, action, params, opts),
            %Ash.Changeset{} = changeset <- atomic_changes(changeset, action) do
         hydrate_atomic_refs(changeset, opts[:actor], Keyword.take(opts, [:eager?]))

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -361,17 +361,14 @@ defmodule Ash.DataLayer.Ets do
         parent \\ nil
       ) do
     with {:ok, records} <- get_records(resource, tenant),
-         {:ok, records} <-
-           filter_matches(records, filter, api, parent),
+         {:ok, records} <- filter_matches(records, filter, api, parent),
          records <- Sort.runtime_sort(records, distinct_sort || sort, api: api),
          records <- Sort.runtime_distinct(records, distinct, api: api),
          records <- Sort.runtime_sort(records, sort, api: api),
          records <- Enum.drop(records, offset || []),
          records <- do_limit(records, limit),
-         {:ok, records} <-
-           do_add_aggregates(records, api, resource, aggregates),
-         {:ok, records} <-
-           do_add_calculations(records, resource, calculations, api) do
+         {:ok, records} <- do_add_aggregates(records, api, resource, aggregates),
+         {:ok, records} <- do_add_calculations(records, resource, calculations, api) do
       {:ok, records}
     else
       {:error, error} ->
@@ -651,10 +648,8 @@ defmodule Ash.DataLayer.Ets do
                      [record],
                      api
                    ),
-                 {:ok, filtered} <-
-                   filter_matches(related, query.filter, api),
-                 sorted <-
-                   Sort.runtime_sort(filtered, query.sort, api: api) do
+                 {:ok, filtered} <- filter_matches(related, query.filter, api),
+                 sorted <- Sort.runtime_sort(filtered, query.sort, api: api) do
               field = field || Enum.at(Ash.Resource.Info.primary_key(query.resource), 0)
 
               value =
@@ -1023,8 +1018,7 @@ defmodule Ash.DataLayer.Ets do
     with {:ok, table} <- wrap_or_create_table(resource, changeset.tenant),
          {:ok, record} <- Ash.Changeset.apply_attributes(changeset),
          record <- unload_relationships(resource, record),
-         {:ok, record} <-
-           put_or_insert_new(table, {pkey, record}, resource) do
+         {:ok, record} <- put_or_insert_new(table, {pkey, record}, resource) do
       {:ok, set_loaded(record)}
     else
       {:error, error} -> {:error, Ash.Error.to_ash_error(error)}

--- a/lib/ash/embeddable_type.ex
+++ b/lib/ash/embeddable_type.ex
@@ -228,8 +228,7 @@ defmodule Ash.EmbeddableType do
         |> Ash.Resource.Info.attributes()
         |> Enum.reduce_while({:ok, struct(__MODULE__)}, fn attr, {:ok, struct} ->
           with {:fetch, {:ok, value}} <- {:fetch, fetch_key(value, attr.name)},
-               {:ok, casted} <-
-                 Ash.Type.cast_stored(attr.type, value, attr.constraints) do
+               {:ok, casted} <- Ash.Type.cast_stored(attr.type, value, attr.constraints) do
             {:cont, {:ok, Map.put(struct, attr.name, casted)}}
           else
             {:fetch, :error} ->

--- a/lib/ash/engine/request.ex
+++ b/lib/ash/engine/request.ex
@@ -1080,8 +1080,7 @@ defmodule Ash.Engine.Request do
   defp do_try_resolve_local(request, field, unresolved, internal?) do
     %{deps: deps, resolver: resolver} = unresolved
 
-    with {:ok, new_request, notifications, []} <-
-           try_resolve(request, deps, internal?) do
+    with {:ok, new_request, notifications, []} <- try_resolve(request, deps, internal?) do
       resolver_context = resolver_context(new_request, deps)
 
       log(request, fn -> "resolving #{field}" end)

--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -2565,20 +2565,10 @@ defmodule Ash.Filter do
       function_module ->
         nested_statement = Tuple.to_list(args)
 
-        with {:ok, args} <-
-               hydrate_refs(List.wrap(nested_statement), context),
+        with {:ok, args} <- hydrate_refs(List.wrap(nested_statement), context),
              refs <- list_refs(args),
-             :ok <-
-               validate_refs(
-                 refs,
-                 context.root_resource,
-                 {function, nested_statement}
-               ),
-             {:ok, function} <-
-               Function.new(
-                 function_module,
-                 args
-               ) do
+             :ok <- validate_refs(refs, context.root_resource, {function, nested_statement}),
+             {:ok, function} <- Function.new(function_module, args) do
           if is_nil(context.resource) ||
                Ash.DataLayer.data_layer_can?(context.resource, {:filter_expr, function}) do
             {:ok, BooleanExpression.optimized_new(:and, expression, function)}
@@ -2729,15 +2719,9 @@ defmodule Ash.Filter do
         end
 
       op_module = get_operator(field) && match?([_, _ | _], nested_statement) ->
-        with {:ok, [left, right]} <-
-               hydrate_refs(nested_statement, context),
+        with {:ok, [left, right]} <- hydrate_refs(nested_statement, context),
              refs <- list_refs([left, right]),
-             :ok <-
-               validate_refs(
-                 refs,
-                 context.root_resource,
-                 {field, nested_statement}
-               ),
+             :ok <- validate_refs(refs, context.root_resource, {field, nested_statement}),
              {:ok, operator} <- Operator.new(op_module, left, right) do
           if is_boolean(operator) do
             {:ok, BooleanExpression.optimized_new(:and, expression, operator)}
@@ -2920,18 +2904,15 @@ defmodule Ash.Filter do
          context
        ) do
     with :ok <- validate_datalayer_supports_nested_expressions(args, context.resource),
-         {:op, op_module} when not is_nil(op_module) <-
-           {:op, get_operator(name)},
+         {:op, op_module} when not is_nil(op_module) <- {:op, get_operator(name)},
          context <-
            Map.merge(context, %{
              resource: Ash.Resource.Info.related(context.resource, relationship_path),
              relationship_path: []
            }),
-         {:ok, [left, right]} <-
-           hydrate_refs(args, context),
+         {:ok, [left, right]} <- hydrate_refs(args, context),
          refs <- list_refs([left, right]),
-         :ok <-
-           validate_refs(refs, context.root_resource, call),
+         :ok <- validate_refs(refs, context.root_resource, call),
          {:ok, operator} <- Operator.new(op_module, left, right) do
       if is_boolean(operator) do
         {:ok, operator}
@@ -3070,17 +3051,12 @@ defmodule Ash.Filter do
 
       _ ->
         with :ok <- validate_datalayer_supports_nested_expressions(args, context.resource),
-             {:ok, args} <-
-               hydrate_refs(args, context),
+             {:ok, args} <- hydrate_refs(args, context),
              refs <- list_refs(args),
              :ok <- validate_refs(refs, context.root_resource, call),
              {:func, function_module} when not is_nil(function_module) <-
                {:func, get_function(name, context.resource, context.public?)},
-             {:ok, function} <-
-               Function.new(
-                 function_module,
-                 args
-               ) do
+             {:ok, function} <- Function.new(function_module, args) do
           if Ash.Filter.TemplateHelpers.expr?(function) && !match?(%{__predicate__?: _}, function) do
             hydrate_refs(function, context)
           else
@@ -3665,20 +3641,10 @@ defmodule Ash.Filter do
                         }
                       end
 
-                    with {:ok, args} <-
-                           hydrate_refs([left, value], context),
+                    with {:ok, args} <- hydrate_refs([left, value], context),
                          refs <- list_refs(args),
-                         :ok <-
-                           validate_refs(
-                             refs,
-                             context.root_resource,
-                             {key, [left, value]}
-                           ),
-                         {:ok, function} <-
-                           Function.new(
-                             function_module,
-                             args
-                           ) do
+                         :ok <- validate_refs(refs, context.root_resource, {key, [left, value]}),
+                         {:ok, function} <- Function.new(function_module, args) do
                       if is_nil(context.resource) ||
                            Ash.DataLayer.data_layer_can?(
                              context.resource,
@@ -3717,15 +3683,9 @@ defmodule Ash.Filter do
                     }
                   end
 
-                with {:ok, [left, right]} <-
-                       hydrate_refs([left, value], context),
+                with {:ok, [left, right]} <- hydrate_refs([left, value], context),
                      refs <- list_refs([left, right]),
-                     :ok <-
-                       validate_refs(
-                         refs,
-                         context.root_resource,
-                         {attr, value}
-                       ),
+                     :ok <- validate_refs(refs, context.root_resource, {attr, value}),
                      {:ok, operator} <- Operator.new(operator_module, left, right) do
                   if is_boolean(operator) do
                     {:cont, {:ok, operator}}

--- a/lib/ash/filter/runtime.ex
+++ b/lib/ash/filter/runtime.ex
@@ -675,8 +675,7 @@ defmodule Ash.Filter.Runtime do
          unknown_on_unknown_refs?
        ) do
     with {:ok, args} <- resolve_exprs(args, record, parent, resource, unknown_on_unknown_refs?),
-         {:args, args} when not is_nil(args) <-
-           {:args, try_cast_arguments(mod.args(), args)},
+         {:args, args} when not is_nil(args) <- {:args, try_cast_arguments(mod.args(), args)},
          {:known, val} <-
            evaluate(%{pred | arguments: args}, record, parent, resource, unknown_on_unknown_refs?) do
       {:ok, val}

--- a/lib/ash/query/boolean_expression.ex
+++ b/lib/ash/query/boolean_expression.ex
@@ -209,10 +209,8 @@ defmodule Ash.Query.BooleanExpression do
         end
 
       %Eq{} = eq_op ->
-        with {:left, nil} <-
-               {:left, Ash.Filter.find(left, &simplify?(&1, eq_op), true, false)},
-             {:right, nil} <-
-               {:right, Ash.Filter.find(right, &simplify?(&1, eq_op), true, false)} do
+        with {:left, nil} <- {:left, Ash.Filter.find(left, &simplify?(&1, eq_op), true, false)},
+             {:right, nil} <- {:right, Ash.Filter.find(right, &simplify?(&1, eq_op), true, false)} do
           do_new(:or, left_expr, eq_op)
         else
           {:left, _} ->
@@ -246,10 +244,8 @@ defmodule Ash.Query.BooleanExpression do
         end
 
       %Eq{} = eq_op ->
-        with {:left, nil} <-
-               {:left, Ash.Filter.find(left, &simplify?(&1, eq_op), false, true)},
-             {:right, nil} <-
-               {:right, Ash.Filter.find(right, &simplify?(&1, eq_op), false, true)} do
+        with {:left, nil} <- {:left, Ash.Filter.find(left, &simplify?(&1, eq_op), false, true)},
+             {:right, nil} <- {:right, Ash.Filter.find(right, &simplify?(&1, eq_op), false, true)} do
           do_new(:and, left_expr, eq_op)
         else
           {:left, _} ->

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -2305,8 +2305,7 @@ defmodule Ash.Query do
     query = to_query(query)
 
     with sanitized_statement <- List.wrap(sanitize_loads(statement)),
-         :ok <-
-           validate_load(query, sanitized_statement),
+         :ok <- validate_load(query, sanitized_statement),
          new_loads <- merge_load(query.load, sanitized_statement) do
       %{query | load: new_loads}
     else
@@ -2716,13 +2715,10 @@ defmodule Ash.Query do
              query,
              Map.put(ash_query.context, :action, ash_query.action)
            ),
-         {:ok, query} <-
-           add_tenant(query, ash_query),
+         {:ok, query} <- add_tenant(query, ash_query),
          {:ok, query} <- Ash.DataLayer.select(query, ash_query.select, ash_query.resource),
-         {:ok, query} <-
-           Ash.DataLayer.sort(query, ash_query.sort, resource),
-         {:ok, query} <-
-           Ash.DataLayer.distinct_sort(query, ash_query.distinct_sort, resource),
+         {:ok, query} <- Ash.DataLayer.sort(query, ash_query.sort, resource),
+         {:ok, query} <- Ash.DataLayer.distinct_sort(query, ash_query.distinct_sort, resource),
          {:ok, query} <-
            Ash.DataLayer.add_aggregates(
              query,
@@ -2737,10 +2733,8 @@ defmodule Ash.Query do
              ash_query.resource
            ),
          {:ok, query} <- Ash.DataLayer.distinct(query, ash_query.distinct, resource),
-         {:ok, query} <-
-           Ash.DataLayer.limit(query, ash_query.limit, resource),
-         {:ok, query} <-
-           Ash.DataLayer.offset(query, ash_query.offset, resource),
+         {:ok, query} <- Ash.DataLayer.limit(query, ash_query.limit, resource),
+         {:ok, query} <- Ash.DataLayer.offset(query, ash_query.offset, resource),
          {:ok, query} <- Ash.DataLayer.lock(query, ash_query.lock, resource),
          {:ok, query} <- maybe_return_query(query, resource, opts) do
       if opts[:no_modify?] || !ash_query.action || !ash_query.action.modify_query do

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -554,8 +554,7 @@ defmodule Ash.Type do
   end
 
   def cast_input(type, term, nil) do
-    with {:ok, constraints} <-
-           Spark.OptionsHelpers.validate([], Ash.Type.constraints(type)),
+    with {:ok, constraints} <- Spark.OptionsHelpers.validate([], Ash.Type.constraints(type)),
          {:ok, constraints} <- Ash.Type.init(type, constraints) do
       cast_input(type, term, constraints)
     end


### PR DESCRIPTION
Seems formatter does not enforce a single style in that case and allows to write both:
```elixir
with a <- b do
end
```
and:
```elixir
with a <-
       b do
end
```

Saw a second variant where first one makes more sense (especially if it does not match neighbors). But I assume that some of changed lines might be a deliberate stylistic choice though.