### PR TITLE
fix: swap the parameters in Ash.ToTenant.to_tenant/2

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -104,7 +104,7 @@ defmodule Ash.Changeset do
         if changeset.tenant do
           concat(
             "tenant: ",
-            to_doc(Ash.ToTenant.to_tenant(changeset.resource, changeset.tenant), opts)
+            to_doc(Ash.ToTenant.to_tenant(changeset.tenant, changeset.resource), opts)
           )
         else
           empty()

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -500,7 +500,7 @@ defmodule Ash.DataLayer do
   @spec set_tenant(Ash.Resource.t(), data_layer_query(), String.t()) ::
           {:ok, data_layer_query()} | {:error, term}
   def set_tenant(resource, query, term) do
-    term = Ash.ToTenant.to_tenant(resource, term)
+    term = Ash.ToTenant.to_tenant(term, resource)
     Ash.DataLayer.data_layer(resource).set_tenant(resource, query, term)
   end
 

--- a/lib/ash/to_tenant.ex
+++ b/lib/ash/to_tenant.ex
@@ -13,7 +13,7 @@ defprotocol Ash.ToTenant do
     ...
 
     defimpl Ash.ToTenant do
-      def to_tenant(%{id: id}), do: "org_\#{id}"
+      def to_tenant(%{id: id}, _resource), do: "org_\#{id}"
     end
   end
   ```
@@ -21,19 +21,19 @@ defprotocol Ash.ToTenant do
 
   @type t :: term()
 
-  @spec to_tenant(Ash.Resource.t(), t) :: term()
-  def to_tenant(resource, value)
+  @spec to_tenant(t, Ash.Resource.t()) :: term()
+  def to_tenant(value, resource)
 end
 
 defimpl Ash.ToTenant, for: BitString do
-  def to_tenant(_resource, value), do: value
+  def to_tenant(value, _resource), do: value
 end
 
 defimpl Ash.ToTenant, for: Atom do
-  def to_tenant(_resource, nil), do: nil
-  def to_tenant(_resource, value), do: value
+  def to_tenant(nil, _resource), do: nil
+  def to_tenant(value, _resource), do: value
 end
 
 defimpl Ash.ToTenant, for: Integer do
-  def to_tenant(_resource, value), do: value
+  def to_tenant(value, _resource), do: value
 end


### PR DESCRIPTION
This is technically a breaking change, but without this the protocol would never work as intended since the funtion gets dispatched based on the type of the first parameter and the resource parameter will always be an atom (precisely, an alias) so the implementation for Atom will always be called

I'll add regression tests in another PR where I call the protocol in actions, I've wanted to leave this separate to highlight the need for a breaking change

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
