### PR TITLE
feat: add new remove_nil_items? array type constraint

### DIFF
--- a/test/type/array_test.exs
+++ b/test/type/array_test.exs
@@ -31,7 +31,7 @@ defmodule Ash.Test.Type.ArrayTest do
              Ash.Type.apply_constraints(
                {:array, :string},
                ["something", nil, nil, "something else"],
-               @default_constraints ++ [remove_nil_items?: true]
+               Keyword.put(@default_constraints, :remove_nil_items?, true)
              )
   end
 end

--- a/test/type/array_test.exs
+++ b/test/type/array_test.exs
@@ -4,6 +4,7 @@ defmodule Ash.Test.Type.ArrayTest do
 
   @default_constraints [
     nil_items?: false,
+    remove_nil_items?: false,
     empty_values: [""]
   ]
 
@@ -22,6 +23,15 @@ defmodule Ash.Test.Type.ArrayTest do
                {:array, :string},
                ["something", ""],
                @default_constraints
+             )
+  end
+
+  test "it removes nil values instead of erroring with remove_nil_items?: true" do
+    assert {:ok, ["something", "something else"]} =
+             Ash.Type.apply_constraints(
+               {:array, :string},
+               ["something", nil, nil, "something else"],
+               @default_constraints ++ [remove_nil_items?: true]
              )
   end
 end


### PR DESCRIPTION
A follow-up to https://github.com/ash-project/ash/pull/1115, which was also [discussed in the Elixir Forum thread](https://elixirforum.com/t/array-type-empty-values-cannot-remove-all-empty-values/63330/2).

This adds a `remove_nil_items?` constraint to the array type, which as its name implies removes `nil` values instead of marking them as errors.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
