### PR TITLE
fix: return {:error, query} for invalid query in Aggregate.run/4

### DIFF
--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -264,6 +264,13 @@ defmodule Ash.Test.Actions.AggregateTest do
                |> Ash.Query.for_read(:with_foo)
                |> Ash.list!(:title, authorize?: false)
     end
+
+    test "returns error for invalid input" do
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Invalid.NoSuchInput{input: :bar}]}} =
+               Post
+               |> Ash.Query.for_read(:with_foo, %{bar: "no such input"})
+               |> Ash.exists(authorize?: false)
+    end
   end
 
   describe "aggregate loading" do


### PR DESCRIPTION
Avoid making callers like Ash.aggregate crash with a WithClause error since they expect an :ok/:error tuple

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
