### PR TITLE
^ref argument order fixes

### DIFF
--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -117,7 +117,7 @@ Most of the time, when you are using an expression, you will actually be creatin
 ^context(:key) # equivalent to `get_in(context, :key)`
 ^context([:key1, :key2]) # equivalent to `get_in(context, [:key1, :key2])`
 ^ref(:key) # equivalent to referring to `key`. Allows for dynamic references
-^ref(:key, [:path]) # equivalent to referring to `path.key`. Allows for dynamic references with dynamic (or static) paths.
+^ref([:path], :key) # equivalent to referring to `path.key`. Allows for dynamic references with dynamic (or static) paths.
 ```
 
 ## Custom Expressions

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -4199,8 +4199,8 @@ defmodule Ash.Changeset do
 
               expr(
                 ^this_filter and
-                  (is_nil(^ref(relationship.destination_attribute, [])) or
-                     ^ref(relationship.destination_attribute, []) == ^destination_value)
+                  (is_nil(^ref(relationship.destination_attribute)) or
+                     ^ref(relationship.destination_attribute) == ^destination_value)
               )
             else
               this_filter


### PR DESCRIPTION
This fixes the argument order in a call to ref in the expressions guide. I also fixed what looks like the same issue in `changeset.ex`, however there is no test coverage – please double check it.