### PR TITLE
improvement: use cached to_tenant when setting tenant attribute

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -513,8 +513,7 @@ defmodule Ash.Actions.Create.Bulk do
          Ash.Resource.Info.multitenancy_strategy(changeset.resource) == :attribute do
       attribute = Ash.Resource.Info.multitenancy_attribute(changeset.resource)
       {m, f, a} = Ash.Resource.Info.multitenancy_parse_attribute(changeset.resource)
-      tenant = Ash.ToTenant.to_tenant(changeset.tenant, changeset.resource)
-      attribute_value = apply(m, f, [tenant | a])
+      attribute_value = apply(m, f, [changeset.to_tenant | a])
 
       Ash.Changeset.force_change_attribute(changeset, attribute, attribute_value)
     else

--- a/lib/ash/actions/create/create.ex
+++ b/lib/ash/actions/create/create.ex
@@ -497,8 +497,7 @@ defmodule Ash.Actions.Create do
          Ash.Resource.Info.multitenancy_strategy(changeset.resource) == :attribute do
       attribute = Ash.Resource.Info.multitenancy_attribute(changeset.resource)
       {m, f, a} = Ash.Resource.Info.multitenancy_parse_attribute(changeset.resource)
-      tenant = Ash.ToTenant.to_tenant(changeset.tenant, changeset.resource)
-      attribute_value = apply(m, f, [tenant | a])
+      attribute_value = apply(m, f, [changeset.to_tenant | a])
 
       Ash.Changeset.force_change_attribute(changeset, attribute, attribute_value)
     else

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -1148,8 +1148,7 @@ defmodule Ash.Actions.Read do
 
     if multitenancy_attribute && query.tenant do
       {m, f, a} = Ash.Resource.Info.multitenancy_parse_attribute(query.resource)
-      tenant = Ash.ToTenant.to_tenant(query.tenant, query.resource)
-      attribute_value = apply(m, f, [tenant | a])
+      attribute_value = apply(m, f, [query.to_tenant | a])
       Ash.Query.filter(query, ^ref(multitenancy_attribute) == ^attribute_value)
     else
       query

--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -581,8 +581,7 @@ defmodule Ash.Actions.Update do
       attribute = Ash.Resource.Info.multitenancy_attribute(changeset.resource)
 
       {m, f, a} = Ash.Resource.Info.multitenancy_parse_attribute(changeset.resource)
-      tenant = Ash.ToTenant.to_tenant(changeset.tenant, changeset.resource)
-      attribute_value = apply(m, f, [tenant | a])
+      attribute_value = apply(m, f, [changeset.to_tenant | a])
 
       Ash.Changeset.force_change_attribute(changeset, attribute, attribute_value)
     else


### PR DESCRIPTION
Improvement over 9f2b4ab8baf now that we cache to to_tenant value in changesets and queries

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
