### PR TITLE
fix: check require_reference? when generating update code interface

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -747,7 +747,7 @@ defmodule Ash.CodeInterface do
                 end
 
               resolve_subject =
-                if Enum.empty?(filter_keys) do
+                if Enum.empty?(filter_keys) and interface.require_reference? do
                   quote do
                     {changeset_opts, opts} =
                       Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer, :context])


### PR DESCRIPTION
Compilation was failing on update code interfaces with require_reference? false and no filters

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
