### PR TITLE
fix: show that `Policy.Check.strict_check` can return an error tuple

### DIFF
--- a/lib/ash/policy/check.ex
+++ b/lib/ash/policy/check.ex
@@ -30,7 +30,8 @@ defmodule Ash.Policy.Check do
   It should return `{:ok, true}` if it can tell that the request is authorized, and `{:ok, false}` if
   it can tell that it is not. If unsure, it should return `{:ok, :unknown}`
   """
-  @callback strict_check(actor(), authorizer(), options) :: {:ok, boolean | :unknown}
+  @callback strict_check(actor(), authorizer(), options()) ::
+              {:ok, boolean | :unknown} | {:error, term}
   @doc """
   An optional callback, that allows the check to work with policies set to `access_type :filter`
 


### PR DESCRIPTION
Type that `strict_check` is [allowed to return](https://github.com/ash-project/ash/blob/0afb9ade26ba540e61fa9db27f4f5bb77bce1071/lib/ash/policy/policy.ex#L190) `{:error, error}` tuple.
