### PR TITLE
fix(types): Missing types on spec for can/can? functions

### DIFF
--- a/lib/ash/api/api.ex
+++ b/lib/ash/api/api.ex
@@ -760,8 +760,8 @@ defmodule Ash.Api do
             Ash.Query.t()
             | Ash.Changeset.t()
             | Ash.ActionInput.t()
-            | {Ash.Resource.t(), atom | Ash.Resource.Actions.action()}
-            | {Ash.Resource.t(), atom | Ash.Resource.Actions.action(), input :: map},
+            | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action()}
+            | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action(), input :: map},
           actor :: term,
           opts :: Keyword.t()
         ) ::
@@ -786,8 +786,8 @@ defmodule Ash.Api do
             Ash.Query.t()
             | Ash.Changeset.t()
             | Ash.ActionInput.t()
-            | {Ash.Resource.t(), atom | Ash.Resource.Actions.action()}
-            | {Ash.Resource.t(), atom | Ash.Resource.Actions.action(), input :: map},
+            | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action()}
+            | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action(), input :: map},
           actor :: term,
           opts :: Keyword.t()
         ) ::
@@ -1712,8 +1712,8 @@ defmodule Ash.Api do
                 Ash.Query.t()
                 | Ash.Changeset.t()
                 | Ash.ActionInput.t()
-                | {Ash.Resource.t(), atom | Ash.Resource.Actions.action()}
-                | {Ash.Resource.t(), atom | Ash.Resource.Actions.action(), input :: map},
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action()}
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action(), input :: map},
               actor :: term,
               opts :: Keyword.t()
             ) ::
@@ -1753,8 +1753,8 @@ defmodule Ash.Api do
                 Ash.Query.t()
                 | Ash.Changeset.t()
                 | Ash.ActionInput.t()
-                | {Ash.Resource.t(), atom | Ash.Resource.Actions.action()}
-                | {Ash.Resource.t(), atom | Ash.Resource.Actions.action(), input :: map},
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action()}
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action(), input :: map},
               actor :: term,
               opts :: Keyword.t()
             ) ::

--- a/lib/ash/api/interface.ex
+++ b/lib/ash/api/interface.ex
@@ -9,7 +9,8 @@ defmodule Ash.Api.Interface do
               query_or_changeset_or_action ::
                 Ash.Query.t()
                 | Ash.Changeset.t()
-                | {Ash.Resource.t(), atom | Ash.Resource.Actions.action()},
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action()}
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action(), input :: map},
               actor :: term,
               opts :: Keyword.t()
             ) ::
@@ -22,7 +23,8 @@ defmodule Ash.Api.Interface do
               action_or_query_or_changeset ::
                 Ash.Query.t()
                 | Ash.Changeset.t()
-                | {Ash.Resource.t(), atom | Ash.Resource.Actions.action()},
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action()}
+                | {Ash.Resource.t() | Ash.Resource.record(), atom | Ash.Resource.Actions.action(), input :: map},
               actor :: term,
               opts :: Keyword.t()
             ) ::

--- a/test/policy/rbac_test.exs
+++ b/test/policy/rbac_test.exs
@@ -124,7 +124,7 @@ defmodule Ash.Test.Policy.RbacTest do
     assert Api.can?(changeset, user)
   end
 
-  test "if the update can be performed with a filter, the can utility should return true", %{
+  test "if the changeset update can be performed with a filter, the can utility should return true", %{
     user: user,
     org: org
   } do
@@ -134,6 +134,26 @@ defmodule Ash.Test.Policy.RbacTest do
     changeset = Ash.Changeset.for_update(file_with_access, :update, %{name: "bar"})
 
     assert Api.can?(changeset, user)
+  end
+
+  test "if the resource struct update can be performed with a filter, the can utility should return true", %{
+    user: user,
+    org: org
+  } do
+    file_with_access = create_file(org, "foo")
+    give_role(user, org, :admin, :file, file_with_access.id)
+
+    assert Api.can?({file_with_access, :update}, user)
+  end
+
+  test "if the resource struct update_with_args can be performed with a filter, the can utility should return true", %{
+    user: user,
+    org: org
+  } do
+    file_with_access = create_file(org, "foo")
+    give_role(user, org, :admin, :file, file_with_access.id)
+
+    assert Api.can?({file_with_access, :update_with_args, %{some_arg: "things"}}, user)
   end
 
   defp give_role(user, org, role, resource, resource_id) do

--- a/test/support/policy_rbac/resources/file.ex
+++ b/test/support/policy_rbac/resources/file.ex
@@ -25,6 +25,10 @@ defmodule Ash.Test.Support.PolicyRbac.File do
 
   actions do
     defaults [:create, :read, :update, :destroy]
+
+    update :update_with_args do
+      argument :some_arg, :string, allow_nil?: false
+    end
   end
 
   attributes do


### PR DESCRIPTION
Was refactoring app to leverage the policies `can?` fn like:

```elixir
Hello.World.can?({thing, :update}, actor)
```

Code worked fine, but Dialyzer yelled at me with

```
The function call will not succeed.

Hello.World.can?(
  {%Hello.World.Thing{_ => _},
   :update},
  _actor :: any()
)

will never return since the 1st arguments differ
from the success typing arguments:

(
  {atom(), atom()}
  | %{
      :__struct__ => Ash.Changeset | Ash.Query,
      :__validated_for_action__ => atom(),
      :action =>
        nil
        | %{
            :__struct__ =>
              Ash.Resource.Actions.Action
              | Ash.Resource.Actions.Create
              | Ash.Resource.Actions.Destroy
              | Ash.Resource.Actions.Read
              | Ash.Resource.Actions.Update,
            :arguments => [map()],
            :description => nil | binary(),
            :name => atom(),
            :primary? => boolean(),
            :touches_resources => [atom()],
            :transaction? => _,
            :type => :action | :create | :destroy | :read | :update,
            :accept => _,
            :allow_nil? => boolean(),
            :allow_nil_input => [atom()],
            :atomics => _,
            :changes => _,
            :constraints => [{_, _}],
            :delay_global_validations? => boolean(),
            :error_handler => _,
            :filter => _,
            :get? => false | nil | true,
            :get_by => atom() | [atom()],
            :manual => atom() | {atom(), [any()]},
            :manual? => _,
            :metadata => _,
            :modify_query => nil | {atom(), atom(), byte()},
            :pagination => _,
            :preparations => _,
            :reject => _,
            :require_atomic? => boolean(),
            :require_attributes => _,
            :returns => atom() | {:array, atom()},
            :run => {atom(), [any()]},
            :skip_global_validations? => boolean(),
            :soft? => _,
            :timeout => nil | pos_integer(),
            :upsert? => boolean(),
            :upsert_fields =>
              nil
              | :replace_all
              | [atom()]
              | {:replace, [any()]}
              | {:replace_all_except, [any()]},
            :upsert_identity => atom()
          },
      :action_failed? => boolean(),
      :after_action => [
        (map(), [any()] | map() -> {_, _} | {_, _, _}) | {(_, _ -> any()), map()}
      ],
      :api => atom(),
      :arguments => %{atom() => _},
      :around_transaction => _,
      :before_action => [(map() -> {_, _} | map()) | {(_, _ -> any()), map()}],
      :context => map(),
      :errors => [
        %{
          :__exception__ => true,
          :__struct__ => atom(),
          :changeset => nil | map(),
          :class => :forbidden | :framework | :invalid | :unknown,
          :error_context => [any()],
          :path => [any()],
          :query => nil | map(),
          :stacktrace => nil | map(),
          :vars => [any()],
          atom() => _
        }
      ],
      :invalid_keys => _,
      :load => Keyword.t([any()]),
      :params => %{atom() | binary() => _},
      :phase =>
        :after_action
        | :after_transaction
        | :around_action
        | :around_transaction
        | :before_action
        | :before_transaction
        | :executing
        | :preparing
        | :validate,
      :resource => atom(),
      :select => nil | [atom()],
      :tenant => _,
      :timeout => nil | pos_integer(),
      :valid? => boolean(),
      :action_type => :action | :create | :destroy | nil | :read | :update,
      :after_transaction => [(map(), {_, _} -> {_, _}) | {(_, _ -> any()), map()}],
      :aggregates => %{atom() => %Ash.Filter{:expression => _, :resource => _}},
      :around_action => [
        (map(), (_ -> any()) -> {_, _} | {_, _, _, _}) | {(_, _ -> any()), map()}
      ],
      :atomic_validations => _,
      :atomics => Keyword.t(),
      :attributes => %{atom() => _},
      :authorize_results => [(map(), [any()] -> {_, _})],
      :before_transaction => [(map() -> map()) | {(_ -> any()), map()}],
      :calculations => %{atom() => :wat},
      :casted_arguments => _,
      :casted_attributes => _,
      :data => nil | struct(),
      :defaults => [atom()],
      :distinct => [atom()],
      :distinct_sort => _,
      :filter => nil | %Ash.Filter{:expression => _, :resource => _},
      :filters => _,
      :handle_errors =>
        nil
        | (%Ash.Changeset{:__validated_for_action__ => atom(), :action => _, _ => _}, _ ->
             any()),
      :limit => nil | non_neg_integer(),
      :load_through => _,
      :lock => _,
      :offset => non_neg_integer(),
      :relationships => %{atom() => [map()] | %{atom() | binary() => _}},
      :sort => [atom() | {atom(), :asc | :desc}],
      :sort_input_indices => _
    },
  any()
)
```

Added missing types also added tests for variant we're using that weren't covered in tests

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
