### PR TITLE
bug: Add more failing tests around cascade_destroy functionality

### DIFF
--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -538,9 +538,6 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
       |> Map.get(:records)
       |> Ash.bulk_destroy(:this_is_not_an_actual_destroy_action, %{}, return_errors?: true)
 
-    # I'm not sure exactly what should be returned here, but something should
-    # go wrong when attempting to call an invalid action.
-    # I'm guessing it falls back to using the default destroy action.
     assert bulk_result.status == :error
     assert [] != bulk_result.errors
 


### PR DESCRIPTION
A couple more issues around using `cascade_destroy` functionality.

Issues occur when there is no data to cascade destroy, or notifications are requested but none are returned

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
