### PR TITLE
docs: add `count` to the Expressions guide

### DIFF
--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -74,6 +74,7 @@ For elixir-backed data layers, they will be a function or an MFA that will be ca
 - `exists/2` | `exists(foo.bar, name == "fred")` takes an expression scoped to the destination resource, and checks if any related entry matches. See the section on `exists` below.
 - `path.exists/2` | Same as `exists` but the source of the relationship is itself a nested relationship. See the section on `exists` below.
 - `parent/1` | Allows an expression scoped to a resource to refer to the "outer" context. Used in relationship filters and `exists`
+- `count/2` | `count(posts, filter: [query: [published == true]])` an inline aggregate function to count records in a relationship, scoped by a second optional expression. See the section on Inline Aggregates for more information.
 
 ## DateTime Functions
 

--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -96,13 +96,15 @@ For elixir-backed data layers, they will be a function or an MFA that will be ca
 
 ## Inline Aggregates
 
-Aggregates can be referenced in-line, with their relationship path specified and any options provided that match the options given to `Ash.Query.Aggregate.new/4`. For example:
+Aggregates such as `count`, `first`, `sum`, etc. can be referenced in-line, with their relationship path specified and any options provided that match the options given to `Ash.Query.Aggregate.new/4`. For example:
 
 ```elixir
 calculate :grade, :decimal, expr(
   count(answers, query: [filter: expr(correct == true)]) /
   count(answers, query: [filter: expr(correct == false)])
 )
+
+calculate :latest_post_published_at, :datetime, expr(max(posts, field: :published_at))
 ```
 
 The available aggregate kinds can also be seen in the `Ash.Query.Aggregate` module documentation.


### PR DESCRIPTION
Noticed this wasn't there, and wanted to link to it, so it's there now!

(It's kind of hinted at as an "inline aggregate", but I wanted to make it more explicit)

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
