### PR TITLE
Test loading relationships on multitenant resources after create or update

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -1298,6 +1298,7 @@ defmodule Ash.Actions.Create.Bulk do
              select,
              reuse_values?: true,
              domain: domain,
+             tenant: opts[:tenant],
              actor: opts[:actor],
              authorize?: opts[:authorize?],
              tracer: opts[:tracer]
@@ -1307,6 +1308,7 @@ defmodule Ash.Actions.Create.Bulk do
             records,
             List.wrap(opts[:load]),
             domain: domain,
+            tenant: opts[:tenant],
             reuse_values?: true,
             actor: opts[:actor],
             authorize?: opts[:authorize?],
@@ -1518,7 +1520,9 @@ defmodule Ash.Actions.Create.Bulk do
                       error = Ash.Error.to_ash_error(error)
 
                       if validation.message do
-                        error = Ash.Changeset.override_validation_message(error, validation.message)
+                        error =
+                          Ash.Changeset.override_validation_message(error, validation.message)
+
                         Ash.Changeset.add_error(changeset, error)
                       else
                         Ash.Changeset.add_error(changeset, error)

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1950,6 +1950,7 @@ defmodule Ash.Actions.Destroy.Bulk do
     case Ash.load(records, select,
            reuse_values?: true,
            domain: domain,
+           tenant: opts[:tenant],
            actor: opts[:actor],
            authorize?: opts[:authorize?],
            tracer: opts[:tracer]
@@ -1959,6 +1960,7 @@ defmodule Ash.Actions.Destroy.Bulk do
           records,
           List.wrap(changeset.load),
           reuse_values?: true,
+          tenant: opts[:tenant],
           domain: domain,
           actor: opts[:actor],
           authorize?: opts[:authorize?],

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -2231,6 +2231,7 @@ defmodule Ash.Actions.Update.Bulk do
     case Ash.load(records, select,
            reuse_values?: true,
            domain: domain,
+           tenant: opts[:tenant],
            actor: opts[:actor],
            authorize?: opts[:authorize?],
            tracer: opts[:tracer]
@@ -2240,6 +2241,7 @@ defmodule Ash.Actions.Update.Bulk do
           records,
           List.wrap(changeset.load),
           reuse_values?: true,
+          tenant: opts[:tenant],
           domain: domain,
           actor: opts[:actor],
           authorize?: opts[:authorize?],

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -647,6 +647,7 @@ defmodule Ash.DataLayer.Ets do
                      |> Ash.Query.load(relationship_path_to_load(relationship_path, field))
                      |> Ash.Query.set_context(%{private: %{internal?: true}}),
                      domain: domain,
+                     tenant: context[:tenant],
                      actor: context[:actor],
                      authorize?: false
                    ),

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -1240,7 +1240,7 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                )
 
       assert %Ash.Page.Offset{
-               results: [%MultitenantTag{name: "foo", __metadata__: %{keyset: keyset}}],
+               results: [%MultitenantTag{name: "bar", __metadata__: %{keyset: keyset}}],
                limit: 1,
                offset: 0,
                count: 2,
@@ -1266,7 +1266,7 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                )
 
       assert %Ash.Page.Keyset{
-               results: [%MultitenantTag{name: "bar"}],
+               results: [%MultitenantTag{name: "foo"}],
                limit: 1,
                count: 2,
                more?: false,

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -280,6 +280,123 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     end
   end
 
+  defmodule Tenant do
+    @doc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :create, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+    end
+
+    defimpl Ash.ToTenant do
+      def to_tenant(tenant, _resource), do: tenant.id
+    end
+  end
+
+  defmodule MultitenantTagLink do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :tenant_id
+    end
+
+    attributes do
+      attribute :type, :string do
+        public?(true)
+      end
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    relationships do
+      belongs_to :tenant, Tenant, allow_nil?: false
+
+      belongs_to :source_tag, Ash.Test.Actions.BulkCreateTest.MultitenantTag,
+        primary_key?: true,
+        allow_nil?: false,
+        public?: true
+
+      belongs_to :destination_tag, Ash.Test.Actions.BulkCreateTest.MultitenantTag,
+        primary_key?: true,
+        allow_nil?: false,
+        public?: true
+    end
+  end
+
+  defmodule MultitenantTag do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :tenant_id
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+
+      create :create_with_related_tags do
+        argument :related_tags, {:array, :string} do
+          allow_nil? false
+          constraints min_length: 1, items: [min_length: 1]
+        end
+
+        change manage_relationship(:related_tags,
+                 on_lookup: :relate,
+                 on_no_match: :create,
+                 value_is_key: :name,
+                 use_identities: [:name]
+               )
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, allow_nil?: false, public?: true
+
+      timestamps()
+    end
+
+    relationships do
+      belongs_to :tenant, Tenant, allow_nil?: false
+
+      many_to_many :related_tags, __MODULE__,
+        through: MultitenantTagLink,
+        source_attribute_on_join_resource: :source_tag_id,
+        destination_attribute_on_join_resource: :destination_tag_id,
+        public?: true
+    end
+
+    identities do
+      identity :name, [:name], pre_check_with: Domain
+    end
+  end
+
   test "returns created records" do
     org =
       Org
@@ -1098,6 +1215,64 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                before: nil,
                after: ^keyset
              } = post.related_posts
+    end
+
+    test "allows loading paginated many_to_many relationship for multitenant resources" do
+      tenant = Ash.create!(Tenant, %{})
+      _ = Ash.create!(MultitenantTag, %{name: "foo"}, tenant: tenant)
+
+      offset_pagination_query =
+        MultitenantTag
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.select([:name])
+        |> Ash.Query.page(count: true, limit: 1)
+
+      assert %Ash.BulkResult{records: [tag]} =
+               Ash.bulk_create!(
+                 [%{name: "tag 1", related_tags: ["foo", "bar"]}],
+                 MultitenantTag,
+                 :create_with_related_tags,
+                 return_records?: true,
+                 return_errors?: true,
+                 authorize?: false,
+                 tenant: tenant,
+                 load: [related_tags: offset_pagination_query]
+               )
+
+      assert %Ash.Page.Offset{
+               results: [%MultitenantTag{name: "foo", __metadata__: %{keyset: keyset}}],
+               limit: 1,
+               offset: 0,
+               count: 2,
+               more?: true
+             } = tag.related_tags
+
+      keyset_pagination_query =
+        MultitenantTag
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.select([:name])
+        |> Ash.Query.page(count: true, limit: 1, after: keyset)
+
+      assert %Ash.BulkResult{records: [tag]} =
+               Ash.bulk_create!(
+                 [%{name: "tag 2", related_tags: ["foo", "bar"]}],
+                 MultitenantTag,
+                 :create_with_related_tags,
+                 return_records?: true,
+                 return_errors?: true,
+                 authorize?: false,
+                 tenant: tenant,
+                 load: [related_tags: keyset_pagination_query]
+               )
+
+      assert %Ash.Page.Keyset{
+               results: [%MultitenantTag{name: "bar"}],
+               limit: 1,
+               count: 2,
+               more?: false,
+               before: nil,
+               after: ^keyset
+             } = tag.related_tags
     end
   end
 end

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -329,6 +329,125 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
     end
   end
 
+  defmodule Tenant do
+    @doc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :create, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+    end
+
+    defimpl Ash.ToTenant do
+      def to_tenant(tenant, _resource), do: tenant.id
+    end
+  end
+
+  defmodule MultitenantTagLink do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :tenant_id
+    end
+
+    attributes do
+      attribute :type, :string do
+        public?(true)
+      end
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    relationships do
+      belongs_to :tenant, Tenant, allow_nil?: false
+
+      belongs_to :source_tag, Ash.Test.Actions.BulkUpdateTest.MultitenantTag,
+        primary_key?: true,
+        allow_nil?: false,
+        public?: true
+
+      belongs_to :destination_tag, Ash.Test.Actions.BulkUpdateTest.MultitenantTag,
+        primary_key?: true,
+        allow_nil?: false,
+        public?: true
+    end
+  end
+
+  defmodule MultitenantTag do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :tenant_id
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+
+      update :add_related_tags do
+        require_atomic? false
+
+        argument :related_tags, {:array, :string} do
+          allow_nil? false
+          constraints min_length: 1, items: [min_length: 1]
+        end
+
+        change manage_relationship(:related_tags,
+                 on_lookup: :relate,
+                 on_no_match: :create,
+                 value_is_key: :name,
+                 use_identities: [:name]
+               )
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, allow_nil?: false, public?: true
+
+      timestamps()
+    end
+
+    relationships do
+      belongs_to :tenant, Tenant, allow_nil?: false
+
+      many_to_many :related_tags, __MODULE__,
+        through: MultitenantTagLink,
+        source_attribute_on_join_resource: :source_tag_id,
+        destination_attribute_on_join_resource: :destination_tag_id,
+        public?: true
+    end
+
+    identities do
+      identity :name, [:name], pre_check_with: Domain
+    end
+  end
+
   test "returns updated records" do
     assert %Ash.BulkResult{records: [%{title2: "updated value"}, %{title2: "updated value"}]} =
              Ash.bulk_create!([%{title: "title1"}, %{title: "title2"}], Post, :create,
@@ -1041,6 +1160,61 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
                before: nil,
                after: ^keyset
              } = post.related_posts
+    end
+
+    test "allows loading paginated many_to_many relationship for multitenant resources" do
+      tenant = Ash.create!(Tenant, %{})
+      tag = Ash.create!(MultitenantTag, %{name: "tag"}, tenant: tenant)
+      _ = Ash.create!(MultitenantTag, %{name: "existing"}, tenant: tenant)
+
+      offset_pagination_query =
+        MultitenantTag
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.select([:name])
+        |> Ash.Query.page(count: true, limit: 1)
+
+      assert %Ash.BulkResult{records: [tag]} =
+               Ash.bulk_update!([tag], :add_related_tags, %{related_tags: ["existing"]},
+                 resource: MultitenantTag,
+                 strategy: :stream,
+                 return_records?: true,
+                 return_errors?: true,
+                 authorize?: false,
+                 load: [related_tags: offset_pagination_query]
+               )
+
+      assert %Ash.Page.Offset{
+               results: [%MultitenantTag{name: "existing", __metadata__: %{keyset: keyset}}],
+               limit: 1,
+               offset: 0,
+               count: 1,
+               more?: false
+             } = tag.related_tags
+
+      keyset_pagination_query =
+        MultitenantTag
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.select([:name])
+        |> Ash.Query.page(count: true, limit: 1, after: keyset)
+
+      assert %Ash.BulkResult{records: [tag]} =
+               Ash.bulk_update!([tag], :add_related_tags, %{related_tags: ["new"]},
+                 resource: MultitenantTag,
+                 strategy: :stream,
+                 return_records?: true,
+                 return_errors?: true,
+                 authorize?: false,
+                 load: [related_tags: keyset_pagination_query]
+               )
+
+      assert %Ash.Page.Keyset{
+               results: [%MultitenantTag{name: "new"}],
+               limit: 1,
+               count: 2,
+               more?: false,
+               before: nil,
+               after: ^keyset
+             } = tag.related_tags
     end
   end
 end

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -1177,6 +1177,7 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
                Ash.bulk_update!([tag], :add_related_tags, %{related_tags: ["existing"]},
                  resource: MultitenantTag,
                  strategy: :stream,
+                 tenant: tenant,
                  return_records?: true,
                  return_errors?: true,
                  authorize?: false,
@@ -1200,6 +1201,7 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
       assert %Ash.BulkResult{records: [tag]} =
                Ash.bulk_update!([tag], :add_related_tags, %{related_tags: ["new"]},
                  resource: MultitenantTag,
+                 tenant: tenant,
                  strategy: :stream,
                  return_records?: true,
                  return_errors?: true,

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -1018,11 +1018,12 @@ defmodule Ash.Test.Actions.CreateTest do
       tag =
         Ash.create!(MultitenantTag, %{name: "tag 1", related_tags: ["foo", "bar"]},
           action: :create_with_related_tags,
+          tenant: tenant,
           load: [related_tags: offset_pagination_query]
         )
 
       assert %Ash.Page.Offset{
-               results: [%MultitenantTag{name: "foo", __metadata__: %{keyset: keyset}}],
+               results: [%MultitenantTag{name: "bar", __metadata__: %{keyset: keyset}}],
                limit: 1,
                offset: 0,
                count: 2,
@@ -1038,11 +1039,12 @@ defmodule Ash.Test.Actions.CreateTest do
       tag =
         Ash.create!(MultitenantTag, %{name: "tag 2", related_tags: ["foo", "bar"]},
           action: :create_with_related_tags,
+          tenant: tenant,
           load: [related_tags: keyset_pagination_query]
         )
 
       assert %Ash.Page.Keyset{
-               results: [%MultitenantTag{name: "bar"}],
+               results: [%MultitenantTag{name: "foo"}],
                limit: 1,
                count: 2,
                more?: false,

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -375,6 +375,123 @@ defmodule Ash.Test.Actions.CreateTest do
     end
   end
 
+  defmodule Tenant do
+    @doc false
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :create, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+    end
+
+    defimpl Ash.ToTenant do
+      def to_tenant(tenant, _resource), do: tenant.id
+    end
+  end
+
+  defmodule MultitenantTagLink do
+    @moduledoc false
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :tenant_id
+    end
+
+    attributes do
+      attribute :type, :string do
+        public?(true)
+      end
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    relationships do
+      belongs_to :tenant, Tenant, allow_nil?: false
+
+      belongs_to :source_tag, Ash.Test.Actions.CreateTest.MultitenantTag,
+        primary_key?: true,
+        allow_nil?: false,
+        public?: true
+
+      belongs_to :destination_tag, Ash.Test.Actions.CreateTest.MultitenantTag,
+        primary_key?: true,
+        allow_nil?: false,
+        public?: true
+    end
+  end
+
+  defmodule MultitenantTag do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Ash.Test.Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :tenant_id
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+
+      create :create_with_related_tags do
+        argument :related_tags, {:array, :string} do
+          allow_nil? false
+          constraints min_length: 1, items: [min_length: 1]
+        end
+
+        change manage_relationship(:related_tags,
+                 on_lookup: :relate,
+                 on_no_match: :create,
+                 value_is_key: :name,
+                 use_identities: [:name]
+               )
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, allow_nil?: false, public?: true
+
+      timestamps()
+    end
+
+    relationships do
+      belongs_to :tenant, Tenant, allow_nil?: false
+
+      many_to_many :related_tags, __MODULE__,
+        through: MultitenantTagLink,
+        source_attribute_on_join_resource: :source_tag_id,
+        destination_attribute_on_join_resource: :destination_tag_id,
+        public?: true
+    end
+
+    identities do
+      identity :name, [:name], pre_check_with: Ash.Test.Domain
+    end
+  end
+
   describe "simple creates" do
     test "allows creating a record with valid attributes" do
       assert %Post{title: "foo", contents: "bar"} =
@@ -886,6 +1003,52 @@ defmodule Ash.Test.Actions.CreateTest do
                before: nil,
                after: ^keyset
              } = post.related_posts
+    end
+
+    test "allows loading paginated many_to_many relationship for multitenant resources" do
+      tenant = Ash.create!(Tenant, %{})
+      _ = Ash.create!(MultitenantTag, %{name: "foo"}, tenant: tenant)
+
+      offset_pagination_query =
+        MultitenantTag
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.select([:name])
+        |> Ash.Query.page(count: true, limit: 1)
+
+      tag =
+        Ash.create!(MultitenantTag, %{name: "tag 1", related_tags: ["foo", "bar"]},
+          action: :create_with_related_tags,
+          load: [related_tags: offset_pagination_query]
+        )
+
+      assert %Ash.Page.Offset{
+               results: [%MultitenantTag{name: "foo", __metadata__: %{keyset: keyset}}],
+               limit: 1,
+               offset: 0,
+               count: 2,
+               more?: true
+             } = tag.related_tags
+
+      keyset_pagination_query =
+        MultitenantTag
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.select([:name])
+        |> Ash.Query.page(count: true, limit: 1, after: keyset)
+
+      tag =
+        Ash.create!(MultitenantTag, %{name: "tag 2", related_tags: ["foo", "bar"]},
+          action: :create_with_related_tags,
+          load: [related_tags: keyset_pagination_query]
+        )
+
+      assert %Ash.Page.Keyset{
+               results: [%MultitenantTag{name: "bar"}],
+               limit: 1,
+               count: 2,
+               more?: false,
+               before: nil,
+               after: ^keyset
+             } = tag.related_tags
     end
   end
 


### PR DESCRIPTION
The PR tests loading relationships on multitenant resources after a create or update action.

The introduced tests are currently failing and require troubleshooting.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
