### PR TITLE
fix: corrections for `reload`/`reload!`

### DIFF
--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -2113,15 +2113,17 @@ defmodule Ash.Api do
               | {:error, term}
 
   @doc """
-  Refetches a record by primary key. See `c:reload/1` for more.
+  Refetches a record by primary key. See `c:reload/2` for more.
   """
-  @callback reload!(record :: Ash.Resource.record(), params :: Keyword.t()) ::
+  @callback reload!(record :: Ash.Resource.record(), opts :: Keyword.t()) ::
               Ash.Resource.record() | no_return
 
   @doc """
   Refetches a record by primary key.
+
+  #{Spark.OptionsHelpers.docs(@get_opts_schema)}
   """
-  @callback reload(record :: Ash.Resource.record()) ::
+  @callback reload(record :: Ash.Resource.record(), opts :: Keyword.t()) ::
               {:ok, Ash.Resource.record()} | {:error, term}
 
   @doc false

--- a/lib/ash/api/functions.ex
+++ b/lib/ash/api/functions.ex
@@ -48,12 +48,12 @@ defmodule Ash.Api.Functions do
     update!: 1,
     destroy: 1,
     destroy!: 1,
-    reload: 1
+    reload: 1,
+    reload!: 1
   ]
 
   @no_opts_functions [
-    :page,
-    :reload
+    :page
   ]
 
   def functions, do: @functions

--- a/lib/ash/api/global_interface.ex
+++ b/lib/ash/api/global_interface.ex
@@ -37,7 +37,7 @@ defmodule Ash.Api.GlobalInterface do
     end
   end
 
-  def resource_from_args!(:reload, _, [%resource{} | _]) do
+  def resource_from_args!(fun, _, [%resource{} | _]) when fun in [:reload, :reload!] do
     resource
   end
 

--- a/lib/ash/api/interface.ex
+++ b/lib/ash/api/interface.ex
@@ -391,7 +391,6 @@ defmodule Ash.Api.Interface do
       def reload!(%resource{} = record, params \\ []) do
         id = record |> Map.take(Ash.Resource.Info.primary_key(resource)) |> Enum.to_list()
         params = Keyword.put_new(params, :tenant, Map.get(record.__metadata__, :tenant))
-
         get!(resource, id, params)
       end
 


### PR DESCRIPTION
- `reload!` was not exposed on `Ash`, only `reload` was.
- `reload` was marked as not having `opts` while it does.
