### PR TITLE
fix: only return valid non nil values items from generator

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -543,13 +543,10 @@ defmodule Ash.Type do
       if constraints[:nil_items?] do
         StreamData.one_of([StreamData.constant(nil), generator])
       else
-        if type in [Ash.Type.String, :string, Ash.Type.CiString, :ci_string] &&
-             !item_constraints(constraints)[:allow_empty?] do
-          generator
-          |> StreamData.filter(&(&1 != ""))
-        else
-          generator
-        end
+        generator
+        |> StreamData.filter(
+          &(Ash.Type.apply_constraints(type, &1, item_constraints(constraints)) != nil)
+        )
       end
 
     StreamData.list_of(generator, Keyword.take(constraints, [:max_length, :min_length]))

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -537,16 +537,15 @@ defmodule Ash.Type do
   end
 
   defp do_generator({:array, type}, constraints) do
-    generator = do_generator(type, item_constraints(constraints))
+    item_constraints = item_constraints(constraints)
+    generator = do_generator(type, item_constraints)
 
     generator =
       if constraints[:nil_items?] do
         StreamData.one_of([StreamData.constant(nil), generator])
       else
         generator
-        |> StreamData.filter(
-          &(Ash.Type.apply_constraints(type, &1, item_constraints(constraints)) != nil)
-        )
+        |> StreamData.filter(&(Ash.Type.apply_constraints(type, &1, item_constraints) != nil))
       end
 
     StreamData.list_of(generator, Keyword.take(constraints, [:max_length, :min_length]))

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -543,7 +543,13 @@ defmodule Ash.Type do
       if constraints[:nil_items?] do
         StreamData.one_of([StreamData.constant(nil), generator])
       else
-        generator
+        if type in [Ash.Type.String, :string, Ash.Type.CiString, :ci_string] &&
+             !item_constraints(constraints)[:allow_empty?] do
+          generator
+          |> StreamData.filter(&(&1 != ""))
+        else
+          generator
+        end
       end
 
     StreamData.list_of(generator, Keyword.take(constraints, [:max_length, :min_length]))

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -546,13 +546,11 @@ defmodule Ash.Type do
       else
         generator
         |> StreamData.filter(fn value ->
-          if Ash.Type.embedded_type?(type) do
-            true
+          with {:ok, value} <- Ash.Type.cast_input(type, value, item_constraints),
+               {:ok, value} <- Ash.Type.apply_constraints(type, value, item_constraints) do
+            value != nil
           else
-            case Ash.Type.apply_constraints(type, value, item_constraints) do
-              {:ok, value} -> value != nil
-              _ -> true
-            end
+            _ -> true
           end
         end)
       end

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -545,7 +545,12 @@ defmodule Ash.Type do
         StreamData.one_of([StreamData.constant(nil), generator])
       else
         generator
-        |> StreamData.filter(&(Ash.Type.apply_constraints(type, &1, item_constraints) != nil))
+        |> StreamData.filter(fn value ->
+          case Ash.Type.apply_constraints(type, value, item_constraints) do
+            {:ok, value} -> value != nil
+            _ -> false
+          end
+        end)
       end
 
     StreamData.list_of(generator, Keyword.take(constraints, [:max_length, :min_length]))

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -548,7 +548,7 @@ defmodule Ash.Type do
         |> StreamData.filter(fn value ->
           case Ash.Type.apply_constraints(type, value, item_constraints) do
             {:ok, value} -> value != nil
-            _ -> false
+            _ -> true
           end
         end)
       end

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -546,9 +546,13 @@ defmodule Ash.Type do
       else
         generator
         |> StreamData.filter(fn value ->
-          case Ash.Type.apply_constraints(type, value, item_constraints) do
-            {:ok, value} -> value != nil
-            _ -> true
+          if Ash.Type.embedded_type?(type) do
+            true
+          else
+            case Ash.Type.apply_constraints(type, value, item_constraints) do
+              {:ok, value} -> value != nil
+              _ -> true
+            end
           end
         end)
       end


### PR DESCRIPTION
# Contributor checklist

Feels like there might be a cleaner way to do this, but it fixes the problem. 