### PR TITLE
fix: handle nil case

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -609,6 +609,9 @@ defmodule Ash.Actions.Read do
                     end)
                   end)
               end
+
+            nil ->
+              record
           end
         end)
       end


### PR DESCRIPTION
Another of my tests failed because nil was returned from `Map.get` above