### PR TITLE
improvement: add tenant to data earlier in read

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -259,6 +259,7 @@ defmodule Ash.Actions.Read do
         end
 
       with {:ok, data, count} <- data_result,
+           data = add_tenant(data, query),
            {:ok, data} <-
              load_through_attributes(
                data,
@@ -302,7 +303,6 @@ defmodule Ash.Actions.Read do
 
         data
         |> Helpers.restrict_field_access(query)
-        |> add_tenant(query)
         |> attach_fields(opts[:initial_data], initial_query, missing_pkeys?)
         |> add_page(
           query.action,


### PR DESCRIPTION
Make the tenant available to calculations so they can call `load!` in their code without the need of passing an explicit tenant

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
