### PR TITLE
docs: Adjust guide to suppress errors and warnings for v3.0

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -248,6 +248,9 @@ attributes do
   attribute :subject, :string do
     # Don't allow `nil` values
     allow_nil? false
+
+    # Allow this attribute to be public. By default, all attributes are private.
+    public? true
   end
 
   # status is either `open` or `closed`. We can add more statuses later
@@ -481,6 +484,7 @@ Now we want to be able to assign a Ticket to a Representative. First, let's crea
 defmodule Helpdesk.Support.Representative do
   # This turns this module into a resource using the in memory ETS data layer
   use Ash.Resource,
+    domain: Helpdesk.Support,
     data_layer: Ash.DataLayer.Ets
 
   actions do
@@ -494,7 +498,10 @@ defmodule Helpdesk.Support.Representative do
     uuid_primary_key :id
 
     # Add a string type attribute called `:name`
-    attribute :name, :string
+    attribute :name, :string do
+      # Make the attribute public in order to give a name when calling functions from `Ash.Changeset`.
+      public? true
+    end
   end
 
   relationships do
@@ -575,7 +582,7 @@ recompile()
 ticket = (
   Helpdesk.Support.Ticket
   |> Ash.Changeset.for_create(:open, %{subject: "I can't find my hand!"})
-  |> Helpdesk.Support.create!()
+  |> Ash.create!()
 )
 ```
 
@@ -585,7 +592,7 @@ ticket = (
 representative = (
   Helpdesk.Support.Representative
   |> Ash.Changeset.for_create(:create, %{name: "Joe Armstrong"})
-  |> Helpdesk.Support.create!()
+  |> Ash.create!()
 )
 ```
 
@@ -594,7 +601,7 @@ representative = (
 ```elixir
 ticket
 |> Ash.Changeset.for_update(:assign, %{representative_id: representative.id})
-|> Helpdesk.Support.update!()
+|> Ash.update!()
 ```
 
 ### What next?


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
----

Hi,

I wanted to try Ash Framework and I have followed the "Get Started" guide with Ash `3.0.0-rc.3`.

I got some errors and warnings, but with the changes from the PR, it should work with no errors and fewer warnings.

There is still 1 warning left in this PR, but I don't know how to remove it:
```
 warning: the Inspect protocol has already been consolidated, an implementation for Helpdesk.Support.Representative has no effect. If you want to implement protocols after compilation or during tests, check the "Consolidation" section in the Protocol module documentation
    │
  1 │ defmodule Helpdesk.Support.Representative do
    │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/helpdesk/support/representative.ex:1: Helpdesk.Support.Representative (module)
```