### PR TITLE
fix: access to change context in get_and_lock(_for_update) changes

### DIFF
--- a/lib/ash/resource/change/get_and_lock.ex
+++ b/lib/ash/resource/change/get_and_lock.ex
@@ -14,8 +14,8 @@ defmodule Ash.Resource.Change.GetAndLock do
              changeset.resource,
              pkey_values,
              domain: changeset.domain,
-             tracer: context[:tracer],
-             tenant: context[:tenant],
+             tracer: context.tracer,
+             tenant: context.tenant,
              authorize?: false,
              lock: opts[:lock]
            ) do

--- a/lib/ash/resource/change/get_and_lock_for_update.ex
+++ b/lib/ash/resource/change/get_and_lock_for_update.ex
@@ -14,8 +14,8 @@ defmodule Ash.Resource.Change.GetAndLockForUpdate do
              changeset.resource,
              pkey_values,
              domain: changeset.domain,
-             tracer: context[:tracer],
-             tenant: context[:tenant],
+             tracer: context.tracer,
+             tenant: context.tenant,
              authorize?: false,
              lock: :for_update
            ) do


### PR DESCRIPTION
context is now a struct and does not implement access behaviour