### PR TITLE
fix: handle `sensitive?` option in query aggregate/calculation

### DIFF
--- a/lib/ash/query/aggregate.ex
+++ b/lib/ash/query/aggregate.ex
@@ -73,11 +73,13 @@ defmodule Ash.Query.Aggregate do
     ],
     filterable?: [
       type: :boolean,
-      doc: "Whether or not this aggregate may be used in filters."
+      doc: "Whether or not this aggregate may be used in filters.",
+      default: true
     ],
     sortable?: [
       type: :boolean,
-      doc: "Whether or not this aggregate may be used in sorts."
+      doc: "Whether or not this aggregate may be used in sorts.",
+      default: true
     ],
     type: [
       type: :any,
@@ -117,7 +119,7 @@ defmodule Ash.Query.Aggregate do
     sensitive?: [
       type: :boolean,
       doc: "Whether or not references to this aggregate will be considered sensitive",
-      default: true
+      default: false
     ],
     authorize?: [
       type: :boolean,
@@ -179,8 +181,9 @@ defmodule Ash.Query.Aggregate do
           relationship = opts[:path] || []
           field = opts[:field]
           default = opts[:default]
-          filterable? = Keyword.get(opts, :filterable?, true)
-          sortable? = Keyword.get(opts, :sortable?, true)
+          filterable? = opts[:filterable?]
+          sortable? = opts[:sortable?]
+          sensitive? = opts[:sensitive?]
           type = opts[:type]
           constraints = Keyword.get(opts, :constraints, [])
           implementation = opts[:implementation]
@@ -240,6 +243,7 @@ defmodule Ash.Query.Aggregate do
                query: query,
                filterable?: filterable?,
                sortable?: sortable?,
+               sensitive?: sensitive?,
                authorize?: authorize?,
                read_action: read_action,
                join_filters: Map.new(join_filters, fn {key, value} -> {List.wrap(key), value} end)

--- a/lib/ash/query/calculation.ex
+++ b/lib/ash/query/calculation.ex
@@ -38,7 +38,7 @@ defmodule Ash.Query.Calculation do
     sensitive?: [
       type: :boolean,
       doc: "Whether or not references to this calculation will be considered sensitive",
-      default: true
+      default: false
     ],
     load: [
       type: :any,
@@ -86,7 +86,8 @@ defmodule Ash.Query.Calculation do
          context: context,
          required_loads: opts[:load],
          filterable?: opts[:filterable?],
-         sortable?: opts[:filterable?]
+         sortable?: opts[:sortable?],
+         sensitive?: opts[:sensitive?]
        }}
     end
   end


### PR DESCRIPTION
In `Ash.Query.Aggregate` and `Ash.Query.Calculation` options included `sensitive?` but it was not used (also one had wrong default value, other had no default value). Now it is handled.

Also in calculation there was `sortable?: opts[:filterable?]`.