### PR TITLE
fix: invert logic for lazy-loading calculations/aggregates

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -1159,24 +1159,24 @@ defmodule Ash.Actions.Read do
     query =
       query
       |> Map.update!(:calculations, fn calculations ->
-        keys =
+        loaded_keys =
           calculations
-          |> Enum.reject(fn {_key, calc} ->
+          |> Enum.filter(fn {_key, calc} ->
             Ash.Resource.loaded?(initial_data, calc)
           end)
           |> Enum.map(&elem(&1, 0))
 
-        Map.drop(calculations, keys)
+        Map.drop(calculations, loaded_keys)
       end)
       |> Map.update!(:aggregates, fn aggregates ->
-        keys =
+        loaded_keys =
           aggregates
-          |> Enum.reject(fn {_key, calc} ->
+          |> Enum.filter(fn {_key, calc} ->
             Ash.Resource.loaded?(initial_data, calc)
           end)
           |> Enum.map(&elem(&1, 0))
 
-        Map.drop(aggregates, keys)
+        Map.drop(aggregates, loaded_keys)
       end)
 
     query

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -177,6 +177,10 @@ defmodule Ash.Test.Actions.LoadTest do
       end
     end
 
+    aggregates do
+      count :posts_count, :posts
+    end
+
     relationships do
       has_many(:posts, Ash.Test.Actions.LoadTest.Post,
         destination_attribute: :author_id,
@@ -663,6 +667,10 @@ defmodule Ash.Test.Actions.LoadTest do
         |> Ash.Query.filter(posts.id == ^post1.id)
         |> Ash.read!(authorize?: true)
 
+      author = Ash.load!(author, :posts_count, lazy?: true)
+
+      assert author.posts_count == 2
+
       assert Enum.sort(Enum.map(author.posts, &Map.get(&1, :id))) ==
                Enum.sort([post1.id, post2.id])
 
@@ -678,7 +686,9 @@ defmodule Ash.Test.Actions.LoadTest do
 
       author =
         author
-        |> Ash.load!([posts: [:author]], authorize?: true)
+        |> Ash.load!([:posts_count, posts: [:author]], authorize?: true)
+
+      assert author.posts_count == 3
 
       assert Enum.sort(Enum.map(author.posts, &Map.get(&1, :id))) ==
                Enum.sort([post1.id, post2.id, post3.id])
@@ -694,10 +704,12 @@ defmodule Ash.Test.Actions.LoadTest do
 
       author =
         author
-        |> Ash.load!([posts: [:author]], authorize?: true, lazy?: true)
+        |> Ash.load!([:posts_count, posts: [:author]], authorize?: true, lazy?: true)
 
       assert Enum.sort(Enum.map(author.posts, &Map.get(&1, :id))) ==
                Enum.sort([post1.id, post2.id, post3.id])
+
+      assert author.posts_count == 3
 
       for post <- author.posts do
         assert post.author.id == author.id


### PR DESCRIPTION
Currently the logic for `lazy?`-loading calculations and aggregates is wrong, which results in already loaded fields to be loaded again and unloaded fields not to be loaded at all.

The following example will only load the calculation or aggregate if it was already loaded:

```elixir
Ash.load(resource, [:some_agg, :another_calc], lazy?: true)
```

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
