### PR TITLE
Properly set action_type when preparing changesets

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1436,7 +1436,7 @@ defmodule Ash.Changeset do
   def prepare_changeset_for_action(changeset, action, opts) do
     changeset
     |> Map.put(:action, action)
-    |> Map.put(:action_type, action.type || :update)
+    |> Map.put(:action_type, action.type)
     |> reset_arguments()
     |> handle_errors(action.error_handler)
     |> set_actor(opts)

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1436,6 +1436,7 @@ defmodule Ash.Changeset do
   def prepare_changeset_for_action(changeset, action, opts) do
     changeset
     |> Map.put(:action, action)
+    |> Map.put(:action_type, action.type || :update)
     |> reset_arguments()
     |> handle_errors(action.error_handler)
     |> set_actor(opts)


### PR DESCRIPTION
In trying to implement bulk actions, we encountered an issue where the `action_type` on a `bulk_delete` was being set as `:update`. We have an after action that depends on the `action_type` being correct. This MR attempts to ensure that the `action_type` is set correctly.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
