### PR TITLE
fix: enforce multitenancy on aggregates

### DIFF
--- a/lib/ash/actions/aggregate.ex
+++ b/lib/ash/actions/aggregate.ex
@@ -6,7 +6,8 @@ defmodule Ash.Actions.Aggregate do
     query = %{query | api: api}
     {query, opts} = Ash.Actions.Helpers.add_process_context(query.api, query, opts)
 
-    with %{valid?: true} = query <- Ash.Actions.Read.handle_attribute_multitenancy(query) do
+    with %{valid?: true} = query <- Ash.Actions.Read.handle_attribute_multitenancy(query),
+         :ok <- Ash.Actions.Read.validate_multitenancy(query) do
       aggregates
       |> Enum.group_by(fn
         %Ash.Query.Aggregate{} = aggregate ->

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -1155,7 +1155,8 @@ defmodule Ash.Actions.Read do
     end
   end
 
-  defp validate_multitenancy(query) do
+  @doc false
+  def validate_multitenancy(query) do
     if is_nil(Ash.Resource.Info.multitenancy_strategy(query.resource)) ||
          Ash.Resource.Info.multitenancy_global?(query.resource) || query.tenant do
       :ok


### PR DESCRIPTION
The multitenancy attribute was already considered as a filter in aggregates, but the presence of the tenant was not enforced

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
