### PR TITLE
fix: `code_interface` actions accept `@context`

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -47,10 +47,6 @@ defmodule Ash do
       doc:
         "If an actor option is provided (even if it is `nil`), authorization happens automatically. If not, this flag can be used to authorize with no user."
     ],
-    context: [
-      type: :map,
-      doc: "Context to set on the query, changeset, or input"
-    ],
     tenant: [
       type: {:protocol, Ash.ToTenant},
       doc: "A tenant to set on the query or changeset"
@@ -59,6 +55,10 @@ defmodule Ash do
       type: :any,
       doc:
         "If an actor is provided, it will be used in conjunction with the authorizers of a resource to authorize access"
+    ],
+    context: [
+      type: :map,
+      doc: "Context to set on the query, changeset, or input"
     ]
   ]
 

--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -47,6 +47,10 @@ defmodule Ash do
       doc:
         "If an actor option is provided (even if it is `nil`), authorization happens automatically. If not, this flag can be used to authorize with no user."
     ],
+    context: [
+      type: :map,
+      doc: "Context to set on the query, changeset, or input"
+    ],
     tenant: [
       type: {:protocol, Ash.ToTenant},
       doc: "A tenant to set on the query or changeset"
@@ -55,10 +59,6 @@ defmodule Ash do
       type: :any,
       doc:
         "If an actor is provided, it will be used in conjunction with the authorizers of a resource to authorize access"
-    ],
-    context: [
-      type: :map,
-      doc: "Context to set on the query, changeset, or input"
     ]
   ]
 

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1031,7 +1031,7 @@ defmodule Ash.Changeset do
       type: {:wrap_list, {:behaviour, Ash.Tracer}},
       doc:
         "A tracer to use. Will be carried over to the action. For more information see `Ash.Tracer`."
-    ]
+    ],
     tenant: [
       type: {:protocol, Ash.ToTenant},
       doc: "set the tenant on the changeset"

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1043,8 +1043,7 @@ defmodule Ash.Changeset do
     ],
     context: [
       type: :map,
-      doc:
-        "Context to set on the query, changeset, or input""
+      doc: "Context to set on the query, changeset, or input"
     ]
   ]
 

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1027,6 +1027,11 @@ defmodule Ash.Changeset do
       doc:
         "set authorize?, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
     ],
+    context: [
+      type: :map,
+      doc:
+        "set context, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
+    ],
     tracer: [
       type: {:wrap_list, {:behaviour, Ash.Tracer}},
       doc:

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1027,16 +1027,11 @@ defmodule Ash.Changeset do
       doc:
         "set authorize?, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
     ],
-    context: [
-      type: :map,
-      doc:
-        "set context, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
-    ],
     tracer: [
       type: {:wrap_list, {:behaviour, Ash.Tracer}},
       doc:
         "A tracer to use. Will be carried over to the action. For more information see `Ash.Tracer`."
-    ],
+    ]
     tenant: [
       type: {:protocol, Ash.ToTenant},
       doc: "set the tenant on the changeset"
@@ -1045,6 +1040,11 @@ defmodule Ash.Changeset do
       type: {:list, {:or, [:atom, :string]}},
       doc:
         "A list of inputs that, if provided, will be ignored if they are not recognized by the action."
+    ],
+    context: [
+      type: :map,
+      doc:
+        "set context, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
     ]
   ]
 

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1044,7 +1044,7 @@ defmodule Ash.Changeset do
     context: [
       type: :map,
       doc:
-        "set context, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
+        "Context to set on the query, changeset, or input""
     ]
   ]
 

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -566,8 +566,6 @@ defmodule Ash.CodeInterface do
                   {query_opts, opts} =
                     Keyword.split(opts, [:query, :actor, :tenant, :authorize?, :tracer, :context])
 
-                  {context, query_opts} = Keyword.pop(query_opts, :context, %{})
-
                   {query, query_opts} = Keyword.pop(query_opts, :query)
 
                   query_opts = Keyword.put(query_opts, :domain, unquote(domain))
@@ -593,10 +591,8 @@ defmodule Ash.CodeInterface do
                       query
                       |> Ash.Query.for_read(unquote(action.name), params, query_opts)
                       |> Ash.Query.filter(filters)
-                      |> Ash.Query.set_context(context)
                     else
                       Ash.Query.for_read(query, unquote(action.name), params, query_opts)
-                      |> Ash.Query.set_context(context)
                     end
                 end
 
@@ -671,8 +667,6 @@ defmodule Ash.CodeInterface do
                       :tracer
                     ])
 
-                  {context, changeset_opts} = Keyword.pop(changeset_opts, :context, %{})
-
                   changeset_opts = Keyword.put(changeset_opts, :domain, unquote(domain))
 
                   changeset =
@@ -698,7 +692,6 @@ defmodule Ash.CodeInterface do
                           changeset
                       end
                       |> Ash.Changeset.for_create(unquote(action.name), params, changeset_opts)
-                      |> Ash.Changeset.set_context(context)
                     end
                 end
 
@@ -710,7 +703,6 @@ defmodule Ash.CodeInterface do
                         opts
                         |> Keyword.delete(:bulk_options)
                         |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
-                        |> Keyword.put(:context, context)
                         |> Enum.concat(changeset_opts)
 
                       Ash.bulk_create(
@@ -733,7 +725,6 @@ defmodule Ash.CodeInterface do
                         opts
                         |> Keyword.delete(:bulk_options)
                         |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
-                        |> Keyword.put(:context, context)
                         |> Enum.concat(changeset_opts)
 
                       Ash.bulk_create!(
@@ -759,8 +750,6 @@ defmodule Ash.CodeInterface do
                   {changeset_opts, opts} =
                     Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer, :context])
 
-                  {context, changeset_opts} = Keyword.pop(changeset_opts, :context, %{})
-
                   changeset_opts = Keyword.put(changeset_opts, :domain, unquote(domain))
 
                   changeset =
@@ -773,7 +762,6 @@ defmodule Ash.CodeInterface do
                           params,
                           changeset_opts
                         )
-                        |> Ash.Changeset.set_context(context)
 
                       %Ash.Changeset{resource: other_resource} ->
                         raise ArgumentError,
@@ -790,7 +778,6 @@ defmodule Ash.CodeInterface do
                           params,
                           changeset_opts
                         )
-                        |> Ash.Changeset.set_context(context)
 
                       %Ash.Query{} = query ->
                         {:atomic, :query, query}
@@ -820,7 +807,6 @@ defmodule Ash.CodeInterface do
                         opts
                         |> Keyword.delete(:bulk_options)
                         |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
-                        |> Keyword.put(:context, context)
                         |> Enum.concat(changeset_opts)
                         |> then(fn bulk_opts ->
                           if method == :id do
@@ -873,7 +859,6 @@ defmodule Ash.CodeInterface do
                         opts
                         |> Keyword.delete(:bulk_options)
                         |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
-                        |> Keyword.put(:context, context)
                         |> Enum.concat(changeset_opts)
                         |> then(fn bulk_opts ->
                           if method == :id do
@@ -925,8 +910,6 @@ defmodule Ash.CodeInterface do
                   {changeset_opts, opts} =
                     Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer, :context])
 
-                  {context, changeset_opts} = Keyword.pop(changeset_opts, :context, %{})
-
                   changeset_opts = Keyword.put(changeset_opts, :domain, unquote(domain))
 
                   changeset =
@@ -939,7 +922,6 @@ defmodule Ash.CodeInterface do
                           params,
                           changeset_opts
                         )
-                        |> Ash.Changeset.set_context(context)
 
                       %Ash.Changeset{resource: other_resource} ->
                         raise ArgumentError,
@@ -956,7 +938,6 @@ defmodule Ash.CodeInterface do
                           params,
                           changeset_opts
                         )
-                        |> Ash.Changeset.set_context(context)
 
                       %Ash.Query{} = query ->
                         {:atomic, :query, query}
@@ -986,7 +967,6 @@ defmodule Ash.CodeInterface do
                         opts
                         |> Keyword.drop([:bulk_options, :return_destroyed?])
                         |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
-                        |> Keyword.put(:context, context)
                         |> Enum.concat(changeset_opts)
                         |> then(fn bulk_opts ->
                           if method == :id do
@@ -1044,7 +1024,6 @@ defmodule Ash.CodeInterface do
                         opts
                         |> Keyword.drop([:bulk_options, :return_destroyed?])
                         |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
-                        |> Keyword.put(:context, context)
                         |> Enum.concat(changeset_opts)
                         |> then(fn bulk_opts ->
                           if method == :id do

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -658,14 +658,7 @@ defmodule Ash.CodeInterface do
                   {changeset, opts} = Keyword.pop(opts, :changeset)
 
                   {changeset_opts, opts} =
-                    Keyword.split(opts, [
-                      :changeset,
-                      :actor,
-                      :tenant,
-                      :authorize?,
-                      :tracer,
-                      :context
-                    ])
+                    Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer, :context])
 
                   changeset_opts = Keyword.put(changeset_opts, :domain, unquote(domain))
 

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -659,12 +659,12 @@ defmodule Ash.CodeInterface do
 
                   {changeset_opts, opts} =
                     Keyword.split(opts, [
-                      :context,
                       :changeset,
                       :actor,
                       :tenant,
                       :authorize?,
-                      :tracer
+                      :tracer,
+                      :context
                     ])
 
                   changeset_opts = Keyword.put(changeset_opts, :domain, unquote(domain))


### PR DESCRIPTION
# Info

- Actions generated by for the code interface did not accept the `@context` option and returned an error/exception.
- We seem to have spotted a bug in `bulk create` (see change `lib/ash/code_interface.ex#702`)
- Ready for review for Ash 3.0 code base
  - Ash 2.0 https://github.com/ash-project/ash/pull/1017
- Many thanks to @barnabasJ for supporting me while digging into this 🤝 