### PR TITLE
docs: Fix filter semantics examples in Expressions guide

### DIFF
--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -150,15 +150,15 @@ The filter refers to a _single post/comment/tag combination_. So in english, thi
 
 ```elixir
 def has_comment_with_more_points_than(query, score) do
-  Ash.Query.filter(Post, comments.points > 10)
+  Ash.Query.filter(query, comments.points > ^score)
 end
 
 def has_comment_tagged(query, tag) do
-  Ash.Query.filter(Post, comments.tag.name == ^tag)
+  Ash.Query.filter(query, comments.tag.name == ^tag)
 end
 
 Post
-|> has_comment_with_more_points_than(query, 10)
+|> has_comment_with_more_points_than(10)
 |> has_comment_tagged("elixir")
 ```
 
@@ -170,15 +170,15 @@ Lets rewrite the above using exists:
 
 ```elixir
 def has_comment_with_more_points_than(query, score) do
-  Ash.Query.filter(Post, exists(comments, points > ^score))
+  Ash.Query.filter(query, exists(comments, points > ^score))
 end
 
 def has_comment_tagged(query, tag) do
-  Ash.Query.filter(Post, exists(comments.tag.name == ^tag)
+  Ash.Query.filter(query, exists(comments.tag.name == ^tag)
 end
 
 Post
-|> has_comment_with_more_points_than(query, ^score)
+|> has_comment_with_more_points_than(10)
 |> has_comment_tagged("elixir")
 ```
 


### PR DESCRIPTION
I think these changes would be needed to make the examples make sense!

Current: https://hexdocs.pm/ash/3.0.0-rc.27/expressions.html#filter-semantics-joins

Now: 
<img width="531" alt="Screenshot 2024-04-21 at 4 27 56 PM" src="https://github.com/ash-project/ash/assets/543859/e14d830f-adc0-4e4f-8a44-ca7999fd0ec1">

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
