### PR TITLE
fix(Ash.Reactor): crash when calling an ash reactor for the first time.

### DIFF
--- a/lib/ash/reactor/builders/transaction.ex
+++ b/lib/ash/reactor/builders/transaction.ex
@@ -9,8 +9,6 @@ defimpl Reactor.Dsl.Build, for: Ash.Reactor.Dsl.Transaction do
   @impl true
   def build(transaction, reactor) do
     sub_reactor = Builder.new({Ash.Reactor.TransactionStep, transaction.name})
-    # force the sub-reactor to not be hooked.
-    sub_reactor = %{sub_reactor | context: Map.put(sub_reactor.context, :__ash_hooked__, true)}
 
     with {:ok, reactor} <- ensure_hooked(reactor),
          {:ok, sub_reactor} <- build_nested_steps(sub_reactor, transaction.steps),

--- a/lib/ash/reactor/builders/utils.ex
+++ b/lib/ash/reactor/builders/utils.ex
@@ -61,12 +61,6 @@ defmodule Ash.Reactor.BuilderUtils do
 
   @doc false
   @spec ensure_hooked(Reactor.t()) :: {:ok, Reactor.t()} | {:error, any}
-  def ensure_hooked(reactor) when is_map_key(reactor.context, :__ash_hooked__),
-    do: {:ok, reactor}
-
-  def ensure_hooked(reactor) do
-    with {:ok, reactor} <- Reactor.Builder.ensure_middleware(reactor, Ash.Reactor.Notifications) do
-      {:ok, %{reactor | context: Map.put(reactor.context, :__ash_hooked__, true)}}
-    end
-  end
+  def ensure_hooked(reactor),
+    do: Reactor.Builder.ensure_middleware(reactor, Ash.Reactor.Notifications)
 end

--- a/test/reactor/reactor_test.exs
+++ b/test/reactor/reactor_test.exs
@@ -55,7 +55,7 @@ defmodule Ash.Test.ReactorTest do
       end
     end
 
-    expect(Ash.Reactor.Notifications, :publish, fn notifications ->
+    expect(Ash.Reactor.Notifications, :publish, fn _context, notifications ->
       assert [
                %Ash.Notifier.Notification{
                  resource: Ash.Test.ReactorTest.Post,

--- a/test/reactor/transaction_test.exs
+++ b/test/reactor/transaction_test.exs
@@ -79,7 +79,7 @@ defmodule Ash.Test.Reactor.TransactionTest do
     end
 
     assert {:ok, %{title: "About Marty McFly"}} =
-             Reactor.run(SuccessfulNamedReturnTransactionReactor)
+             Reactor.run!(SuccessfulNamedReturnTransactionReactor)
   end
 
   test "when the transaction fails it is rolled back" do


### PR DESCRIPTION
Thanks to @carlgleisner for the [detailed reproduction](https://github.com/carlgleisner/reactor_notification_worker_issue).

The problem was caused by an attempt to not have nested reactors indepdently publish their notifications separate to the parents but contained a logic flaw which caused the agent to not start, but only the first time you try and use a given reactor.

The fix involves _always_ starting a notification agent for each reactor, but nesting them.  When a reactor completes it either publishes it's notifications to the parent reactor or to ash if there are no parent reactors.
