### PR TITLE
Add documentation on disabling pagination

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.md
+++ b/documentation/dsls/DSL:-Ash.Resource.md
@@ -1395,7 +1395,7 @@ Adds pagination options to a resource
 | [`default_limit`](#actions-read-pagination-default_limit){: #actions-read-pagination-default_limit } | `pos_integer` |  | The default page size to apply, if one is not supplied |
 | [`countable`](#actions-read-pagination-countable){: #actions-read-pagination-countable } | `true \| false \| :by_default` | `false` | Whether not a returned page will have a full count of all records. Use `:by_default` to do it automatically. |
 | [`max_page_size`](#actions-read-pagination-max_page_size){: #actions-read-pagination-max_page_size } | `pos_integer` | `250` | The maximum amount of records that can be requested in a single page |
-| [`required?`](#actions-read-pagination-required?){: #actions-read-pagination-required? } | `boolean` | `true` | Whether or not pagination can be disabled (by passing `page: false` to `Ash.Api.read!/2`). Only relevant if some pagination configuration is supplied. |
+| [`required?`](#actions-read-pagination-required?){: #actions-read-pagination-required? } | `boolean` | `true` | Whether or not pagination can be disabled (by passing `page: false` to `Ash.Api.read!/2`, or by having `required?: false, default_limit: nil` set). Only relevant if some pagination configuration is supplied. |
 
 
 

--- a/documentation/dsls/DSL:-Ash.Resource.md
+++ b/documentation/dsls/DSL:-Ash.Resource.md
@@ -1395,7 +1395,7 @@ Adds pagination options to a resource
 | [`default_limit`](#actions-read-pagination-default_limit){: #actions-read-pagination-default_limit } | `pos_integer` |  | The default page size to apply, if one is not supplied |
 | [`countable`](#actions-read-pagination-countable){: #actions-read-pagination-countable } | `true \| false \| :by_default` | `false` | Whether not a returned page will have a full count of all records. Use `:by_default` to do it automatically. |
 | [`max_page_size`](#actions-read-pagination-max_page_size){: #actions-read-pagination-max_page_size } | `pos_integer` | `250` | The maximum amount of records that can be requested in a single page |
-| [`required?`](#actions-read-pagination-required?){: #actions-read-pagination-required? } | `boolean` | `true` | Whether or not pagination can be disabled. Only relevant if some pagination configuration is supplied. |
+| [`required?`](#actions-read-pagination-required?){: #actions-read-pagination-required? } | `boolean` | `true` | Whether or not pagination can be disabled (by passing `page: false` to `Ash.Api.read!/2`). Only relevant if some pagination configuration is supplied. |
 
 
 

--- a/lib/ash/resource/actions/read.ex
+++ b/lib/ash/resource/actions/read.ex
@@ -121,7 +121,7 @@ defmodule Ash.Resource.Actions.Read do
     required?: [
       type: :boolean,
       doc:
-        "Whether or not pagination can be disabled (by passing `page: false` to `Ash.Api.read!/2`). Only relevant if some pagination configuration is supplied.",
+        "Whether or not pagination can be disabled (by passing `page: false` to `Ash.Api.read!/2`, or by having `required?: false, default_limit: nil` set). Only relevant if some pagination configuration is supplied.",
       default: true
     ]
   ]

--- a/lib/ash/resource/actions/read.ex
+++ b/lib/ash/resource/actions/read.ex
@@ -121,7 +121,7 @@ defmodule Ash.Resource.Actions.Read do
     required?: [
       type: :boolean,
       doc:
-        "Whether or not pagination can be disabled. Only relevant if some pagination configuration is supplied.",
+        "Whether or not pagination can be disabled (by passing `page: false` to `Ash.Api.read!/2`). Only relevant if some pagination configuration is supplied.",
       default: true
     ]
   ]


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

This PR adds documentation on ways one can disable pagination in `required?` section of pagination API.
