### PR TITLE
fix: make lateral join filtering in ETS data layer work

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -497,7 +497,7 @@ defmodule Ash.DataLayer.Ets do
                     {destination_attribute, [in: join_attrs]}
                   ])
                 else
-                  Ash.Filter.add_to_filter(query.filter, [
+                  Ash.Filter.add_to_filter!(query.filter, [
                     {destination_attribute, [in: join_attrs]}
                   ])
                 end


### PR DESCRIPTION
One of the two branches was using the non-bang version of a function, which returned `{:ok, filter}`. That value was then directly put in the Query struct, resulting in an invalid filter that was never applied.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
