### PR TITLE
improvement: allow simple check to return error tuple

### DIFF
--- a/lib/ash/policy/simple_check.ex
+++ b/lib/ash/policy/simple_check.ex
@@ -16,7 +16,7 @@ defmodule Ash.Policy.SimpleCheck do
   @type options :: Keyword.t()
 
   @doc "Whether or not the request matches the check"
-  @callback match?(actor(), context(), options()) :: boolean
+  @callback match?(actor(), context(), options()) :: boolean | {:ok, boolean} | {:error, term}
 
   defmacro __using__(_) do
     quote do
@@ -27,8 +27,13 @@ defmodule Ash.Policy.SimpleCheck do
 
       def requires_original_data?(_, _), do: false
 
+      @dialyzer {:nowarn_function, strict_check: 3}
       def strict_check(actor, context, opts) do
-        {:ok, match?(actor, context, opts)}
+        case match?(actor, context, opts) do
+          {:ok, value} -> {:ok, value}
+          {:error, error} -> {:error, error}
+          value -> {:ok, value}
+        end
       end
 
       defoverridable requires_original_data?: 2


### PR DESCRIPTION
Allows simple check to return `{:error, error}` or explicit `{:ok, boolean}` in addition to simply returning a boolean.

Had to silence dialyzer because it is used in macro, so when it is used it knows what `match?` specifically returns in a module and complains about never matching pattern.

This is PR to main. Ash 2 lives on a separate branch now. If this is merged in, what do I need to do to add it to second version too (the code and change is the same in this case)?