### PR TITLE
fix: support all calculate opts in code interface methods

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -322,7 +322,7 @@ defmodule Ash.CodeInterface do
 
              ### Options
 
-             #{Spark.Options.docs(Ash.Resource.Interface.interface_options(:calculate))}
+             #{Spark.Options.docs(opt_schema)}
              """
              |> Ash.CodeInterface.trim_double_newlines()
         @doc spark_opts: [
@@ -351,13 +351,8 @@ defmodule Ash.CodeInterface do
               end
             )
 
-          Ash.calculate!(unquote(resource), unquote(interface.calculation),
-            domain: unquote(domain),
-            refs: refs,
-            args: arguments,
-            actor: opts[:actor],
-            record: record
-          )
+          opts = [domain: unquote(domain), refs: refs, args: arguments, record: record] ++ opts
+          Ash.calculate!(unquote(resource), unquote(interface.calculation), opts)
         end
 
         @doc """
@@ -367,7 +362,7 @@ defmodule Ash.CodeInterface do
 
              ### Options
 
-             #{Spark.Options.docs(Ash.Resource.Interface.interface_options(:calculate))}
+             #{Spark.Options.docs(opt_schema)}
              """
              |> Ash.CodeInterface.trim_double_newlines()
         @doc spark_opts: [
@@ -396,13 +391,8 @@ defmodule Ash.CodeInterface do
               end
             )
 
-          Ash.calculate(unquote(resource), unquote(interface.calculation),
-            domain: unquote(domain),
-            refs: refs,
-            args: arguments,
-            actor: opts[:actor],
-            record: record
-          )
+          opts = [domain: unquote(domain), refs: refs, args: arguments, record: record] ++ opts
+          Ash.calculate(unquote(resource), unquote(interface.calculation), opts)
         end
       end
 

--- a/lib/ash/resource/interface.ex
+++ b/lib/ash/resource/interface.ex
@@ -39,12 +39,8 @@ defmodule Ash.Resource.Interface do
   end
 
   def interface_options(:calculate) do
-    [
-      actor: [
-        type: :any,
-        doc: "The actor to use for actor references"
-      ]
-    ]
+    Ash.calculate_opts()
+    |> Keyword.drop([:domain, :refs, :args, :record])
   end
 
   def interface_options(:create) do


### PR DESCRIPTION
For some reason opts in code interface `define_calculation` methods were limited to only `actor`.

This allows using `authorize?`, `tenant` and `tracer` too.

(Note: `Ash.calculate` validates opts.)