### PR TITLE
fix: make bang variant of field aggregates work correctly

### DIFF
--- a/lib/ash/api/interface.ex
+++ b/lib/ash/api/interface.ex
@@ -184,14 +184,14 @@ defmodule Ash.Api.Interface do
         def unquote(:"#{kind}!")(query, field, opts \\ []) do
           query = Ash.Query.to_query(query)
 
-          {aggregate_opts, opts} = Ash.Query.Aggregate.split_aggregate_opts(opts)
-
           opts =
             if query.action do
               Keyword.put(opts, :read_action, query.action.name)
             else
               opts
             end
+
+          {aggregate_opts, opts} = Ash.Query.Aggregate.split_aggregate_opts(opts)
 
           case Api.aggregate(
                  __MODULE__,


### PR DESCRIPTION
split_aggregate_opts/1 was called too early so it didn't handle the translation of :read_action to :action, leading to a NimbleOptions error during validation

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
