### PR TITLE
docs: Fix formatting of examples for `Ash.Resource.Preparation.Builtins`

### DIFF
--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -313,7 +313,7 @@ defmodule Ash.Resource.Change.Builtins do
 
   ## Example
 
-    change ensure_selected([:necessary_field])
+      change ensure_selected([:necessary_field])
   """
   @spec ensure_selected(select :: atom | list(atom)) :: Ash.Resource.Change.ref()
   def ensure_selected(value) do

--- a/lib/ash/resource/preparation/builtins.ex
+++ b/lib/ash/resource/preparation/builtins.ex
@@ -43,11 +43,11 @@ defmodule Ash.Resource.Preparation.Builtins do
 
   ## Example
 
-    prepare before_action(fn query ->
-      Logger.debug("About to execute query for #{query.action.name} on #{inspect(query.resource)})
+      prepare before_action(fn query ->
+        Logger.debug("About to execute query for #{query.action.name} on #{inspect(query.resource)}")
 
-      query
-    end)
+        query
+      end)
   """
   defmacro before_action(callback) do
     {value, function} =
@@ -67,11 +67,11 @@ defmodule Ash.Resource.Preparation.Builtins do
 
   ## Example
 
-    prepare after_action(fn query, records ->
-      Logger.debug("Query for #{query.action.name} on resource #{inspect(query.resource)} returned #{length(records)} records")
+      prepare after_action(fn query, records ->
+        Logger.debug("Query for #{query.action.name} on resource #{inspect(query.resource)} returned #{length(records)} records")
 
-      {:ok, records}
-    end)
+        {:ok, records}
+      end)
   """
   defmacro after_action(callback) do
     {value, function} =

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -65,7 +65,8 @@ defmodule Ash.Resource.Validation.Builtins do
   Validates that other validation does not pass
 
   ## Examples
-    validate negate(one_of(:status, [:closed, :finished]))
+
+      validate negate(one_of(:status, [:closed, :finished]))
   """
   @spec negate(validation :: Validation.ref()) :: Validation.ref()
   def negate(validation) do
@@ -213,7 +214,7 @@ defmodule Ash.Resource.Validation.Builtins do
 
   ## Examples
 
-    validate match(:slug, ~r/^[0-9a-z-_]+$/)
+      validate match(:slug, ~r/^[0-9a-z-_]+$/)
   """
   @spec match(attribute :: atom, match :: Regex.t()) :: Validation.ref()
   def match(attribute, match) do


### PR DESCRIPTION
All examples should be indented by four spaces. (Also added a missing close quote)

Before: https://hexdocs.pm/ash/Ash.Resource.Preparation.Builtins.html#after_action/1

After: 

<img width="323" alt="Screenshot 2024-04-07 at 3 44 51 pm" src="https://github.com/ash-project/ash/assets/543859/c6e97c20-ce26-4d80-a1e8-b402d7382f8c">

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
