### PR TITLE
fix: handle resource being passed as query code_interface.ex

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -569,7 +569,7 @@ defmodule Ash.CodeInterface do
                         raise ArgumentError,
                               "Query resource #{inspect(other_resource)} does not match expected resource #{inspect(unquote(resource))}."
 
-                      resource when is_atom(resource) ->
+                      resource when is_atom(resource) and not is_nil(resource) ->
                         resource
 
                       query ->

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -569,6 +569,9 @@ defmodule Ash.CodeInterface do
                         raise ArgumentError,
                               "Query resource #{inspect(other_resource)} does not match expected resource #{inspect(unquote(resource))}."
 
+                      resource when is_atom(resource) ->
+                        resource
+
                       query ->
                         Ash.Query.build(unquote(resource), query || [])
                     end

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -569,8 +569,14 @@ defmodule Ash.CodeInterface do
                         raise ArgumentError,
                               "Query resource #{inspect(other_resource)} does not match expected resource #{inspect(unquote(resource))}."
 
-                      resource when is_atom(resource) and not is_nil(resource) ->
-                        resource
+                      unquote(resource) ->
+                        unquote(resource)
+                        |> Ash.Query.new()
+
+                      other_resource
+                      when is_atom(other_resource) and not is_nil(other_resource) ->
+                        raise ArgumentError,
+                              "Query resource #{inspect(other_resource)} does not match expected resource #{inspect(unquote(resource))}."
 
                       query ->
                         Ash.Query.build(unquote(resource), query || [])


### PR DESCRIPTION
This bit me today because I had code  like this and it worked in 2.0

```elixir
                Resource
                |> filter_board_codes(board_codes)
                |> filter_min_price(min_price)
                |> filter_max_price(max_price)
                |> filter_refundable_only(refundable_only)
```

and all the `filter_*` functions looked like this

```elixir
def filter_something(query, nil), do: query

def filter_something(query, something) do
  query
  |> Ash.Query.filter(....)
end
```

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
