### PR TITLE
do not lose constraints context

### DIFF
--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -907,7 +907,7 @@ defmodule Ash.Type.Union do
             {:array, type},
             old_values_by_type[name] || [],
             new_values,
-            items: constraints[:types][name][:constraints]
+            Keyword.put(constraints, :items, constraints[:types][name][:constraints])
           )
 
         case result do


### PR DESCRIPTION
only passing the item constraints led to an forbidden error for a destroy on an embeddable type because the context with the actor was missing.