### PR TITLE
fix: fix missing tenant in some bulk contexts

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -1386,12 +1386,6 @@ defmodule Ash.Actions.Create.Bulk do
                   changes: state.changes
               }
             else
-              context = %{
-                actor: actor,
-                authorize?: authorize? || false,
-                tracer: tracer
-              }
-
               matches = batch_change(module, matches, change_opts, context, actor)
 
               must_return_records? =

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1866,12 +1866,6 @@ defmodule Ash.Actions.Destroy.Bulk do
                   changes: state.changes
               }
             else
-              context = %{
-                actor: actor,
-                authorize?: authorize? || false,
-                tracer: tracer
-              }
-
               matches = batch_change(module, matches, change_opts, context, actor)
 
               must_return_records? =

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1997,12 +1997,6 @@ defmodule Ash.Actions.Update.Bulk do
                   changes: state.changes
               }
             else
-              context = %{
-                actor: actor,
-                authorize?: authorize? || false,
-                tracer: tracer
-              }
-
               matches = batch_change(module, matches, change_opts, context, actor)
 
               must_return_records? =


### PR DESCRIPTION
There were two identical contexts on the same level in nesting. Both were missing tenants. Then in some PR definition for one of contexts was moved up and added tenant. So by removing second context a tenant also gets passed properly there.