### PR TITLE
improvement: pass context to anonymous validate functions

### DIFF
--- a/lib/ash/reactor/dsl/change.ex
+++ b/lib/ash/reactor/dsl/change.ex
@@ -87,7 +87,7 @@ defmodule Ash.Reactor.Dsl.Change do
           type:
             {:wrap_list,
              {:spark_function_behaviour, Ash.Resource.Validation,
-              Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 1}}},
+              Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 2}}},
           required: false,
           default: [],
           doc: """

--- a/lib/ash/resource/change/change.ex
+++ b/lib/ash/resource/change/change.ex
@@ -48,7 +48,7 @@ defmodule Ash.Resource.Change do
         type:
           {:wrap_list,
            {:spark_function_behaviour, Ash.Resource.Validation, Ash.Resource.Validation.Builtins,
-            {Ash.Resource.Validation.Function, 1}}},
+            {Ash.Resource.Validation.Function, 2}}},
         required: false,
         default: [],
         doc: """

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -79,14 +79,14 @@ defmodule Ash.Resource.Validation do
   @optional_callbacks describe: 1, validate: 3, atomic: 3
 
   @validation_type {:spark_function_behaviour, Ash.Resource.Validation,
-                    Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 1}}
+                    Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 2}}
 
   @schema [
     validation: [
       type: @validation_type,
       required: true,
       doc:
-        "The module (or module and opts) that implements the `Ash.Resource.Validation` behaviour. Also accepts a one argument function that takes the changeset."
+        "The module (or module and opts) that implements the `Ash.Resource.Validation` behaviour. Also accepts a function that receives the changeset and its context."
     ],
     where: [
       type: {:wrap_list, @validation_type},

--- a/lib/ash/resource/validation/function.ex
+++ b/lib/ash/resource/validation/function.ex
@@ -4,13 +4,13 @@ defmodule Ash.Resource.Validation.Function do
   use Ash.Resource.Validation
 
   @impl true
-  def validate(changeset, [{:fun, {m, f, a}}], _context) do
-    apply(m, f, [changeset | a])
+  def validate(changeset, [{:fun, {m, f, a}}], context) do
+    apply(m, f, [changeset, context | a])
   end
 
   @impl true
-  def validate(changeset, [{:fun, fun}], _context) do
-    fun.(changeset)
+  def validate(changeset, [{:fun, fun}], context) do
+    fun.(changeset, context)
   end
 
   @impl true


### PR DESCRIPTION
Breaking change for Ash 3 that aligns anonymous validate functions with those of changes, preparations and `before_action`/`after_action` built-ins helpers. Now anonymous validate functions should expect two arguments - a changeset and a context. 
