### PR TITLE
Fix: keep data's metadata in atomic update

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -449,7 +449,7 @@ defmodule Ash.Actions.Update.Bulk do
           results =
             case results do
               [result] ->
-                if atomic_changeset.context[:data_layer][:use_atomic_update_data] do
+                if atomic_changeset.context[:data_layer][:use_atomic_update_data?] do
                   Map.put(result, :__metadata__, atomic_changeset.data.__metadata__)
                 else
                   [result]

--- a/test/actions/multitenancy_test.exs
+++ b/test/actions/multitenancy_test.exs
@@ -401,6 +401,13 @@ defmodule Ash.Actions.MultitenancyTest do
         )
         |> Ash.create!()
 
+      thing2 =
+        thing2
+        |> Ash.Changeset.for_update(:update, %{name: "bar updated"})
+        |> Ash.update!()
+
+      %{other_thing_name_reversed: "oof"} = Ash.load!(thing2, :other_thing_name_reversed)
+
       %{other_thing_name_reversed: "oof"} =
         MultitenantThing
         |> Ash.get!(thing2.id, tenant: tenant1, load: :other_thing_name_reversed)


### PR DESCRIPTION
Fix the usage of the `:use_atomic_update_data?` option so that the `__metadata__` map from the data source is correctly considered when running atomic updates.

For instance, `Ash.update!/3` now correctly keeps the `tenant` metadata on the resource.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
