### PR TITLE
improvement: better create/update first argument

### DIFF
--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -269,6 +269,17 @@ defmodule Ash.Helpers do
     end
   end
 
+  @doc """
+  Returns {params, opts} from ambigous inputs.
+  """
+  def get_params_and_opts(params_or_opts, opts) do
+    if opts == [] && Keyword.keyword?(params_or_opts) do
+      {%{}, params_or_opts}
+    else
+      {params_or_opts, opts}
+    end
+  end
+
   def pagination_check(action, resource, opts) do
     if Keyword.get(opts, :page) && Keyword.get(opts, :page) != [] && !Map.get(action, :pagination) do
       {:error,

--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -178,6 +178,24 @@ defmodule Ash.Helpers do
     end
   end
 
+  defmacro expect_map_or_nil!(map_or_nil) do
+    formatted = format_caller(__CALLER__)
+
+    quote generated: true, bind_quoted: [map_or_nil: map_or_nil, formatted: formatted] do
+      case map_or_nil do
+        nil ->
+          :ok
+
+        map when is_map(map) ->
+          :ok
+
+        other ->
+          raise ArgumentError,
+                "Expected a keyword list in #{formatted}, got: #{inspect(other)}"
+      end
+    end
+  end
+
   def resource_from_query_or_stream(domain, query_or_stream, opts) do
     resource =
       opts[:resource] ||

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -1,5 +1,6 @@
 defmodule Ash.Test.AshTest do
   @moduledoc false
+
   use ExUnit.Case, async: true
 
   defmodule Domain do
@@ -53,73 +54,121 @@ defmodule Ash.Test.AshTest do
 
   describe "create/1" do
     test "with a resource as first argument" do
-      assert {:ok, %User{name: "John"}} = Ash.create(User, input: %{name: "John"})
+      assert {:ok, %User{name: nil}} = Ash.create(User)
     end
   end
 
   describe "create/2" do
-    test "with a record as first argument and explicit action" do
-      assert {:ok, %User{name: "John"}} =
-               Ash.create(User, input: %{name: "John"}, action: :create)
+    test "with a resource as first argument, with params as second argument" do
+      assert {:ok, %User{name: "Alice"}} = Ash.create(User, %{name: "Alice"})
+    end
 
-      assert {:ok, %User{name: "John", state: :awake}} =
-               Ash.create(User, input: %{name: "John"}, action: :create_awake)
+    test "with a resource as first argument, with opts as second argument" do
+      assert {:ok, %User{name: nil}} = Ash.create(User, action: :create)
+    end
+  end
+
+  describe "create/3" do
+    test "with a record as first argument, then params and opts" do
+      assert {:ok, %User{name: "Alice"}} =
+               Ash.create(User, %{name: "Alice"}, action: :create)
+
+      assert {:ok, %User{name: "Alice", state: :awake}} =
+               Ash.create(User, %{name: "Alice"}, action: :create_awake)
     end
   end
 
   describe "create!/1" do
     test "with a resource as first argument" do
-      assert %User{name: "John"} = Ash.create!(User, input: %{name: "John"})
+      assert %User{name: nil} = Ash.create!(User)
     end
   end
 
   describe "create!/2" do
-    test "with a record as first argument and explicit action" do
-      assert %User{name: "John"} =
-               Ash.create!(User, input: %{name: "John"}, action: :create)
+    test "with a resource as first argument, with params as second argument" do
+      assert %User{name: "Alice"} = Ash.create!(User, %{name: "Alice"})
+    end
 
-      assert %User{name: "John", state: :awake} =
-               Ash.create!(User, input: %{name: "John"}, action: :create_awake)
+    test "with a resource as first argument, with opts as second argument" do
+      assert %User{name: nil} = Ash.create!(User, action: :create)
+    end
+  end
+
+  describe "create!/3" do
+    test "with a record as first argument, then params and opts" do
+      assert %User{name: "Alice"} =
+               Ash.create!(User, %{name: "Alice"}, action: :create)
+
+      assert %User{name: "Alice", state: :awake} =
+               Ash.create!(User, %{name: "Alice"}, action: :create_awake)
     end
   end
 
   describe "update/1" do
     test "with a record as first argument" do
-      user = Ash.create!(User, input: %{name: "John"})
+      user = Ash.create!(User, %{name: "Alice"})
 
-      assert {:ok, %User{name: "Jane"}} = Ash.update(user, input: %{name: "Jane"})
+      assert {:ok, %User{name: "Alice"}} = Ash.update(user)
     end
   end
 
   describe "update/2" do
-    test "with a record as first argument and explicit action" do
-      user = Ash.create!(User, input: %{name: "John"})
+    test "with a record as first argument, with params as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
 
-      assert {:ok, %User{name: "Jane"}} =
-               Ash.update(user, input: %{name: "Jane"}, action: :update)
+      assert {:ok, %User{name: "Bob"}} = Ash.update(user, %{name: "Bob"})
+    end
 
-      assert {:ok, %User{name: "John", state: :awake}} =
-               Ash.update(user, input: %{state: :awake}, action: :update_state)
+    test "with a record as first argument, with opts as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert {:ok, %User{name: "Alice"}} = Ash.update(user, action: :update)
+    end
+  end
+
+  describe "update/3" do
+    test "with a record as first argument, then params and opts" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert {:ok, %User{name: "Bob"}} =
+               Ash.update(user, %{name: "Bob"}, action: :update)
+
+      assert {:ok, %User{name: "Alice", state: :awake}} =
+               Ash.update(user, %{state: :awake}, action: :update_state)
     end
   end
 
   describe "update!/1" do
     test "with a record as first argument" do
-      user = Ash.create!(User, input: %{name: "John"})
+      user = Ash.create!(User, %{name: "Alice"})
 
-      assert %User{name: "Jane"} = Ash.update!(user, input: %{name: "Jane"})
+      assert %User{name: "Alice"} = Ash.update!(user)
     end
   end
 
   describe "update!/2" do
+    test "with a record as first argument, with params as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert %User{name: "Bob"} = Ash.update!(user, %{name: "Bob"})
+    end
+
+    test "with a record as first argument, with opts as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert %User{name: "Alice"} = Ash.update!(user, action: :update)
+    end
+  end
+
+  describe "update!/3" do
     test "with a record as first argument and explicit action" do
-      user = Ash.create!(User, input: %{name: "John"})
+      user = Ash.create!(User, %{name: "Alice"})
 
-      assert %User{name: "Jane"} =
-               Ash.update!(user, input: %{name: "Jane"}, action: :update)
+      assert %User{name: "Bob"} =
+               Ash.update!(user, %{name: "Bob"}, action: :update)
 
-      assert %User{name: "John", state: :awake} =
-               Ash.update!(user, input: %{state: :awake}, action: :update_state)
+      assert %User{name: "Alice", state: :awake} =
+               Ash.update!(user, %{state: :awake}, action: :update_state)
     end
   end
 end

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -52,102 +52,74 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "create/1" do
-    test "with a {resource, args} as first argument" do
-      assert {:ok, %User{name: "John"}} = Ash.create({User, name: "John"})
-      assert {:ok, %User{name: "John"}} = Ash.create({User, %{name: "John"}})
+    test "with a resource as first argument" do
+      assert {:ok, %User{name: "John"}} = Ash.create(User, input: %{name: "John"})
     end
   end
 
   describe "create/2" do
-    test "with a {record, args} as first argument and explicit action" do
+    test "with a record as first argument and explicit action" do
       assert {:ok, %User{name: "John"}} =
-               Ash.create({User, name: "John"}, action: :create)
-
-      assert {:ok, %User{name: "John"}} =
-               Ash.create({User, %{name: "John"}}, action: :create)
+               Ash.create(User, input: %{name: "John"}, action: :create)
 
       assert {:ok, %User{name: "John", state: :awake}} =
-               Ash.create({User, name: "John"}, action: :create_awake)
-
-      assert {:ok, %User{name: "John", state: :awake}} =
-               Ash.create({User, %{name: "John"}}, action: :create_awake)
+               Ash.create(User, input: %{name: "John"}, action: :create_awake)
     end
   end
 
   describe "create!/1" do
-    test "with a {resource, args} as first argument" do
-      assert %User{name: "John"} = Ash.create!({User, name: "John"})
-      assert %User{name: "John"} = Ash.create!({User, %{name: "John"}})
+    test "with a resource as first argument" do
+      assert %User{name: "John"} = Ash.create!(User, input: %{name: "John"})
     end
   end
 
   describe "create!/2" do
-    test "with a {record, args} as first argument and explicit action" do
+    test "with a record as first argument and explicit action" do
       assert %User{name: "John"} =
-               Ash.create!({User, name: "John"}, action: :create)
-
-      assert %User{name: "John"} =
-               Ash.create!({User, %{name: "John"}}, action: :create)
+               Ash.create!(User, input: %{name: "John"}, action: :create)
 
       assert %User{name: "John", state: :awake} =
-               Ash.create!({User, name: "John"}, action: :create_awake)
-
-      assert %User{name: "John", state: :awake} =
-               Ash.create!({User, %{name: "John"}}, action: :create_awake)
+               Ash.create!(User, input: %{name: "John"}, action: :create_awake)
     end
   end
 
   describe "update/1" do
-    test "with a {record, args} as first argument" do
-      user = Ash.create!({User, name: "John"})
+    test "with a record as first argument" do
+      user = Ash.create!(User, input: %{name: "John"})
 
-      assert {:ok, %User{name: "Jane"}} = Ash.update({user, name: "Jane"})
-      assert {:ok, %User{name: "Jane"}} = Ash.update({user, %{name: "Jane"}})
+      assert {:ok, %User{name: "Jane"}} = Ash.update(user, input: %{name: "Jane"})
     end
   end
 
   describe "update/2" do
-    test "with a {record, args} as first argument and explicit action" do
-      user = Ash.create!({User, name: "John"})
+    test "with a record as first argument and explicit action" do
+      user = Ash.create!(User, input: %{name: "John"})
 
       assert {:ok, %User{name: "Jane"}} =
-               Ash.update({user, name: "Jane"}, action: :update)
-
-      assert {:ok, %User{name: "Jane"}} =
-               Ash.update({user, %{name: "Jane"}}, action: :update)
+               Ash.update(user, input: %{name: "Jane"}, action: :update)
 
       assert {:ok, %User{name: "John", state: :awake}} =
-               Ash.update({user, state: :awake}, action: :update_state)
-
-      assert {:ok, %User{name: "John", state: :awake}} =
-               Ash.update({user, %{state: :awake}}, action: :update_state)
+               Ash.update(user, input: %{state: :awake}, action: :update_state)
     end
   end
 
   describe "update!/1" do
-    test "with a {record, args} as first argument" do
-      user = Ash.create!({User, name: "John"})
+    test "with a record as first argument" do
+      user = Ash.create!(User, input: %{name: "John"})
 
-      assert %User{name: "Jane"} = Ash.update!({user, name: "Jane"})
-      assert %User{name: "Jane"} = Ash.update!({user, %{name: "Jane"}})
+      assert %User{name: "Jane"} = Ash.update!(user, input: %{name: "Jane"})
     end
   end
 
   describe "update!/2" do
-    test "with a {record, args} as first argument and explicit action" do
-      user = Ash.create!({User, name: "John"})
+    test "with a record as first argument and explicit action" do
+      user = Ash.create!(User, input: %{name: "John"})
 
       assert %User{name: "Jane"} =
-               Ash.update!({user, name: "Jane"}, action: :update)
-
-      assert %User{name: "Jane"} =
-               Ash.update!({user, %{name: "Jane"}}, action: :update)
+               Ash.update!(user, input: %{name: "Jane"}, action: :update)
 
       assert %User{name: "John", state: :awake} =
-               Ash.update!({user, state: :awake}, action: :update_state)
-
-      assert %User{name: "John", state: :awake} =
-               Ash.update!({user, %{state: :awake}}, action: :update_state)
+               Ash.update!(user, input: %{state: :awake}, action: :update_state)
     end
   end
 end

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -53,12 +53,40 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "create/1" do
+    test "with a changeset as first argument" do
+      assert {:ok, %User{name: nil}} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create()
+    end
+
     test "with a resource as first argument" do
       assert {:ok, %User{name: nil}} = Ash.create(User)
     end
   end
 
   describe "create/2" do
+    test "with a changeset as first argument, with params as second argument" do
+      assert {:ok, %User{name: "Alice"}} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create(%{name: "Alice"})
+
+      assert_raise ArgumentError, fn ->
+        User
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create(%{name: "Alice"})
+      end
+    end
+
+    test "with a changeset as first argument, with opts as second argument" do
+      assert {:ok, %User{name: nil}} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create(action: :create)
+    end
+
     test "with a resource as first argument, with params as second argument" do
       assert {:ok, %User{name: "Alice"}} = Ash.create(User, %{name: "Alice"})
     end
@@ -69,6 +97,32 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "create/3" do
+    test "with a changeset as first argument, then params and opts" do
+      assert {:ok, %User{name: "Alice"}} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create(%{name: "Alice"})
+
+      assert {:ok, %User{name: "Alice", state: :awake}} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create(%{name: "Alice"}, action: :create_awake)
+
+      assert_raise ArgumentError, fn ->
+        User
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create(%{name: "Alice"})
+      end
+    end
+
+    test "with a changeset as first argument, with params and opts" do
+      assert {:ok, %User{name: "Alice"}} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create(%{name: "Alice"}, action: :create)
+    end
+
     test "with a record as first argument, then params and opts" do
       assert {:ok, %User{name: "Alice"}} =
                Ash.create(User, %{name: "Alice"}, action: :create)
@@ -79,12 +133,40 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "create!/1" do
+    test "with a changeset as first argument" do
+      assert %User{name: nil} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create!()
+    end
+
     test "with a resource as first argument" do
       assert %User{name: nil} = Ash.create!(User)
     end
   end
 
   describe "create!/2" do
+    test "with a changeset as first argument, with params as second argument" do
+      assert %User{name: "Alice"} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create!(%{name: "Alice"})
+
+      assert_raise ArgumentError, fn ->
+        User
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create!(%{name: "Alice"})
+      end
+    end
+
+    test "with a changeset as first argument, with opts as second argument" do
+      assert %User{name: nil} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create!(action: :create)
+    end
+
     test "with a resource as first argument, with params as second argument" do
       assert %User{name: "Alice"} = Ash.create!(User, %{name: "Alice"})
     end
@@ -95,6 +177,25 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "create!/3" do
+    test "with a changeset as first argument, then params and opts" do
+      assert %User{name: "Alice"} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create!(%{name: "Alice"})
+
+      assert %User{name: "Alice", state: :awake} =
+               User
+               |> Ash.Changeset.new()
+               |> Ash.create!(%{name: "Alice"}, action: :create_awake)
+
+      assert_raise ArgumentError, fn ->
+        User
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create!(%{name: "Alice"})
+      end
+    end
+
     test "with a record as first argument, then params and opts" do
       assert %User{name: "Alice"} =
                Ash.create!(User, %{name: "Alice"}, action: :create)
@@ -105,6 +206,15 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "update/1" do
+    test "with a changeset as first argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert {:ok, %User{name: "Alice"}} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update()
+    end
+
     test "with a record as first argument" do
       user = Ash.create!(User, %{name: "Alice"})
 
@@ -113,6 +223,31 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "update/2" do
+    test "with a changeset as first argument, with params as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert {:ok, %User{name: "Bob"}} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update(%{name: "Bob"})
+
+      assert_raise ArgumentError, fn ->
+        user
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_update(:update)
+        |> Ash.update(%{name: "Bob"})
+      end
+    end
+
+    test "with a changeset as first argument, with opts as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert %User{name: "Alice"} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update!(action: :update)
+    end
+
     test "with a record as first argument, with params as second argument" do
       user = Ash.create!(User, %{name: "Alice"})
 
@@ -127,6 +262,27 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "update/3" do
+    test "with a changeset as first argument, then params and opts" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert {:ok, %User{name: "Bob"}} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update(%{name: "Bob"}, action: :update)
+
+      assert {:ok, %User{name: "Alice", state: :awake}} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update(%{state: :awake}, action: :update_state)
+
+      assert_raise ArgumentError, fn ->
+        user
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_update(:update)
+        |> Ash.update(%{name: "Bob"})
+      end
+    end
+
     test "with a record as first argument, then params and opts" do
       user = Ash.create!(User, %{name: "Alice"})
 
@@ -139,6 +295,15 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "update!/1" do
+    test "with a changeset as first argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert %User{name: "Alice"} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update!()
+    end
+
     test "with a record as first argument" do
       user = Ash.create!(User, %{name: "Alice"})
 
@@ -147,6 +312,22 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "update!/2" do
+    test "with a changeset as first argument, with params as second argument" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert %User{name: "Bob"} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update!(%{name: "Bob"})
+
+      assert_raise ArgumentError, fn ->
+        user
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_update(:update)
+        |> Ash.update!(%{name: "Bob"})
+      end
+    end
+
     test "with a record as first argument, with params as second argument" do
       user = Ash.create!(User, %{name: "Alice"})
 
@@ -161,6 +342,27 @@ defmodule Ash.Test.AshTest do
   end
 
   describe "update!/3" do
+    test "with a changeset as first argument, then params and opts" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      assert %User{name: "Bob"} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update!(%{name: "Bob"}, action: :update)
+
+      assert %User{name: "Alice", state: :awake} =
+               user
+               |> Ash.Changeset.new()
+               |> Ash.update!(%{state: :awake}, action: :update_state)
+
+      assert_raise ArgumentError, fn ->
+        user
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.for_update(:update)
+        |> Ash.update!(%{name: "Bob"})
+      end
+    end
+
     test "with a record as first argument and explicit action" do
       user = Ash.create!(User, %{name: "Alice"})
 


### PR DESCRIPTION
`See` #1051 and #1055.

First argument of Ash.create (with a resource) and Ash.update (with a record) no longer are in a tuple with its arguments.

Arguments are now the second argument if it's not a keyword list.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies