### PR TITLE
chore: remove unneeded `persist` call

### DIFF
--- a/lib/ash/resource/transformers/set_define_for.ex
+++ b/lib/ash/resource/transformers/set_define_for.ex
@@ -5,15 +5,8 @@ defmodule Ash.Resource.Transformers.SetDefineFor do
   def transform(dsl) do
     api = Spark.Dsl.Transformer.get_persisted(dsl, :api)
 
-    if api do
-      dsl =
-        Spark.Dsl.Transformer.persist(dsl, :api, api)
-
-      if Ash.Resource.Info.define_interface_for(dsl) do
-        {:ok, dsl}
-      else
-        {:ok, Spark.Dsl.Transformer.set_option(dsl, [:code_interface], :define_for, api)}
-      end
+    if api && !Ash.Resource.Info.define_interface_for(dsl) do
+      {:ok, Spark.Dsl.Transformer.set_option(dsl, [:code_interface], :define_for, api)}
     else
       {:ok, dsl}
     end


### PR DESCRIPTION
There is no need to do `Spark.Dsl.Transformer.persist(dsl, :api, api)` since `api` comes from `Spark.Dsl.Transformer.get_persisted(dsl, :api)`.
