### PR TITLE
fix: set `source_attribute` from `join_relationship` in `many_to_many`

### DIFF
--- a/lib/ash/resource/transformers/create_join_relationship.ex
+++ b/lib/ash/resource/transformers/create_join_relationship.ex
@@ -56,6 +56,7 @@ defmodule Ash.Resource.Transformers.CreateJoinRelationship do
             %{
               relationship
               | through: join_relationship.destination,
+                source_attribute: join_relationship.source_attribute,
                 source_attribute_on_join_resource: join_relationship.destination_attribute
             }
 


### PR DESCRIPTION
If existing `join_relationship` is provided for `many_to_many` then `source_attribute` should be copied from the join relationship into many-to-many. Just like join `destination_attribute` gets transferred as `source_attribute_on_join_resource`.
