### PR TITLE
fix: don't require domain for empty stream bulk update and destroy

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -2255,7 +2255,6 @@ defmodule Ash do
   @doc spark_opts: [{3, @bulk_update_opts_schema}]
   def bulk_update(query_or_stream, action, input, opts \\ []) do
     Ash.Helpers.expect_options!(opts)
-    domain = Ash.Helpers.domain!(query_or_stream, opts)
 
     case query_or_stream do
       [] ->
@@ -2275,6 +2274,8 @@ defmodule Ash do
         end
 
       query_or_stream ->
+        domain = Ash.Helpers.domain!(query_or_stream, opts)
+
         with {:ok, opts} <- Spark.Options.validate(opts, @bulk_update_opts_schema),
              {:ok, resource} <-
                Ash.Helpers.resource_from_query_or_stream(domain, query_or_stream, opts) do
@@ -2353,7 +2354,6 @@ defmodule Ash do
   @doc spark_opts: [{3, @bulk_destroy_opts_schema}]
   def bulk_destroy(query_or_stream, action, input, opts \\ []) do
     Ash.Helpers.expect_options!(opts)
-    domain = Ash.Helpers.domain!(query_or_stream, opts)
 
     case query_or_stream do
       [] ->
@@ -2373,6 +2373,8 @@ defmodule Ash do
         end
 
       query_or_stream ->
+        domain = Ash.Helpers.domain!(query_or_stream, opts)
+
         with {:ok, opts} <- Spark.Options.validate(opts, @bulk_destroy_opts_schema),
              {:ok, resource} <-
                Ash.Helpers.resource_from_query_or_stream(domain, query_or_stream, opts) do

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -413,6 +413,11 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
              end)
   end
 
+  test "works with empty list without the need to define a domain" do
+    assert %Ash.BulkResult{records: []} =
+             Ash.bulk_destroy!([], :destroy, %{}, return_records?: true)
+  end
+
   describe "authorization" do
     test "policy success results in successes" do
       assert %Ash.BulkResult{records: [_, _], errors: []} =

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -594,6 +594,11 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
     assert_receive {:error, _}
   end
 
+  test "works with empty list without the need to define a domain" do
+    assert %Ash.BulkResult{records: []} =
+             Ash.bulk_update!([], :update, %{title2: 3}, return_records?: true)
+  end
+
   describe "authorization" do
     test "policy success results in successes" do
       assert %Ash.BulkResult{records: [_, _], errors: []} =


### PR DESCRIPTION
It can't be extracted from an empty list, but it's not actually needed

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
