### PR TITLE
test: assert that notifications are sent for specific cases

### DIFF
--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1269,7 +1269,7 @@ defmodule Ash.Actions.Destroy.Bulk do
 
             store_error(ref, new_errors, opts, new_error_count)
 
-            notifications = Process.get({:bulk_update_notifications, tmp_ref}) || []
+            notifications = Process.get({:bulk_destroy_notifications, tmp_ref}) || []
             store_notification(ref, notifications, opts)
 
             result

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   require Ash.Query
   alias Ash.Test.Domain, as: Domain
 
@@ -223,6 +225,28 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
     end
   end
 
+  defmodule MnesiaPost do
+    @doc false
+
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Mnesia, notifiers: [Notifier]
+
+    mnesia do
+      table :mnesia_post_destroys
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+
+      timestamps()
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, :create, :update]
+    end
+  end
+
   test "returns destroyed records" do
     assert %Ash.BulkResult{records: [%{}, %{}]} =
              Ash.bulk_create!([%{title: "title1"}, %{title: "title2"}], Post, :create,
@@ -261,6 +285,45 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
 
     assert_received {:notification, %{data: %{title: "title1"}}}
     assert_received {:notification, %{data: %{title: "title2"}}}
+  end
+
+  test "sends notifications with stream strategy in transactions" do
+    capture_log(fn ->
+      Ash.DataLayer.Mnesia.start(Domain, [MnesiaPost])
+    end)
+
+    assert %Ash.BulkResult{records: [%{}, %{}]} =
+             Ash.bulk_create!([%{title: "title1"}, %{title: "title2"}], MnesiaPost, :create,
+               return_stream?: true,
+               return_records?: true,
+               authorize?: false
+             )
+             |> Stream.map(fn {:ok, result} ->
+               result
+             end)
+             |> Ash.bulk_destroy!(:destroy, %{},
+               resource: MnesiaPost,
+               strategy: :stream,
+               allow_stream_with: :full_read,
+               return_records?: true,
+               notify?: true,
+               return_errors?: true
+             )
+
+    assert_received {:notification,
+                     %{
+                       data: %{title: "title1"}
+                     }}
+
+    assert_received {:notification,
+                     %{
+                       data: %{title: "title2"}
+                     }}
+
+    capture_log(fn ->
+      :mnesia.stop()
+      :mnesia.delete_schema([node()])
+    end)
   end
 
   test "doesn't send notifications if not asked to" do


### PR DESCRIPTION
Asserts that notifications are sent for bulk updates and destroys using the `:stream` strategy with a data layer that supports transactions.

# Contributor checklist

- [x] Bug fixes include regression tests

Asserts and fixes #1262 