### PR TITLE
Don't filter by `public?` in `Ash.Resource.Transformers.DefaultAccept`

### DIFF
--- a/lib/ash/resource/transformers/default_accept.ex
+++ b/lib/ash/resource/transformers/default_accept.ex
@@ -6,10 +6,10 @@ defmodule Ash.Resource.Transformers.DefaultAccept do
   alias Spark.Dsl.Transformer
 
   def transform(dsl_state) do
-    public_attribute_names =
+    attribute_names =
       dsl_state
       |> Transformer.get_entities([:attributes])
-      |> Enum.filter(&(&1.public? && &1.writable?))
+      |> Enum.filter(& &1.writable?)
       |> Enum.map(& &1.name)
 
     default_default_accept =
@@ -50,7 +50,7 @@ defmodule Ash.Resource.Transformers.DefaultAccept do
       action, {:ok, dsl_state} ->
         accept =
           case List.wrap(action.accept || default_accept) do
-            [:*] -> public_attribute_names
+            [:*] -> attribute_names
             list -> list
           end
 


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Based on the [documentation](https://github.com/ash-project/ash/blob/44c38277e5848bf0abf1b5a98b057443627bfe99/documentation/topics/security/sensitive-data.md), the `public?` option has no effect internally within Ash. However, the current implementation of `Ash.Resource.Transformer.DefaultAccept` only adds public attributes with `:*`. As `Ash.Resource.Verifiers.ValidateAccept` has been modified to no longer consider whether attributes are public, it seems appropriate to apply the same principle to `Ash.Resource.Transformer.DefaultAccept`.