### PR TITLE
Add documentation for Ash.Filter, linking to Expressions guide

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -182,6 +182,19 @@ defmodule Ash.Filter do
 
   Maps are also accepted, as are maps with string keys. Technically, a list of
   `[{"string_key", value}]` would also work.
+
+  ### Filter Functions
+
+  A set of built-in helper functions are provided for more complex filtering.
+
+  Example
+
+  ```elixir
+  Ash.Query.filter(Helpdesk.Support.Ticket, contains(subject, "2"))
+  ```
+
+  The `contains/2` macro is provided by the `Ash.Filter.Functions.Contains` module.
+  See other modules in the `Ash.Filter.Functions` namespace for more functions.
   """
 
   @builtin_operators Enum.map(@operators, &{&1.operator(), &1}) ++ @operator_aliases

--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -145,6 +145,22 @@ defmodule Ash.Filter do
   Ash.Query.filter(resource, first_name == "Zar" or last_name == "Doz" or (high_score > 10 and high_score < -10))
   ```
 
+  ### Expressions
+
+  More complex filters can be built using Ash Expressions.
+
+  Examples
+
+  ```elixir
+  # Filter based on the contents of a string attribute
+  Ash.Query.filter(Helpdesk.Support.Ticket, contains(subject, "2"))
+  # Filter based on the attribute of a joined relationship:
+  Ash.Query.filter(Helpdesk.Support.Ticket, representative.name == ^name)
+  ```
+
+  See the [Expressions guide](/documentation/topics/reference/expressions.md)
+  guide for more information.
+
   ### Keyword list syntax
 
   A filter is a nested keyword list (with some exceptions, like `true` for
@@ -182,19 +198,6 @@ defmodule Ash.Filter do
 
   Maps are also accepted, as are maps with string keys. Technically, a list of
   `[{"string_key", value}]` would also work.
-
-  ### Filter Functions
-
-  A set of built-in helper functions are provided for more complex filtering.
-
-  Example
-
-  ```elixir
-  Ash.Query.filter(Helpdesk.Support.Ticket, contains(subject, "2"))
-  ```
-
-  The `contains/2` macro is provided by the `Ash.Filter.Functions.Contains` module.
-  See other modules in the `Ash.Filter.Functions` namespace for more functions.
   """
 
   @builtin_operators Enum.map(@operators, &{&1.operator(), &1}) ++ @operator_aliases


### PR DESCRIPTION
I found no mention in the documentation about the connection between `Ash.Filter` and the `Ash.Filter.Functions.*` modules. Seemed like an important connection to make.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
