### PR TITLE
fix: don't double-encode vector data

### DIFF
--- a/lib/ash/type/vector.ex
+++ b/lib/ash/type/vector.ex
@@ -37,8 +37,8 @@ defmodule Ash.Type.Vector do
   @impl true
   def dump_to_native(nil, _), do: {:ok, nil}
 
-  def dump_to_native(%Ash.Vector{data: data}, _) do
-    {:ok, data}
+  def dump_to_native(%Ash.Vector{} = value, _) do
+    {:ok, value}
   end
 
   def dump_to_native(value, constraints) when is_list(value) do

--- a/lib/ash/vector.ex
+++ b/lib/ash/vector.ex
@@ -10,10 +10,6 @@ defmodule Ash.Vector do
   @doc """
   Creates a new vector from a list or tensor
   """
-  def new(binary) when is_binary(binary) do
-    new(:erlang.binary_to_list(binary))
-  end
-
   def new(%__MODULE__{} = vector), do: {:ok, vector}
 
   def new(list) when is_list(list) do

--- a/test/type/vector_test.exs
+++ b/test/type/vector_test.exs
@@ -1,0 +1,12 @@
+defmodule Ash.Test.Type.VectorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  test "it casts list to Ash.Vector" do
+    list = [1.0, 2.0, 3.0]
+
+    assert {:ok, vector} = Ash.Type.cast_input(Ash.Type.Vector, list)
+    assert {:ok, ^vector} = Ash.Type.dump_to_native(Ash.Type.Vector, list)
+    assert {:ok, ^vector} = Ash.Type.dump_to_native(Ash.Type.Vector, vector)
+  end
+end


### PR DESCRIPTION
I'm trying to store embeddings as `pgvector` data in Postgres as follows (simplified):

```elixir
defmodule MyApp.Context.Chunk do
  use Ash.Resource,
    data_layer: AshPostgres.DataLayer

  @embedding_size 384

  attributes do
    uuid_primary_key :id
    attribute :embedding, :vector
    # ...
  end

  # ...

  postgres do
    table "chunks"
    repo MyApp.Repo
    # ...
    migration_types embedding: {:vector, @embedding_size}
  end
end
```

I have the following test:

```elixir
defmodule MyApp.Context.ChunkTest do
  use MyApp.DataCase, async: true

  test "can store embedding as vector" do
    embedding = 1..384 |> Enum.to_list()
    assert {:ok, chunk} = MyApp.Context.Chunk.create!(%{embedding: embedding})
  end
end
```

Which fails with the following error:

```
** (Postgrex.Error) ERROR 22000 (data_exception) expected 384 dimensions, not 1540
```

I suspect somehow the vector is encoded twice (because 384*4+4 = 1540). I think that [Ash.Type.Vector.dump_to_native/2](https://github.com/ash-project/ash/blob/v2.20.2/lib/ash/type/vector.ex#L40-L42) should return a `Ash.Vector` (because this is the "native" type which will be encoded in the Postgrex extension). The original `pgvector-elixir` library is doing the same:

https://github.com/pgvector/pgvector-elixir/blob/master/lib/pgvector/ecto/vector.ex#L15-L17

The changes in this PR seem to fix the problem, but unfortunately I could not add a test  (because it would require a database with the pgvector extension).

It would be great if the testing infrastructure would allow adding tests for these ([example](https://github.com/pgvector/pgvector-elixir/blob/master/.github/workflows/build.yml)).

@zachdaniel What's the reason for not using the original [https://github.com/pgvector/pgvector-elixir](pgvector-elixir) library and just delegate to its existing Ecto type in `Ash.Type.Vector`? If there is interest, I could refactor it using this library.


# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
