### PR TITLE
Add attributes_present, attributes_absent for 2.0

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1419,7 +1419,7 @@ defmodule Ash.Changeset do
   end
 
   @doc """
-  Checks if an attribute is not nil, either in the original data, or that it is not being changed to a `nil` value if it is changing.
+  Checks if an argument is not nil or an attribute is not nil, either in the original data, or that it is not being changed to a `nil` value if it is changing.
 
   This also accounts for the `accessing_from` context that is set when using `manage_relationship`, so it is aware that a particular value
   *will* be set by `manage_relationship` even if it isn't currently being set.
@@ -1433,6 +1433,32 @@ defmodule Ash.Changeset do
       end
 
     not is_nil(arg_or_attribute_value) ||
+      belongs_to_attr_of_rel_being_managed?(attribute, changeset, true) ||
+      is_belongs_to_rel_being_managed?(attribute, changeset)
+  end
+
+  @doc """
+  Checks if an attribute is not nil, either in the original data, or that it is not being changed to a `nil` value if it is changing.
+
+  This also accounts for the `accessing_from` context that is set when using `manage_relationship`, so it is aware that a particular value
+  *will* be set by `manage_relationship` even if it isn't currently being set.
+  """
+  def attributes_present?(changeset, attribute) do
+    attribute_value = Ash.Changeset.get_attribute(changeset, attribute)
+
+    attribute_value =
+      case attribute_value do
+        %Ash.NotLoaded{} ->
+          nil
+
+        %Ash.ForbiddenField{} ->
+          nil
+
+        other ->
+          other
+      end
+
+    not is_nil(attribute_value) ||
       belongs_to_attr_of_rel_being_managed?(attribute, changeset, true) ||
       is_belongs_to_rel_being_managed?(attribute, changeset)
   end

--- a/lib/ash/resource/validation/attributes_present.ex
+++ b/lib/ash/resource/validation/attributes_present.ex
@@ -1,0 +1,38 @@
+defmodule Ash.Resource.Validation.AttributesPresent do
+  @moduledoc false
+  use Ash.Resource.Validation
+
+  alias Ash.Resource.Validation.Present
+  import Ash.Expr
+
+  def opt_schema, do: Present.opt_schema()
+
+  @impl true
+  def init(opts) do
+    Present.init(opts)
+  end
+
+  @impl true
+  def validate(changeset, opts, _context) do
+    {present, count} =
+      Enum.reduce(opts[:attributes], {0, 0}, fn attribute, {present, count} ->
+        if Ash.Changeset.attributes_present?(changeset, attribute) do
+          {present + 1, count + 1}
+        else
+          {present, count + 1}
+        end
+      end)
+
+    Present.do_validate(changeset, opts, present, count)
+  end
+
+  @impl true
+  def atomic(_changeset, opts, context) do
+    values =
+      Enum.map(opts[:attributes], fn attr ->
+        expr(^atomic_ref(attr))
+      end)
+
+    Present.atomic_for_values(opts, context, values)
+  end
+end

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -263,6 +263,27 @@ defmodule Ash.Resource.Validation.Builtins do
   end
 
   @doc """
+  Validates the presence of a list of attributes.
+
+  If no options are provided, validates that they are all present.
+
+  ## Options
+
+  #{Spark.Options.docs(Ash.Resource.Validation.AttributesPresent.opt_schema())}
+  """
+  @spec attributes_present(attributes :: atom | list(atom), opts :: Keyword.t()) ::
+          Validation.ref()
+  def attributes_present(attributes, opts \\ []) do
+    if opts == [] do
+      attributes = List.wrap(attributes)
+      {Validation.AttributesPresent, attributes: attributes, exactly: Enum.count(attributes)}
+    else
+      opts = Keyword.put(opts, :attributes, List.wrap(attributes))
+      {Validation.AttributesPresent, opts}
+    end
+  end
+
+  @doc """
   Validates the absence of a list of attributes or arguments.
 
   If no options are provided, validates that they are all absent.
@@ -301,6 +322,48 @@ defmodule Ash.Resource.Validation.Builtins do
         end
 
       present(attributes, new_opts)
+    end
+  end
+
+  @doc """
+  Validates the absence of a list of attributes.
+
+  If no options are provided, validates that they are all absent.
+
+  This works by changing your options and providing them to the `present` validation.
+
+  ## Options
+
+  #{String.replace(Spark.Options.docs(Ash.Resource.Validation.AttributesPresent.opt_schema()), "present", "absent")}
+  """
+  @spec attributes_absent(attributes :: atom | list(atom), opts :: Keyword.t()) ::
+          Validation.ref()
+  def attributes_absent(attributes, opts \\ []) do
+    if opts == [] do
+      {Validation.AttributesPresent, attributes: List.wrap(attributes), exactly: 0}
+    else
+      attributes = List.wrap(attributes)
+      count = Enum.count(attributes)
+
+      new_opts =
+        case Keyword.fetch(opts, :at_least) do
+          {:ok, value} ->
+            Keyword.put(opts, :at_most, count - value)
+
+          :error ->
+            Keyword.put(opts, :at_most, 0)
+        end
+
+      new_opts =
+        case Keyword.fetch(opts, :at_most) do
+          {:ok, value} ->
+            Keyword.put(new_opts, :at_least, count - value)
+
+          :error ->
+            Keyword.put(new_opts, :at_least, 0)
+        end
+
+      attributes_present(attributes, new_opts)
     end
   end
 

--- a/lib/ash/resource/validation/present.ex
+++ b/lib/ash/resource/validation/present.ex
@@ -33,6 +33,10 @@ defmodule Ash.Resource.Validation.Present do
         end
       end)
 
+    do_validate(changeset, opts, present, count)
+  end
+
+  def do_validate(changeset, opts, present, count) do
     opts =
       opts
       |> Keyword.put(:keys, Enum.join(opts[:attributes] || [], ","))
@@ -86,6 +90,10 @@ defmodule Ash.Resource.Validation.Present do
         end
       end)
 
+    atomic_for_values(opts, context, values)
+  end
+
+  def atomic_for_values(opts, context, values) do
     nil_count = expr(count_nils(^values))
 
     opts

--- a/test/actions/validation_test.exs
+++ b/test/actions/validation_test.exs
@@ -191,4 +191,53 @@ defmodule Ash.Test.Actions.ValidationTest do
       end)
     end
   end
+
+  describe "attributes_present, attributes_absent" do
+    defmodule Author do
+      @moduledoc false
+      use Ash.Resource,
+        domain: Domain,
+        data_layer: Ash.DataLayer.Ets
+
+      ets do
+        private? true
+      end
+
+      actions do
+        default_accept :*
+        defaults [:read, :destroy, create: :*, update: :*]
+
+        update :fill_bar do
+          argument :bar, :integer, allow_nil?: false
+
+          validate attributes_absent(:bar)
+          validate present(:bar)
+
+          change fn cs, _ctx ->
+            arg_bar = cs |> Ash.Changeset.get_argument(:bar)
+            cs |> Ash.Changeset.change_attribute(:bar, arg_bar)
+          end
+
+          validate attributes_present(:bar)
+          validate present(:bar)
+        end
+      end
+
+      attributes do
+        uuid_primary_key :id
+
+        attribute :bar, :integer do
+          public?(true)
+        end
+      end
+    end
+
+    test "it checks an attribute but not an argument" do
+      Author
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+      |> Ash.Changeset.for_update(:fill_bar, %{bar: 1})
+      |> Ash.update!()
+    end
+  end
 end


### PR DESCRIPTION
I require this backport since I'm currently still using version 2.0.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
