### PR TITLE
fix: undo adding primary key argument for methods with `get?`

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -420,9 +420,6 @@ defmodule Ash.CodeInterface do
             interface.get_by ->
               interface.get_by
 
-            interface.get? ->
-              Ash.Resource.Info.primary_key(resource)
-
             true ->
               []
           end

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -13,10 +13,10 @@ defmodule Ash.Test.CodeInterfaceTest do
     end
 
     code_interface do
-      define :get_user, action: :read, get?: true
-      define :get_user_safely, action: :read, get?: true, not_found_error?: false
+      define :get_user, action: :read, get_by: :id
+      define :get_user_safely, action: :read, get_by: :id, not_found_error?: false
       define :read_users, action: :read
-      define :get_by_id, action: :read, get_by: [:id]
+      define :get_by_id, action: :by_id, get?: true, args: [:id]
       define :create, args: [{:optional, :first_name}]
       define :hello, args: [:name]
 
@@ -84,7 +84,7 @@ defmodule Ash.Test.CodeInterfaceTest do
 
     resources do
       resource User do
-        define :get_user, action: :read, get?: true
+        define :get_user, action: :read, get_by: :id
 
         define_calculation(:full_name, args: [:first_name, :last_name])
       end


### PR DESCRIPTION
In Ash 3 code interface started to automatically add an argument for primary key to methods with `get?: true`. 

Seems like it was unintended consequence of refactoring `if` to `case` statement.

This PR undoes this change. To get things by id one can use `get_by: :id`.