### PR TITLE
Fix bulk updates

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -2032,9 +2032,9 @@ defmodule Ash.Actions.Update.Bulk do
   defp batch_change(module, batch, change_opts, context, actor) do
     case change_opts do
       {:templated, change_opts} ->
-        if function_exported?(module, :batch_change, 4) do
+        if function_exported?(module, :batch_change, 3) do
           {:ok, change_opts} = module.init(change_opts)
-          module.batch_change(batch, change_opts, context, actor)
+          module.batch_change(batch, change_opts, context)
         else
           Enum.map(batch, fn changeset ->
             {:ok, change_opts} = module.init(change_opts)

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -700,7 +700,7 @@ defmodule Ash.Actions.Update.Bulk do
       end
 
     batch_size =
-      if !action.manual? || manual_action_can_bulk? do
+      if action.manual == nil || manual_action_can_bulk? do
         opts[:batch_size] || 100
       else
         1


### PR DESCRIPTION
I'm trying to use bulk updates to generate text embeddings for an Ash resource in batches using an `Nx.Serving`:

```elixir
@impl Ash.Resource.Change
def batch_change(changesets, _opts, _context) do
  Logger.info("Generating embeddings for #{length(changesets)} chunks ...")

  texts = Enum.map(changesets, &Changeset.get_attribute(&1, :text))
  embeddings = generate_embeddings(texts)

  changesets
  |> Enum.zip(embeddings)
  |> Enum.map(&change_embedding/1)
end
```

When running this code I noticed the following issues:
- `batch_change/3` was never called, because Ash checks for `batch_change/4` (callback is defined as `batch_change/3`): https://github.com/ash-project/ash/blob/c04b638136f464b659a0c1d4dfe5bce91f25e561/lib/ash/actions/update/bulk.ex#L2035

- The `:batch_size` option is ignored (unless using manual actions) and bulk changes are only called with 1 changeset:
https://github.com/ash-project/ash/blob/c04b638136f464b659a0c1d4dfe5bce91f25e561/lib/ash/actions/update/bulk.ex#L693-L707

This PR should fix these issues.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
