### PR TITLE
docs: `uuid_primary_key` does not have `generated?: true` by default

### DIFF
--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -102,7 +102,6 @@ defmodule Ash.Resource.Dsl do
         writable? false
         default &Ash.UUID.generate/0
         primary_key? true
-        generated? true
         type :uuid
     """,
     examples: [


### PR DESCRIPTION
Just a one line correction. `integer_primary_key` does set `generated?: true` but `uuid_primary_key` does not.