### PR TITLE
fix: fix `changing_attributes` for multiple attributes

### DIFF
--- a/lib/ash/policy/check/changing_attributes.ex
+++ b/lib/ash/policy/check/changing_attributes.ex
@@ -59,7 +59,7 @@ defmodule Ash.Policy.Check.ChangingAttributes do
               end
           end
         else
-          {:cont, expr}
+          {:halt, false}
         end
       end
     end)


### PR DESCRIPTION
Should return false (as documented and implemented before transition to filter) if any of attributes do not change.
