### PR TITLE
fix: use correct boolean operation names in Filter.find/4

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -655,10 +655,10 @@ defmodule Ash.Filter do
 
         %BooleanExpression{op: op, left: left, right: right} ->
           cond do
-            op == :ors && !ors? ->
+            op == :or && !ors? ->
               nil
 
-            op == :ands && !ands? ->
+            op == :and && !ands? ->
               nil
 
             true ->


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
