### PR TITLE
fix: don't pass an error tuple to rollback in bulk update

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1318,7 +1318,7 @@ defmodule Ash.Actions.Update.Bulk do
             if new_error_count != starting_error_count do
               Ash.DataLayer.rollback(
                 resource,
-                {:error, Enum.take(new_errors, new_error_count - starting_error_count)}
+                Enum.take(new_errors, new_error_count - starting_error_count)
               )
             else
               result


### PR DESCRIPTION
Rollback just accepts the error term, without an error tuple. This broke error handling downstream.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
