### PR TITLE
feat: add read_action option to bulk actions

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -324,6 +324,10 @@ defmodule Ash do
   def create_opts, do: @create_opts_schema
 
   @shared_bulk_opts_schema [
+    read_action: [
+      type: :atom,
+      doc: "The action to use when building the read query."
+    ],
     assume_casted?: [
       type: :boolean,
       default: false,


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fairly simple changes, I didn't add any tests because the existing tests should fail if there was a problem with my changes. Not entirely sure if the option is in the best place, figured this being a shared option for all bulk operations was the most flexible/failsafe place to put it.