### PR TITLE
fix: run array type nil check after item constraints

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -813,7 +813,11 @@ defmodule Ash.Type do
         |> Enum.with_index()
         |> Enum.reduce({[], []}, fn {item, index}, {items, errors} ->
           if type.custom_apply_constraints_array?() do
-            {[item | items], errors}
+            if is_nil(item) && not nil_items? do
+              {[item | items], [[message: "no nil values", index: index] | errors]}
+            else
+              {[item | items], errors}
+            end
           else
             case apply_constraints(type, item, item_constraints) do
               {:ok, value} ->

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -812,31 +812,31 @@ defmodule Ash.Type do
         term
         |> Enum.with_index()
         |> Enum.reduce({[], []}, fn {item, index}, {items, errors} ->
-          if is_nil(item) && not nil_items? do
-            {[item | items], [[message: "no nil values", index: index] | errors]}
+          if type.custom_apply_constraints_array?() do
+            {[item | items], errors}
           else
-            if type.custom_apply_constraints_array?() do
-              {[item | items], errors}
-            else
-              case apply_constraints(type, item, item_constraints) do
-                {:ok, value} ->
+            case apply_constraints(type, item, item_constraints) do
+              {:ok, value} ->
+                if is_nil(value) && not nil_items? do
+                  {[value | items], [[message: "no nil values", index: index] | errors]}
+                else
                   {[value | items], errors}
+                end
 
-                {:error, new_errors} ->
-                  new_errors =
-                    new_errors
-                    |> List.wrap()
-                    |> Ash.Helpers.flatten_preserving_keywords()
-                    |> Enum.map(fn
-                      string when is_binary(string) ->
-                        [message: string, index: index]
+              {:error, new_errors} ->
+                new_errors =
+                  new_errors
+                  |> List.wrap()
+                  |> Ash.Helpers.flatten_preserving_keywords()
+                  |> Enum.map(fn
+                    string when is_binary(string) ->
+                      [message: string, index: index]
 
-                      vars ->
-                        Keyword.put(vars, :index, index)
-                    end)
+                    vars ->
+                      Keyword.put(vars, :index, index)
+                  end)
 
-                  {[item | items], List.wrap(new_errors) ++ errors}
-              end
+                {[item | items], List.wrap(new_errors) ++ errors}
             end
           end
         end)

--- a/test/type/array_test.exs
+++ b/test/type/array_test.exs
@@ -1,0 +1,27 @@
+defmodule Ash.Test.Type.ArrayTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  @default_constraints [
+    nil_items?: false,
+    empty_values: [""]
+  ]
+
+  test "it errors when containing a nil value" do
+    assert {:error, [[message: "no nil values", index: 1]]} =
+             Ash.Type.apply_constraints(
+               {:array, :string},
+               ["something", nil],
+               @default_constraints
+             )
+  end
+
+  test "it errors when containing an empty string (which is converted to nil by the string type)" do
+    assert {:error, [[message: "no nil values", index: 1]]} =
+             Ash.Type.apply_constraints(
+               {:array, :string},
+               ["something", ""],
+               @default_constraints
+             )
+  end
+end


### PR DESCRIPTION
Following [my discussion with Zach on the Elixir Forum](https://elixirforum.com/t/array-type-empty-values-cannot-remove-all-empty-values/63330/3), this PR makes sure to run the item constraints before checking for `nil` values in an array type.

The main goal is to address empty strings being converted to `nil` *after* we checked for `nil` values in the array, effectively resulting in `nil` values in the data layer.

# Notes/Questions
- Moving the `nil` check has the side-effect of not running it anymore when `type.custom_apply_constraints_array?()` is true. In the Ash codebase that only impacts `Ash.EmbeddableType`. I don't know what the implications of that change are, so it's worth making sure it's not breaking any existing behavior for anyone.
- I've added a `test/type/array_test.exs` test file, which breaks the 1-to-1 mapping. Should I instead move its content to `test/type/type_test.exs`, given the special array type logic is contained in `ash/type/type.ex`?


# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
