### PR TITLE
improvement: normalise `List.wrap` usage for policy checks

### DIFF
--- a/lib/ash/policy/check/action.ex
+++ b/lib/ash/policy/check/action.ex
@@ -4,14 +4,13 @@ defmodule Ash.Policy.Check.Action do
 
   @impl true
   def describe(options) do
-    operator =
-      if is_list(options[:action]) do
-        "in"
-      else
-        "=="
+    {operator, action} =
+      case options[:action] do
+        [action] -> {"==", action}
+        actions -> {"in", actions}
       end
 
-    "action #{operator} #{inspect(options[:action])}"
+    "action #{operator} #{inspect(action)}"
   end
 
   @impl true
@@ -19,6 +18,6 @@ defmodule Ash.Policy.Check.Action do
 
   @impl true
   def match?(_actor, %{action: %{name: name}}, options) do
-    name in List.wrap(options[:action])
+    name in options[:action]
   end
 end

--- a/lib/ash/policy/check/action_type.ex
+++ b/lib/ash/policy/check/action_type.ex
@@ -6,14 +6,8 @@ defmodule Ash.Policy.Check.ActionType do
   def describe(options) do
     {operator, type} =
       case options[:type] do
-        [type] ->
-          {"==", type}
-
-        types when is_list(types) ->
-          {"in", types}
-
-        type ->
-          {"==", type}
+        [type] -> {"==", type}
+        types -> {"in", types}
       end
 
     "action.type #{operator} #{inspect(type)}"
@@ -24,12 +18,6 @@ defmodule Ash.Policy.Check.ActionType do
 
   @impl true
   def match?(_actor, %{action: %{type: type}}, options) do
-    case List.wrap(options[:type]) do
-      [configured_type] ->
-        type == configured_type
-
-      types ->
-        Enum.any?(types, &(&1 == type))
-    end
+    type in options[:type]
   end
 end

--- a/lib/ash/policy/check/built_in_checks.ex
+++ b/lib/ash/policy/check/built_in_checks.ex
@@ -47,7 +47,7 @@ defmodule Ash.Policy.Check.Builtins do
   """
   @spec action_type(Ash.Resource.Actions.action_type()) :: Ash.Policy.Check.ref()
   def action_type(action_type) do
-    {Ash.Policy.Check.ActionType, type: action_type}
+    {Ash.Policy.Check.ActionType, type: List.wrap(action_type)}
   end
 
   @doc """
@@ -57,7 +57,7 @@ defmodule Ash.Policy.Check.Builtins do
   """
   @spec action(atom | list(atom)) :: Ash.Policy.Check.ref()
   def action(action) do
-    {Ash.Policy.Check.Action, action: action}
+    {Ash.Policy.Check.Action, action: List.wrap(action)}
   end
 
   @doc """
@@ -65,7 +65,7 @@ defmodule Ash.Policy.Check.Builtins do
   """
   @spec resource(atom | list(atom)) :: Ash.Policy.Check.ref()
   def resource(resource) do
-    {Ash.Policy.Check.Resource, resource: resource}
+    {Ash.Policy.Check.Resource, resource: List.wrap(resource)}
   end
 
   @doc """
@@ -244,7 +244,7 @@ defmodule Ash.Policy.Check.Builtins do
   """
   def changing_attributes(opts) do
     opts =
-      Enum.map(opts, fn opt ->
+      Enum.map(List.wrap(opts), fn opt ->
         if is_atom(opt) do
           {opt, []}
         else
@@ -269,12 +269,12 @@ defmodule Ash.Policy.Check.Builtins do
 
   @doc "This check is true when the specified relationship is changing"
   def changing_relationship(relationship) do
-    changing_relationships(List.wrap(relationship))
+    changing_relationships(relationship)
   end
 
   @doc "This check is true when the specified relationships are changing"
   def changing_relationships(relationships) do
-    {Ash.Policy.Check.ChangingRelationships, relationships: relationships}
+    {Ash.Policy.Check.ChangingRelationships, relationships: List.wrap(relationships)}
   end
 
   @doc "This check is true when the specified function returns true"

--- a/lib/ash/policy/check/resource.ex
+++ b/lib/ash/policy/check/resource.ex
@@ -4,14 +4,13 @@ defmodule Ash.Policy.Check.Resource do
 
   @impl true
   def describe(options) do
-    operator =
-      if is_list(options[:resource]) do
-        "in"
-      else
-        "=="
+    {operator, resource} =
+      case options[:resource] do
+        [resource] -> {"==", resource}
+        resources -> {"in", resources}
       end
 
-    "resource #{operator} #{inspect(options[:resource])}"
+    "resource #{operator} #{resource}"
   end
 
   @impl true
@@ -19,6 +18,6 @@ defmodule Ash.Policy.Check.Resource do
 
   @impl true
   def match?(_actor, %{resource: resource}, options) do
-    resource in List.wrap(options[:resource])
+    resource in options[:resource]
   end
 end


### PR DESCRIPTION
1) Adds `List.wrap` call to `changing_attributes`. So one can write `changing_attributes(:my_field)`. 
2) Same for `changing_relationships`. So `changing_relationship` becomes just an alias for `changing_relationships`.
3) Move some wrap calls from runtime `match?` to options creation site.

If you prefer having separate methods I can undo 1 and 2 change and add `changing_attribute` instead. But I think one method is more consistent since you don't have `action` and `actions` for example.

3 is a small breaking change in case somebody was using those check modules directly without normalizing options.