### PR TITLE
improvement: Allow Reactor modules to be run directly from generic actions

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.md
+++ b/documentation/dsls/DSL:-Ash.Resource.md
@@ -952,7 +952,7 @@ end
 |------|------|---------|------|
 | [`constraints`](#actions-action-constraints){: #actions-action-constraints } | `keyword` |  | Constraints for the return type. See `Ash.Type` for more. |
 | [`allow_nil?`](#actions-action-allow_nil?){: #actions-action-allow_nil? } | `boolean` | `false` | Whether or not the action can return nil. Unlike attributes & arguments, this defaults to `false`. |
-| [`run`](#actions-action-run){: #actions-action-run } | `(any, any -> any) \| module` |  |  |
+| [`run`](#actions-action-run){: #actions-action-run } | `(any, any -> any) \| module \| module` |  |  |
 | [`primary?`](#actions-action-primary?){: #actions-action-primary? } | `boolean` | `false` | Whether or not this action should be used when no action is specified by the caller. |
 | [`description`](#actions-action-description){: #actions-action-description } | `String.t` |  | An optional description for the action |
 | [`transaction?`](#actions-action-transaction?){: #actions-action-transaction? } | `boolean` |  | Whether or not the action should be run in transactions. Reads default to false, while create/update/destroy actions default to `true`. |

--- a/documentation/topics/advanced/reactor.md
+++ b/documentation/topics/advanced/reactor.md
@@ -151,7 +151,14 @@ Because a reactor has transaction-like semantics notifications are automatically
 
 ## Running Reactors as an action
 
-Currently the best way to expose a Reactor as an action is to use a [Generic Action](actions.html#generic-actions).
+Ash's [generic actions](actions.md#generic-actions) now support providing a Reactor module directly as their `run` option.
+
+Notes:
+
+- Every Reactor input must have a corresponding action argument.
+- Ash's action context is passed in as the Reactor's context (including things like actor, tenant, etc).
+- [Reactor runtime options](`t:Reactor.options/0`) can be set by setting `run {MyReactor, opts}` instead of just `run MyReactor`.
+- If you set the `transaction?` action DSL option to true then the Reactor will be run synchronously - regardless of the value of the `async?` runtime option.
 
 ### Example
 
@@ -163,8 +170,6 @@ action :run_reactor, :struct do
   argument :blog_body, :string, allow_nil?: false
   argument :author_email, :ci_string, allow_nil?: false
 
-  run fn input, _context ->
-    Reactor.run(MyBlog.CreatePostReactor, input.arguments)
-  end
+  run MyBlog.CreatePostReactor
 end
 ```

--- a/lib/ash/resource/actions/action/action.ex
+++ b/lib/ash/resource/actions/action/action.ex
@@ -83,8 +83,12 @@ defmodule Ash.Resource.Actions.Action do
                 ],
                 run: [
                   type:
-                    {:spark_function_behaviour, Ash.Resource.Actions.Implementation,
-                     {Ash.Resource.Action.ImplementationFunction, 2}}
+                    {:or,
+                     [
+                       {:spark_function_behaviour, Ash.Resource.Actions.Implementation,
+                        {Ash.Resource.Action.ImplementationFunction, 2}},
+                       {:spark, Reactor}
+                     ]}
                 ]
               ]
               |> Spark.Options.merge(

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1461,7 +1461,8 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Verifiers.ValidatePrimaryKey,
     Ash.Resource.Verifiers.VerifyAcceptedByDomain,
     Ash.Resource.Verifiers.VerifyActionsAtomic,
-    Ash.Resource.Verifiers.VerifyPrimaryKeyPresent
+    Ash.Resource.Verifiers.VerifyPrimaryKeyPresent,
+    Ash.Resource.Verifiers.VerifyGenericActionReactorInputs
   ]
 
   @moduledoc false

--- a/lib/ash/resource/verifiers/verify_generic_action_reactor_inputs.ex
+++ b/lib/ash/resource/verifiers/verify_generic_action_reactor_inputs.ex
@@ -1,0 +1,69 @@
+defmodule Ash.Resource.Verifiers.VerifyGenericActionReactorInputs do
+  @moduledoc """
+  Returns an error if a generic action calls a Reactor module without specifying
+  an argument for all expected inputs.
+  """
+  use Spark.Dsl.Verifier
+
+  def verify(dsl) do
+    dsl
+    |> Ash.Resource.Info.actions()
+    |> Enum.filter(&(&1.type == :action))
+    |> Enum.reduce_while(:ok, fn action, :ok ->
+      case verify_action(action, dsl) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp verify_action(%{run: module} = action, dsl) when is_atom(module) do
+    if is_reactor?(module) do
+      verify_reactor_action(action, module, dsl)
+    else
+      :ok
+    end
+  end
+
+  defp verify_action(%{run: {module, _}} = action, dsl) do
+    if is_reactor?(module) do
+      verify_reactor_action(action, module, dsl)
+    else
+      :ok
+    end
+  end
+
+  defp verify_reactor_action(action, module, dsl) do
+    reactor = module.reactor()
+
+    required_inputs = MapSet.new(reactor.inputs)
+    provided_arguments = MapSet.new(action.arguments, & &1.name)
+
+    required_inputs
+    |> MapSet.difference(provided_arguments)
+    |> Enum.sort()
+    |> case do
+      [] ->
+        :ok
+
+      missing ->
+        missing =
+          missing
+          |> Enum.map_join(", ", &"`#{inspect(&1)}`")
+
+        {:error,
+         Spark.Error.DslError.exception(
+           module: Spark.Dsl.Verifier.get_persisted(dsl, :module),
+           path: [:actions, :action, action.name],
+           message:
+             "You need to provide arguments for all the Reactor's inputs.  Missing #{missing}"
+         )}
+    end
+  end
+
+  defp is_reactor?(module) when is_atom(module) do
+    module.spark_is() == Reactor
+  rescue
+    UndefinedFunctionError -> false
+  end
+end

--- a/test/actions/generic_actions_test.exs
+++ b/test/actions/generic_actions_test.exs
@@ -101,4 +101,39 @@ defmodule Ash.Test.Actions.GenericActionsTest do
       end
     end
   end
+
+  describe "generic actions wrapping a reactor" do
+    defmodule EchoReactor do
+      @moduledoc false
+      use Reactor
+
+      input :input
+
+      step :echo do
+        argument :echo, input(:input)
+        run &Map.fetch(&1, :echo)
+      end
+    end
+
+    defmodule EchoResource do
+      @moduledoc false
+      use Ash.Resource, domain: Domain
+
+      actions do
+        action :echo, :string do
+          argument :input, :string, allow_nil?: false
+
+          run EchoReactor
+        end
+      end
+
+      code_interface do
+        define :echo, args: [:input]
+      end
+    end
+
+    test "it automatically runs the reactor" do
+      assert {:ok, "Marty"} = EchoResource.echo("Marty")
+    end
+  end
 end


### PR DESCRIPTION
- Extends the generic action runner to detect when the `run` module is a Reactor and automatically executes it in the correct way.
- Adds a verifier that detects said actions and ensures that action arguments are present for all expected inputs.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
