### PR TITLE
fix: accept changeset inputs on bulk creates

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -574,18 +574,34 @@ defmodule Ash.Actions.Create.Bulk do
          action,
          opts,
          lazy_matching_default_values,
-         base,
+         base_changeset,
          argument_names
        ) do
-    base
+    changeset =
+      case input do
+        %Ash.Changeset{} ->
+          input
+
+        input ->
+          handle_params(
+            base_changeset,
+            Keyword.get(opts, :assume_casted?, false),
+            action,
+            opts,
+            input,
+            argument_names
+          )
+      end
+
+    changeset =
+      if opts[:tenant] do
+        Ash.Changeset.set_tenant(changeset, opts[:tenant])
+      else
+        changeset
+      end
+
+    changeset
     |> Ash.Changeset.put_context(:bulk_create, %{index: index})
-    |> handle_params(
-      Keyword.get(opts, :assume_casted?, false),
-      action,
-      opts,
-      input,
-      argument_names
-    )
     |> set_lazy_non_matching_defaults()
     |> set_lazy_matching_defaults(lazy_matching_default_values)
     |> set_tenant()


### PR DESCRIPTION
As stated in the documentation, bulk creates accept either a list of changesets or a list of maps as inputs.

However, bulk create is not actually working when providing changesets as inputs.

This change proposes a fix to ensure that bulk creates support changesets as the input argument.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
