### PR TITLE
fix: trim spaces from codegen name

### DIFF
--- a/lib/mix/tasks/ash.codegen.ex
+++ b/lib/mix/tasks/ash.codegen.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Ash.Codegen do
           {nil, argv}
 
         [first | rest] ->
-          {first, rest}
+          {String.trim(first), rest}
 
         [] ->
           {nil, []}


### PR DESCRIPTION
This PR addresses the possibility of running `mix ash.codegen <something><tailing space>` which leads to a migration file name and migration name containing the same space (e.g. `creating priv/repo/migrations/name .exs` and `...Repo.Migrations.Name ".up/0 forward`.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Not applicable, as there are no specs for that.
