### PR TITLE
Update sensitive-data.md, tyring to clearify that public? applies to …

### DIFF
--- a/documentation/topics/development/project-structure.md
+++ b/documentation/topics/development/project-structure.md
@@ -23,7 +23,7 @@ lib/ # top level lib folder for your whole project
 │  │  ├─ notification.ex # A resource without additional files
 │  │  ├─ other_file.ex # A non-resource file
 │  │  ├─ ticket/ # A resource with additional files
-│  │  │  ├─ preparations/ # Components of the reosurce, grouped by type
+│  │  │  ├─ preparations/ # Components of the resource, grouped by type
 │  │  │  ├─ changes/
 │  │  │  ├─ checks/
 │  │  ├─ ticket.ex # The resource file

--- a/documentation/topics/security/sensitive-data.md
+++ b/documentation/topics/security/sensitive-data.md
@@ -2,16 +2,21 @@
 
 ## Public & Private Attributes
 
-By default, attributes, calculations, aggregates and relationships are *private* (they are marked `public?: false`). If you are working with Ash in code, the public/private status of an attribute is not relevant. However, when working with api extensions like `AshGraphql` and `AshJsonApi`, they will only include public fields in their interfaces. This helps avoid accidentally exposing data over "public" interfaces.
+By default, attributes, calculations, aggregates and relationships are *private* (they are marked `public?: false`).  
+If you are working with Ash in code, reading a resource, for example using `Ash.read/2`, the public/private status of an attribute is not relevant.  
+However, when working with api extensions like `AshGraphql` and `AshJsonApi`, they will only include public fields in their interfaces. This helps avoid accidentally exposing data over "public" interfaces.  
 
 ## Public & Private Arguments
 
-Public/private arguments work the same way as public/private fields, except that they default to `public?: true`. This is because arguments to an action being used in a public interface would naturally be expected to be `public`. If an argument is marked as `public?: false`, it can only be set with `Ash.Query.set_argument/3` or `Ash.Changeset.set_argument/3`
+Public/private arguments work the same way as public/private fields, except that they default to `public?: true`.  
+This is because arguments to an action being used in a public interface would naturally be expected to be `public`. If an argument is marked as `public?: false`, it can only be set with `Ash.Query.set_argument/3` or `Ash.Changeset.set_argument/3`
 
 ## Sensitive Attributes
 
-Using `sensitive? true` will cause an attribute, calculation or argument to show as `"** Redacted **"` when inspecting records. In filter statements, any value used in the same expression as a sensitive field will also be redacted. For example, you might see: `email == "** Redacted **"` in a filter statement if `email` is marked as sensitive.
+Using `sensitive? true` will cause an attribute, calculation or argument to show as `"** Redacted **"` when inspecting records.  
+In filter statements, any value used in the same expression as a sensitive field will also be redacted. For example, you might see: `email == "** Redacted **"` in a filter statement if `email` is marked as sensitive.
 
 ## Field Policies
 
-Field policies are a way to control the visibility of individual fields (except for relationships) as a part of authorization flow, for those using `Ash.Policy.Authorizer`. If a field is not visible, it will be populated with `%Ash.ForbiddenField{}`, or will be not shown (or may show an error) in public interfaces. See the [Policies guide](documentation/topics/security/policies.md#field-policies) for more.
+Field policies are a way to control the visibility of individual fields (except for relationships) as a part of authorization flow, for those using `Ash.Policy.Authorizer`.  
+If a field is not visible, it will be populated with `%Ash.ForbiddenField{}`, or will be not shown (or may show an error) in public interfaces. See the [Policies guide](documentation/topics/security/policies.md#field-policies) for more.


### PR DESCRIPTION
Added `, reading a resource, for example using Ash.read/2`, tyring to clearify that `public?` applies to reading operations via extensions and not when using `Ash.read` directly.

Also added some newlines as I thought made it easier to read.

Also thinking that https://hexdocs.pm/ash/3.0.1/dsl-ash-resource.html#attributes-attribute-public? maybe should mention that this property is used in `accept` for the actions as well?

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
