### PR TITLE
feat: allow providing descriptions to Ash.Type.Enum values

### DIFF
--- a/test/type/enum_test.exs
+++ b/test/type/enum_test.exs
@@ -9,6 +9,17 @@ defmodule Ash.Test.Type.EnumTest do
     use Ash.Type.Enum, values: [:open, :Closed, :NeverHappened, :Always_Was]
   end
 
+  defmodule DescriptiveEnum do
+    use Ash.Type.Enum,
+      values: [
+        {:foo, "Clearly a foo"},
+        {:bar, "Obviously a bar"},
+        {:baz, "Undoubtedly a baz"},
+        :a_thing_with_no_description,
+        {:another_thing_with_no_description, nil}
+      ]
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource, data_layer: Ash.DataLayer.Ets
@@ -82,5 +93,19 @@ defmodule Ash.Test.Type.EnumTest do
     assert Status.values() == [:open, :Closed, :NeverHappened, :Always_Was]
     assert Status.match("OPEN") == {:ok, :open}
     assert Status.match?(:always_was)
+  end
+
+  test "it handles descriptions" do
+    assert DescriptiveEnum.values() == [
+             :foo,
+             :bar,
+             :baz,
+             :a_thing_with_no_description,
+             :another_thing_with_no_description
+           ]
+
+    assert DescriptiveEnum.description(:foo) == "Clearly a foo"
+    assert DescriptiveEnum.description(:a_thing_with_no_description) == nil
+    assert DescriptiveEnum.description(:another_thing_with_no_description) == nil
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/ash-project/ash_graphql/issues/116, this allows extensions to use the description to use the provided descriptions.

The documentation assumes that if a user provides a description, it does so for all values (since this seems to be a reasonable assumption and allows the nicer keyword list syntax). However tests also cover an enum with some missing descriptions.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
