### PR TITLE
Fix get_domain

### DIFF
--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -452,6 +452,10 @@ defmodule Ash.Helpers do
     get_domain(resource, opts)
   end
 
+  def get_domain({resource, _, _}, opts) when is_atom(resource) do
+    get_domain(resource, opts)
+  end
+
   def get_domain(%page_struct{rerun: {query, _}}, opts)
       when page_struct in [Ash.Page.Offset, Ash.Page.Keyset] do
     get_domain(query, opts)

--- a/test/policy/rbac_test.exs
+++ b/test/policy/rbac_test.exs
@@ -95,6 +95,10 @@ defmodule Ash.Test.Policy.RbacTest do
     assert Ash.can?({File, :read}, user)
     refute Ash.can?({File, :read}, user, data: [file1, file2])
     assert Ash.can?({File, :read}, user, data: file_with_access)
+
+    assert Ash.can?({File, :read, %{}}, user)
+    refute Ash.can?({File, :read, %{}}, user, data: [file1, file2])
+    assert Ash.can?({File, :read, %{}}, user, data: file_with_access)
   end
 
   test "if the query can be performed, the can utility should return true", %{


### PR DESCRIPTION
# Contributor checklist

Since Ash.can? accepts {resource, action, input}, get_domain should also accept it.

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
