### PR TITLE
fix: correct `for_read` calls in update and destroy actions

### DIFF
--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -592,14 +592,15 @@ defmodule Ash.Actions.Destroy.Bulk do
         pkeys = [or: Enum.map(batch, &Map.take(&1, pkey))]
 
         resource
-        |> Ash.Query.for_read(Ash.Resource.Info.primary_action!(resource, :read).name,
+        |> Ash.Query.for_read(Ash.Resource.Info.primary_action!(resource, :read).name, %{},
           actor: opts[:actor],
           authorize?: false,
+          context: atomic_changeset.context,
           tenant: atomic_changeset.tenant,
           tracer: opts[:tracer]
         )
-        |> Ash.Query.filter(^pkeys)
         |> Ash.Query.set_context(%{private: %{internal?: true}})
+        |> Ash.Query.filter(^pkeys)
         |> Ash.Query.select([])
         |> then(fn query ->
           run(

--- a/lib/ash/actions/destroy/destroy.ex
+++ b/lib/ash/actions/destroy/destroy.ex
@@ -87,15 +87,15 @@ defmodule Ash.Actions.Destroy do
 
         query =
           atomic_changeset.resource
-          |> Ash.Query.set_context(%{private: %{internal?: true}})
-          |> Ash.Query.for_read(primary_read.name,
+          |> Ash.Query.for_read(primary_read.name, %{},
             actor: opts[:actor],
             authorize?: false,
-            tracer: opts[:tracer],
-            tenant: atomic_changeset.tenant
+            context: atomic_changeset.context,
+            tenant: atomic_changeset.tenant,
+            tracer: opts[:tracer]
           )
+          |> Ash.Query.set_context(%{private: %{internal?: true}})
           |> Ash.Query.do_filter(primary_key_filter)
-          |> Ash.Query.set_context(changeset.context)
 
         case Ash.Actions.Destroy.Bulk.run(
                api,

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -640,14 +640,15 @@ defmodule Ash.Actions.Update.Bulk do
         pkeys = [or: Enum.map(batch, &Map.take(&1, pkey))]
 
         resource
-        |> Ash.Query.for_read(Ash.Resource.Info.primary_action!(resource, :read).name,
+        |> Ash.Query.for_read(Ash.Resource.Info.primary_action!(resource, :read).name, %{},
           actor: opts[:actor],
           authorize?: false,
+          context: atomic_changeset.context,
           tenant: atomic_changeset.tenant,
           tracer: opts[:tracer]
         )
-        |> Ash.Query.filter(^pkeys)
         |> Ash.Query.set_context(%{private: %{internal?: true}})
+        |> Ash.Query.filter(^pkeys)
         |> Ash.Query.select([])
         |> then(fn query ->
           run(api, query, action.name, input,

--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -91,13 +91,14 @@ defmodule Ash.Actions.Update do
 
           query =
             atomic_changeset.resource
-            |> Ash.Query.set_context(%{private: %{internal?: true}})
-            |> Ash.Query.for_read(primary_read.name,
+            |> Ash.Query.for_read(primary_read.name, %{},
               actor: opts[:actor],
               authorize?: false,
-              tracer: opts[:tracer],
-              tenant: atomic_changeset.tenant
+              context: atomic_changeset.context,
+              tenant: atomic_changeset.tenant,
+              tracer: opts[:tracer]
             )
+            |> Ash.Query.set_context(%{private: %{internal?: true}})
             |> Ash.Query.do_filter(primary_key_filter)
 
           case Ash.Actions.Update.Bulk.run(

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -499,7 +499,7 @@ defmodule Ash.Query do
           |> set_actor(opts)
           |> set_authorize?(opts)
           |> set_tracer(opts)
-          |> Ash.Query.set_tenant(opts[:tenant] || query.tenant)
+          |> set_tenant(opts[:tenant] || query.tenant)
           |> cast_params(action, args)
           |> set_argument_defaults(action)
           |> require_arguments(action)


### PR DESCRIPTION
`for_read` opts were provided as a third argument, meaning they were treated as an input arguments instead and ignored (unless somebody had arguments with same names).

In non-bulk destroy there was a propagation of context from a changeset to a query through `Ash.Query.set_context(changeset.context)` but in other three places there wasn't. Meaning that important context like table for polymorphic relationships was missing.

Reordered some lines to be in the same order.