### PR TITLE
fix: fixes to some atomic validations

### DIFF
--- a/lib/ash/resource/validation/attribute_in.ex
+++ b/lib/ash/resource/validation/attribute_in.ex
@@ -45,7 +45,7 @@ defmodule Ash.Resource.Validation.AttributeIn do
 
   @impl true
   def atomic(_changeset, opts, context) do
-    {:atomic, [opts[:attribute]], expr(^atomic_ref(opts[:attribute]) in ^opts[:list]),
+    {:atomic, [opts[:attribute]], expr(^atomic_ref(opts[:attribute]) not in ^opts[:list]),
      expr(
        error(^InvalidAttribute, %{
          field: ^opts[:attribute],

--- a/lib/ash/resource/validation/changing.ex
+++ b/lib/ash/resource/validation/changing.ex
@@ -54,7 +54,7 @@ defmodule Ash.Resource.Validation.Changing do
 
   @impl true
   def atomic(_changeset, opts, context) do
-    {:atomic, [opts[:field]], expr(^atomic_ref(opts[:attribute]) != ^ref(opts[:attribute])),
+    {:atomic, [opts[:field]], expr(^atomic_ref(opts[:attribute]) == ^ref(opts[:attribute])),
      expr(
        error(^InvalidAttribute, %{
          field: ^opts[:field],

--- a/lib/ash/resource/validation/present.ex
+++ b/lib/ash/resource/validation/present.ex
@@ -106,14 +106,13 @@ defmodule Ash.Resource.Validation.Present do
   end
 
   def atomic_for_values(opts, context, values) do
+    attribute_count = length(opts[:attributes])
     nil_count = expr(count_nils(^values))
 
     opts
     |> Keyword.delete(:attributes)
     |> Enum.map(fn
       {:exactly, exactly} ->
-        attribute_count = length(opts[:attributes])
-
         message =
           cond do
             context.message ->
@@ -149,7 +148,7 @@ defmodule Ash.Resource.Validation.Present do
              })
            )}
         else
-          exactly_nil = Enum.count(opts[:attributes]) - exactly
+          exactly_nil = attribute_count - exactly
 
           {:atomic, opts[:attributes], expr(^nil_count != ^exactly_nil),
            expr(
@@ -163,11 +162,9 @@ defmodule Ash.Resource.Validation.Present do
         end
 
       {:at_least, at_least} ->
-        attributes = Enum.map(opts[:attributes], fn attr -> expr(^atomic_ref(attr)) end)
+        at_most_nil = attribute_count - at_least
 
-        at_most_nil = Enum.count(opts[:attributes]) - at_least
-
-        {:atomic, opts[:attributes], expr(count_nils(^attributes) > ^at_most_nil),
+        {:atomic, opts[:attributes], expr(^nil_count > ^at_most_nil),
          expr(
            error(^InvalidAttribute, %{
              field: ^Enum.at(opts[:attributes], 0),
@@ -178,10 +175,9 @@ defmodule Ash.Resource.Validation.Present do
          )}
 
       {:at_most, at_most} ->
-        attributes = Enum.map(opts[:attributes], fn attr -> expr(^atomic_ref(attr)) end)
-        at_least_nil = Enum.count(opts[:attributes]) - at_most
+        at_least_nil = attribute_count - at_most
 
-        {:atomic, opts[:attributes], expr(count_nils(^attributes) < ^at_least_nil),
+        {:atomic, opts[:attributes], expr(^nil_count < ^at_least_nil),
          expr(
            error(^InvalidAttribute, %{
              field: ^Enum.at(opts[:attributes], 0),


### PR DESCRIPTION
`attribute_in` and `changing` were using non-inverted condition in atomic implementation.

`present` was ignoring arguments for `at_most`/`at_least` options.