### PR TITLE
fix: remove unneeded code for calculations in a filter

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -2666,20 +2666,14 @@ defmodule Ash.Filter do
 
         {input, nested_statement} =
           case nested_statement do
-            {input, nested} ->
-              {input || %{}, nested}
+            %{"input" => input} ->
+              {input, Map.delete(nested_statement, "input")}
 
-            nested ->
-              cond do
-                is_map(nested) and Map.has_key?(nested, "input") ->
-                  {Map.get(nested, "input"), Map.delete(nested, "input")}
+            %{input: input} ->
+              {input, Map.delete(nested_statement, :input)}
 
-                is_map(nested) and Map.has_key?(nested, :input) ->
-                  {Map.get(nested, :input), Map.delete(nested, :input)}
-
-                true ->
-                  {%{}, nested}
-              end
+            _ ->
+              {%{}, nested_statement}
           end
 
         with {:ok, args} <-


### PR DESCRIPTION
Continue #891: Looked again into code for different reason and saw that this case assumes that `nested_statement` can be a tuple but it cannot - previous function clause of `add_expression_part` handles that.