### PR TITLE
fix: do not use Enum.map_join in Ash.Type.Enum.cast_atomic

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -160,7 +160,7 @@ defmodule Ash.Type.Enum do
                error(
                  Ash.Error.Changes.InvalidChanges,
                  message: "must be one of %{values}",
-                 vars: %{values: ^Enum.map_join(@values, ", ")}
+                 vars: %{values: ^Enum.join(@values, ", ")}
                )
              end
            )}
@@ -170,7 +170,7 @@ defmodule Ash.Type.Enum do
               error(
                 Ash.Error.Changes.InvalidChanges,
                 message: "must be one of %{values}",
-                vars: %{values: ^Enum.map_join(@values, ", ")}
+                vars: %{values: ^Enum.join(@values, ", ")}
               )
             )
 


### PR DESCRIPTION
values are only a flat list of values, and map_join would need a function as the third argument if you specify a `joiner`

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
