### PR TITLE
fix: generate a MapSet, not a list, when creating calculation deps

### DIFF
--- a/lib/ash/actions/read/calculations.ex
+++ b/lib/ash/actions/read/calculations.ex
@@ -1444,7 +1444,7 @@ defmodule Ash.Actions.Read.Calculations do
             end
 
           {new_key,
-           Enum.map(value, fn depends_on ->
+           MapSet.new(value, fn depends_on ->
              if depends_on == current_key do
                new_calc.name
              else


### PR DESCRIPTION
`add_calculation_dependency` expects a MapSet

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
