### PR TITLE
docs: Fix incorrect documentation for Ash.create

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -1984,7 +1984,7 @@ defmodule Ash do
   """
   @doc spark_opts: [{1, @create_opts_schema}]
   @spec create!(
-          changset_or_resource :: Ash.Changeset.t() | Ash.Changeset.t(),
+          changset_or_resource :: Ash.Changeset.t() | Ash.Resource.t(),
           params_or_opts :: map() | Keyword.t(),
           opts :: Keyword.t()
         ) ::
@@ -2003,7 +2003,7 @@ defmodule Ash do
   """
   @doc spark_opts: [{1, @create_opts_schema}]
   @spec create(
-          changset_or_resource :: Ash.Changeset.t() | Ash.Changeset.t(),
+          changset_or_resource :: Ash.Changeset.t() | Ash.Resource.t(),
           params_or_opts :: map() | Keyword.t(),
           opts :: Keyword.t()
         ) ::


### PR DESCRIPTION
Hi,

Found this small error in the documentation for `Ash.create`, it causes the LSP to think the following will not succeed for example:

![image](https://github.com/ash-project/ash/assets/7223328/33c2efa3-ad5d-45de-9e1a-89272f517d10)

But it does in fact work