### PR TITLE
fix: inifite recursion if query is empty

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -493,6 +493,9 @@ defmodule Ash.Actions.Read do
   def cleanup_field_auth(nil, _query, _top_level?), do: nil
   def cleanup_field_auth(%Ash.NotLoaded{} = not_loaded, _query, _top_level?), do: not_loaded
 
+  def cleanup_field_auth([%resource{} | _] = records, [], top_level?),
+    do: cleanup_field_auth(records, resource |> Ash.Query.new(), top_level?)
+
   def cleanup_field_auth(%struct{results: results} = page, query, top_level?)
       when struct in [Ash.Page.Keyset, Ash.Page.Offset] do
     %{page | results: cleanup_field_auth(results, query, top_level?)}


### PR DESCRIPTION
I'm not completely sure why this is happening. But right now, a test of mine fails for a read where I load through a calculation that returns a union, and I load relationships on the union. The load inside the query for the resource in the union looks like this `load: [relationship: []]`, and because it is an empty array instead of a `query`, it hit the last implementation of `clean_up_field_auth` indefinitely. 