### PR TITLE
Fix Ash.Resource.Info.public_relationship/2

### DIFF
--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -351,6 +351,10 @@ defmodule Ash.Resource.Info do
   end
 
   @doc "Get a public relationship by name or path"
+  def public_relationship(resource, [name]) do
+    public_relationship(resource, name)
+  end
+
   def public_relationship(resource, [name | rest]) do
     case public_relationship(resource, name) do
       nil ->

--- a/test/resource/info_test.exs
+++ b/test/resource/info_test.exs
@@ -208,12 +208,10 @@ defmodule Ash.Test.Resource.InfoTest do
     end
 
     test "get relationship fields" do
-      assert Spark.Dsl.Extension.get_entities(Comment, [:post]) |> IO.inspect()
-      IO.inspect(IEx.Info.info(Comment))
+      assert Spark.Dsl.Extension.get_entities(Comment, [:post])
 
       comment = Info.public_relationship(Post, [:comments]).destination
-      IO.inspect(IEx.Info.info(comment))
-      assert Spark.Dsl.Extension.get_entities(comment, [:post]) |> IO.inspect()
+      assert Spark.Dsl.Extension.get_entities(comment, [:post])
 
       assert %Resource.Relationships.ManyToMany{name: :tags} =
                Info.public_relationship(Post, :tags)


### PR DESCRIPTION
The function was missing a base case causing it to always return nil when trying to get relationships by path.

# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [x] Update dependencies
