### PR TITLE
fix: add callback arg to Changeset.around_transaction/2 spec

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -224,13 +224,15 @@ defmodule Ash.Changeset do
 
   @type before_transaction_fun :: (t -> t)
 
-  @type around_result ::
+  @type around_action_result ::
           {:ok, Ash.Resource.record(), t(), %{notifications: list(Ash.Notifier.Notification.t())}}
           | {:error, Ash.Error.t()}
-  @type around_callback :: (t() -> around_result)
-  @type around_action_fun :: (t, around_callback -> around_result)
+  @type around_action_callback :: (t -> around_action_result)
+  @type around_action_fun :: (t, around_action_callback -> around_action_result)
 
-  @type around_transaction_fun :: (t -> {:ok, Ash.Resource.record()} | {:error, any})
+  @type around_transaction_result :: {:ok, Ash.Resource.record()} | {:error, any}
+  @type around_transaction_callback :: (t -> around_transaction_result)
+  @type around_transaction_fun :: (t, around_transaction_callback -> around_transaction_result)
 
   @phases [
     :atomic,


### PR DESCRIPTION
The type for the `Changeset.around_transaction_fun` is missing the callback function argument, which results in the following Dialyzer warning in our app:

```
The call 'Elixir.Ash.Changeset':around_transaction
         (_changeset@1 :: any(),
          fun((_, _) -> any())) breaks the contract 
          (t(), around_transaction_fun()) -> t()
``` 

I fixed the spec and refactored the types according the `around_action_fun` spec.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
