### PR TITLE
improvement: change `type` argument position in `Ash.Query.calculate`

### DIFF
--- a/lib/ash/actions/read/calculations.ex
+++ b/lib/ash/actions/read/calculations.ex
@@ -803,9 +803,9 @@ defmodule Ash.Actions.Read.Calculations do
                   Ash.Query.calculate(
                     query,
                     new_calc_name,
+                    equivalent_aggregate.type,
                     {Ash.Resource.Calculation.FetchAgg,
                      load: equivalent_aggregate.name, name: equivalent_aggregate.load},
-                    equivalent_aggregate.type,
                     %{},
                     equivalent_aggregate.constraints,
                     equivalent_aggregate.context
@@ -1014,11 +1014,11 @@ defmodule Ash.Actions.Read.Calculations do
                       query
                       |> Ash.Query.calculate(
                         new_calc_name,
+                        type,
                         {Ash.Resource.Calculation.LoadRelationship,
                          relationship: relationship.name,
                          query: further,
                          domain: relationship.domain || domain},
-                        type,
                         %{},
                         constraints
                       )
@@ -1180,9 +1180,9 @@ defmodule Ash.Actions.Read.Calculations do
           Ash.Query.calculate(
             query,
             new_calc_name,
+            equivalent_calculation.type,
             {Ash.Resource.Calculation.FetchCalc,
              load: equivalent_calculation.name, name: equivalent_calculation.load},
-            equivalent_calculation.type,
             equivalent_calculation.context.arguments,
             equivalent_calculation.constraints,
             equivalent_calculation.context

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -1941,8 +1941,8 @@ defmodule Ash.Actions.Read do
         Ash.Query.calculate(
           query,
           calc.name,
-          {calc.module, calc.opts},
           calc.type,
+          {calc.module, calc.opts},
           calc.context.arguments,
           calc.constraints,
           calc.context

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -2104,11 +2104,11 @@ defmodule Ash.Query do
       {:aggregate, {name, type, relationship, agg_query}}, query ->
         aggregate(query, name, type, relationship, agg_query)
 
-      {:calculate, {name, module_and_opts, type}}, query ->
-        calculate(query, name, module_and_opts, type)
+      {:calculate, {name, type, module_and_opts}}, query ->
+        calculate(query, name, type, module_and_opts)
 
-      {:calculate, {name, module_and_opts, type, arguments}}, query ->
-        calculate(query, name, module_and_opts, type, arguments)
+      {:calculate, {name, type, module_and_opts, arguments}}, query ->
+        calculate(query, name, type, module_and_opts, arguments)
 
       {:select, fields}, query ->
         select(query, fields)
@@ -2249,8 +2249,8 @@ defmodule Ash.Query do
   def calculate(
         query,
         name,
-        module_and_opts,
         type,
+        module_and_opts,
         arguments \\ %{},
         constraints \\ [],
         extra_context \\ %{}

--- a/test/calculations/calculation_test.exs
+++ b/test/calculations/calculation_test.exs
@@ -918,7 +918,7 @@ defmodule Ash.Test.CalculationTest do
   test "custom calculations can be added to a query" do
     full_names =
       User
-      |> Ash.Query.calculate(:full_name, {Concat, keys: [:first_name, :last_name]}, :string, %{
+      |> Ash.Query.calculate(:full_name, :string, {Concat, keys: [:first_name, :last_name]}, %{
         separator: " \o.o/ "
       })
       |> Ash.read!()


### PR DESCRIPTION
Small breaking change: aligns position of `type` in `Ash.Query.calculate` with position in `calculation` dsl entity and with `Ash.Query.aggregate`. Also should help with formatting when `module_and_opts` supports anonymous functions.
