### PR TITLE
improvement: support `load` option for create/update/destroy

### DIFF
--- a/lib/ash/actions/create/create.ex
+++ b/lib/ash/actions/create/create.ex
@@ -19,7 +19,8 @@ defmodule Ash.Actions.Create do
          action_type: :create
        )}
     else
-      {changeset, opts} = Ash.Actions.Helpers.add_process_context(api, changeset, opts)
+      {changeset, opts} = Helpers.add_process_context(api, changeset, opts)
+      changeset = Helpers.apply_opts_load(changeset, opts)
 
       Ash.Tracer.span :action,
                       Ash.Api.Info.span_name(
@@ -189,7 +190,7 @@ defmodule Ash.Actions.Create do
     if return_notifications? do
       {:ok, result, Map.get(instructions, :notifications, [])}
     else
-      Ash.Actions.Helpers.warn_missed!(resource, action, instructions)
+      Helpers.warn_missed!(resource, action, instructions)
 
       {:ok, result}
     end
@@ -349,7 +350,7 @@ defmodule Ash.Actions.Create do
                         opts[:upsert?] ->
                           changeset.resource
                           |> Ash.DataLayer.upsert(changeset, upsert_keys)
-                          |> Ash.Actions.Helpers.rollback_if_in_transaction(
+                          |> Helpers.rollback_if_in_transaction(
                             changeset.resource,
                             changeset
                           )
@@ -363,7 +364,7 @@ defmodule Ash.Actions.Create do
                         true ->
                           changeset.resource
                           |> Ash.DataLayer.create(changeset)
-                          |> Ash.Actions.Helpers.rollback_if_in_transaction(
+                          |> Helpers.rollback_if_in_transaction(
                             changeset.resource,
                             changeset
                           )

--- a/lib/ash/actions/destroy/destroy.ex
+++ b/lib/ash/actions/destroy/destroy.ex
@@ -24,7 +24,8 @@ defmodule Ash.Actions.Destroy do
   end
 
   def run(api, changeset, action, opts) do
-    {changeset, opts} = Ash.Actions.Helpers.add_process_context(api, changeset, opts)
+    {changeset, opts} = Helpers.add_process_context(api, changeset, opts)
+    changeset = Helpers.apply_opts_load(changeset, opts)
 
     Ash.Tracer.span :action,
                     Ash.Api.Info.span_name(
@@ -80,8 +81,6 @@ defmodule Ash.Actions.Destroy do
   end
 
   def do_run(api, changeset, action, opts) do
-    {changeset, opts} = Ash.Actions.Helpers.add_process_context(api, changeset, opts)
-
     return_destroyed? = opts[:return_destroyed?]
     changeset = %{changeset | api: api}
 
@@ -194,7 +193,7 @@ defmodule Ash.Actions.Destroy do
                 else
                   changeset.resource
                   |> Ash.DataLayer.destroy(changeset)
-                  |> Ash.Actions.Helpers.rollback_if_in_transaction(changeset.resource, changeset)
+                  |> Helpers.rollback_if_in_transaction(changeset.resource, changeset)
                   |> case do
                     :ok ->
                       {:ok, data} = Ash.Changeset.apply_attributes(changeset, force?: true)
@@ -304,7 +303,7 @@ defmodule Ash.Actions.Destroy do
     if return_notifications? do
       {:ok, Map.get(instructions, :notifications, [])}
     else
-      Ash.Actions.Helpers.warn_missed!(resource, action, instructions)
+      Helpers.warn_missed!(resource, action, instructions)
       :ok
     end
   end

--- a/lib/ash/actions/helpers.ex
+++ b/lib/ash/actions/helpers.ex
@@ -536,6 +536,22 @@ defmodule Ash.Actions.Helpers do
     end
   end
 
+  def apply_opts_load(%Ash.Changeset{} = changeset, opts) do
+    if opts[:load] do
+      Ash.Changeset.load(changeset, opts[:load])
+    else
+      changeset
+    end
+  end
+
+  def apply_opts_load(%Ash.Query{} = query, opts) do
+    if opts[:load] do
+      Ash.Query.load(query, opts[:load])
+    else
+      query
+    end
+  end
+
   def load({:ok, result, instructions}, changeset, api, opts) do
     if changeset.load in [nil, []] do
       {:ok, result, instructions}

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -25,7 +25,8 @@ defmodule Ash.Actions.Read do
   end
 
   def run(query, action, opts) do
-    {query, opts} = Ash.Actions.Helpers.add_process_context(query.api, query, opts)
+    {query, opts} = Helpers.add_process_context(query.api, query, opts)
+    query = Helpers.apply_opts_load(query, opts)
 
     action = get_action(query.resource, action || query.action)
 
@@ -98,13 +99,6 @@ defmodule Ash.Actions.Read do
 
     opts = sanitize_opts(opts, query)
     action = get_action(query.resource, query.action || action)
-
-    query =
-      if opts[:load] do
-        Ash.Query.load(query, opts[:load])
-      else
-        query
-      end
 
     query =
       for_read(
@@ -413,7 +407,7 @@ defmodule Ash.Actions.Read do
                },
                !Keyword.has_key?(opts, :initial_data)
              )
-             |> Ash.Actions.Helpers.rollback_if_in_transaction(
+             |> Helpers.rollback_if_in_transaction(
                query.resource,
                query
              ),

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -311,6 +311,8 @@ defmodule Ash.Actions.Update.Bulk do
   end
 
   defp do_atomic_update(query, atomic_changeset, has_after_action_hooks?, input, opts) do
+    atomic_changeset = Ash.Actions.Helpers.apply_opts_load(atomic_changeset, opts)
+
     atomic_changeset =
       if opts[:select] do
         Ash.Changeset.select(atomic_changeset, opts[:select])
@@ -326,13 +328,6 @@ defmodule Ash.Actions.Update.Bulk do
           atomic_changeset
           | data: %Ash.Changeset.OriginalDataNotAvailable{reason: :atomic_query_update}
         }
-      end
-
-    atomic_changeset =
-      if opts[:load] do
-        Ash.Changeset.load(atomic_changeset, opts[:load])
-      else
-        atomic_changeset
       end
 
     with {:ok, query} <-

--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -88,8 +88,8 @@ defmodule Ash.Actions.Update do
             |> Map.put(:select, changeset.select)
             |> Ash.Changeset.set_context(changeset.context)
 
-          {atomic_changeset, opts} =
-            Ash.Actions.Helpers.add_process_context(api, atomic_changeset, opts)
+          {atomic_changeset, opts} = Helpers.add_process_context(api, atomic_changeset, opts)
+          atomic_changeset = Helpers.apply_opts_load(atomic_changeset, opts)
 
           opts =
             Keyword.merge(opts,
@@ -163,7 +163,8 @@ defmodule Ash.Actions.Update do
                reason: reason
              )}
           else
-            {changeset, opts} = Ash.Actions.Helpers.add_process_context(api, changeset, opts)
+            {changeset, opts} = Helpers.add_process_context(api, changeset, opts)
+            changeset = Helpers.apply_opts_load(changeset, opts)
 
             Ash.Tracer.span :action,
                             Ash.Api.Info.span_name(
@@ -316,7 +317,7 @@ defmodule Ash.Actions.Update do
         {:ok, result, Map.get(instructions, :notifications, [])}
       end
     else
-      Ash.Actions.Helpers.warn_missed!(resource, action, instructions)
+      Helpers.warn_missed!(resource, action, instructions)
 
       if changeset.action_type == :destroy do
         :ok
@@ -439,7 +440,7 @@ defmodule Ash.Actions.Update do
                           {:error, error} ->
                             {:error, error}
                         end
-                        |> Ash.Actions.Helpers.rollback_if_in_transaction(
+                        |> Helpers.rollback_if_in_transaction(
                           changeset.resource,
                           changeset
                         )

--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -374,6 +374,10 @@ defmodule Ash.Api do
                    |> merge_schemas(@global_opts, "Global Options")
 
   @shared_created_update_and_destroy_opts_schema [
+    load: [
+      type: :any,
+      doc: "A load statement to add onto the changeset"
+    ],
     return_notifications?: [
       type: :boolean,
       default: false,
@@ -406,8 +410,6 @@ defmodule Ash.Api do
     ]
   ]
 
-  @create_update_opts_schema []
-
   @create_opts_schema [
                         upsert?: [
                           type: :boolean,
@@ -434,10 +436,6 @@ defmodule Ash.Api do
                         ]
                       ]
                       |> merge_schemas(@global_opts, "Global Options")
-                      |> merge_schemas(
-                        @create_update_opts_schema,
-                        "Shared create/update Options"
-                      )
                       |> merge_schemas(
                         @shared_created_update_and_destroy_opts_schema,
                         "Shared create/update/destroy Options"
@@ -572,11 +570,6 @@ defmodule Ash.Api do
                                doc:
                                  "If a query is given, determines whether or not authorization is run on that query."
                              ],
-                             load: [
-                               type: :any,
-                               doc:
-                                 "A load statement to apply to records. Ignored if `return_records?` is not true."
-                             ],
                              select: [
                                type: {:list, :atom},
                                doc:
@@ -666,11 +659,6 @@ defmodule Ash.Api do
                                doc:
                                  "The identity to use when detecting conflicts for `upsert?`, e.g. `upsert_identity: :full_name`. By default, the primary key is used. Has no effect if `upsert?: true` is not provided"
                              ],
-                             load: [
-                               type: :any,
-                               doc:
-                                 "A load statement to apply to records. Ignored if `return_records?` is not true."
-                             ],
                              select: [
                                type: {:list, :atom},
                                doc:
@@ -714,10 +702,6 @@ defmodule Ash.Api do
                         ]
                       ]
                       |> merge_schemas(@global_opts, "Global Options")
-                      |> merge_schemas(
-                        @create_update_opts_schema,
-                        "Shared create/update Options"
-                      )
                       |> merge_schemas(
                         @shared_created_update_and_destroy_opts_schema,
                         "Shared create/update/destroy Options"


### PR DESCRIPTION
`load` option was supported in read and bulk actions. Now it is applicable to usual create/update/destroy actions too.

Noting that create/update/soft-destroy and non-soft destroy handle loads different.

Small changes besides that - consistent usage of `Helpers` alias, remove double call to `add_process_context` in destroy action, remove empty `@create_update_opts_schema`.