### PR TITLE
Update upgrading-to-3.0.md

### DIFF
--- a/documentation/topics/development/upgrading-to-3.0.md
+++ b/documentation/topics/development/upgrading-to-3.0.md
@@ -296,7 +296,7 @@ For those who want to be more explicit, or after your upgrade has complete if yo
 
 > ### :\* includes belongs_to attributes! {: .warning}
 >
-> The change to explicit accepts also included a change that defaults belongs_to attributes to `writable?: true` and `public?: true`. You may want to add `attribute_writable?: false` to your belongs_to relationships if you are adding `default_accept :*` and don't currently have `attribute_writable?: true` on them currently.
+> The change to explicit accepts also included a change that defaults belongs_to attributes to `writable?: true` and `public?: false`. You may want to add `attribute_writable?: false` to your belongs_to relationships if you are adding `default_accept :*` and don't currently have `attribute_writable?: true` on them currently.
 
 ---
 


### PR DESCRIPTION
I might be misunderstanding this paragraph but it looks like `public?` defaults to `false`: https://hexdocs.pm/ash/3.0.0-rc.27/dsl-ash-resource.html#options-8