### PR TITLE
Reproduce run_flow is not counted as a step inside map, branch

### DIFF
--- a/test/flow/run_flow_test.exs
+++ b/test/flow/run_flow_test.exs
@@ -1,0 +1,89 @@
+defmodule Ash.Flow.RunFlowTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      defaults [:create, :read, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule Registry do
+    @moduledoc false
+    use Ash.Registry
+
+    entries do
+      entry(Post)
+    end
+  end
+
+  defmodule Api do
+    @moduledoc false
+    use Ash.Api
+
+    resources do
+      registry Registry
+    end
+  end
+
+  defmodule CreatePost do
+    use Ash.Flow
+
+    flow do
+      api Api
+
+      returns create_post: :post
+    end
+
+    steps do
+      create :create_post, Post, :create do
+        input %{}
+      end
+    end
+  end
+
+  test "CreatePost" do
+    assert %{valid?: true, result: %{post: post}} = CreatePost.run(%{})
+  end
+
+  test "CreateTwoPosts" do
+    # COMPILE ERROR with
+    # ** (Spark.Error.DslError) [nil]
+    # create_two_posts:
+    #  Must have at least one step.
+
+    defmodule CreateTwoPosts do
+      use Ash.Flow
+
+      flow do
+        api Api
+
+        returns create_two_posts: :posts
+      end
+
+      steps do
+        map :create_two_posts, range(1, 2) do
+          run_flow :create_post, CreatePost do
+            input %{}
+          end
+        end
+      end
+    end
+
+    CreateTwoPosts.run(%{})
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

To reproduce, run
```
mix test test/flow/run_flow_test.exs
```

ValidateNoEmptySteps raises "Must have at least one step." when map or branch has only run_flow during compile.

```elixir
      steps do
        map :create_two_posts, range(1, 2) do
          run_flow :create_post, CreatePost do
            input %{}
          end
        end
      end
```