### PR TITLE
Add strict?-option to Ash.Query.load

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -170,29 +170,10 @@ defmodule Ash do
                           default: false,
                           doc: """
                             If set to true, only specified attributes will be loaded when passing
-                            a list of fields to fetch on a relationship, which allows for more optimized data-fetching.
+                            a list of fields to fetch on a relationship, which allows for more
+                            optimized data-fetching.
 
-                            Example:
-                            ```
-                            Ash.load(category, [:name, posts: [:title, :published_at]], strict?: true)
-                            ```
-
-                            Here, the only fields that will be loaded on the `posts` relationship are `title` and `published_at`,
-                            in addition to any other fields that are required to be loaded, like the primary and relevant foreign keys.
-                            This entails that when using `strict?: true` and loading nested relationships, you will also always have
-                            to specify all the attributes you want to load alongside the nested relationships.
-
-                            Example:
-                            ```
-                            Ash.load(post, [:title, :published_at, :other_needed_attribute, category: [:name]], strict?: true)
-                            ```
-
-                            If no fields are specified on a relationship, all attributes will be loaded by default.
-
-                            Example:
-                            ```
-                            Ash.load(category, [:name, :posts], strict?: true)
-                            ```
+                            See `Ash.Query.load/2`.
                           """
                         ]
                       ],

--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -164,6 +164,11 @@ defmodule Ash do
                           default: false,
                           doc:
                             "Whether calculations are allowed to reuse values that have already been loaded, or must refetch them from the data layer."
+                        ],
+                        strict?: [
+                          type: :boolean,
+                          default: false,
+                          doc: "If set to true, only specified attributes will be loaded."
                         ]
                       ],
                       @global_opts,
@@ -1705,7 +1710,7 @@ defmodule Ash do
           resource
           |> Ash.Query.new()
           |> Ash.Query.set_tenant(opts[:tenant] || Map.get(record.__metadata__, :tenant))
-          |> Ash.Query.load(keyword)
+          |> Ash.Query.load(keyword, opts)
       end
 
     with %{valid?: true} <- query,

--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -168,7 +168,32 @@ defmodule Ash do
                         strict?: [
                           type: :boolean,
                           default: false,
-                          doc: "If set to true, only specified attributes will be loaded."
+                          doc: """
+                            If set to true, only specified attributes will be loaded when passing
+                            a list of fields to fetch on a relationship, which allows for more optimized data-fetching.
+
+                            Example:
+                            ```
+                            Ash.load(category, [:name, posts: [:title, :published_at]], strict?: true)
+                            ```
+
+                            Here, the only fields that will be loaded on the `posts` relationship are `title` and `published_at`,
+                            in addition to any other fields that are required to be loaded, like the primary and relevant foreign keys.
+                            This entails that when using `strict?: true` and loading nested relationships, you will also always have
+                            to specify all the attributes you want to load alongside the nested relationships.
+
+                            Example:
+                            ```
+                            Ash.load(post, [:title, :published_at, :other_needed_attribute, category: [:name]], strict?: true)
+                            ```
+
+                            If no fields are specified on a relationship, all attributes will be loaded by default.
+
+                            Example:
+                            ```
+                            Ash.load(category, [:name, :posts], strict?: true)
+                            ```
+                          """
                         ]
                       ],
                       @global_opts,

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1231,11 +1231,7 @@ defmodule Ash.Query do
   @doc """
   Loads relationships, calculations, or aggregates on the resource.
 
-  Currently, loading attributes has no effects, as all attributes are returned.
-  Before long, we will have the default list to load as the attributes, but if you say
-  `load(query, [:attribute1])`, that will be the only field filled in. This will let
-  data layers make more intelligent "select" statements as well.
-
+  By default, loading attributes has no effects, as all attributes are returned.
 
   ```elixir
   # Loading nested relationships
@@ -1244,6 +1240,35 @@ defmodule Ash.Query do
   # Loading relationships with a query
   Ash.Query.load(query, [comments: [author: author_query]])
   ```
+
+  By passing the `strict?: true` option, only specified attributes will be loaded when passing
+  a list of fields to fetch on a relationship, which allows for more optimized data-fetching.
+
+  The select statement of any queries inside the load statement will not be affected.
+
+  Example:
+  ```elixir
+  Ash.load(category, [:name, posts: [:title, :published_at]], strict?: true)
+  ```
+
+  Here, the only fields that will be loaded on the `posts` relationship are `title` and
+  `published_at`, in addition to any other fields that are required to be loaded, like the
+  primary and relevant foreign keys.
+  This entails that when using `strict?: true` and loading nested relationships, you will also
+  always have to specify all the attributes you want to load alongside the nested relationships.
+
+  Example:
+  ```elixir
+  Ash.load(post, [:title, :published_at, :other_needed_attribute, category: [:name]], strict?: true)
+  ```
+
+  If no fields are specified on a relationship when using `strict?: true`, all attributes will be
+  loaded by default.
+
+  Example:
+  ```elixir
+  Ash.load(category, [:name, :posts], strict?: true)
+  ```
   """
   @spec load(
           t() | Ash.Resource.t(),
@@ -1251,7 +1276,8 @@ defmodule Ash.Query do
           | Ash.Query.Calculation.t()
           | Ash.Query.Aggregate.t()
           | list(atom | Ash.Query.Calculation.t() | Ash.Query.Aggregate.t())
-          | list({atom | Ash.Query.Calculation.t() | Ash.Query.Aggregate.t(), term})
+          | list({atom | Ash.Query.Calculation.t() | Ash.Query.Aggregate.t(), term}),
+          Keyword.t()
         ) ::
           t()
 

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -1608,5 +1608,106 @@ defmodule Ash.Test.Actions.LoadTest do
       assert %Ash.Page.Offset{count: 3} = author.posts
       assert %{} == author.aggregates
     end
+
+    test "strict?: true option only loads specified fields on related resource" do
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "a"})
+        |> Ash.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "author post",
+          contents: "post content",
+          author_id: author.id
+        })
+        |> Ash.create!()
+
+      assert [author] =
+               Author
+               |> Ash.Query.load([posts: [:title]], strict?: true)
+               |> Ash.read!()
+
+      [loaded_post] = author.posts
+
+      assert post.contents == "post content"
+      assert loaded_post.title == "author post"
+      assert %Ash.NotLoaded{} = loaded_post.contents
+    end
+
+    @tag :new
+    test "all fields are loaded if no fields are specified when using strict?: true" do
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "a"})
+        |> Ash.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "author post",
+          contents: "post content",
+          author_id: author.id
+        })
+        |> Ash.create!()
+
+      assert [author] =
+               Author
+               |> Ash.Query.load([:posts], strict?: true)
+               |> Ash.read!()
+
+      [loaded_post] = author.posts
+
+      assert post.title == loaded_post.title
+      assert post.contents == loaded_post.contents
+    end
+
+    @tag :new
+    test "strict?: true option only loads specified fields on related resource for Ash.load" do
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "a"})
+        |> Ash.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "author post",
+          contents: "post content",
+          author_id: author.id
+        })
+        |> Ash.create!()
+
+      loaded_author = Ash.load!(author, [posts: [:title]], strict?: true)
+      [loaded_post] = loaded_author.posts
+
+      assert post.contents == "post content"
+      assert loaded_post.title == "author post"
+      assert %Ash.NotLoaded{} = loaded_post.contents
+    end
+
+    @tag :new
+    test "all fields are loaded if no fields are specified when using strict?: true for Ash.load" do
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "a"})
+        |> Ash.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "author post",
+          contents: "post content",
+          author_id: author.id
+        })
+        |> Ash.create!()
+
+      loaded_author = Ash.load!(author, [:posts], strict?: true)
+      [loaded_post] = loaded_author.posts
+
+      assert post.title == loaded_post.title
+      assert post.contents == loaded_post.contents
+    end
   end
 end

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -1636,7 +1636,6 @@ defmodule Ash.Test.Actions.LoadTest do
       assert %Ash.NotLoaded{} = loaded_post.contents
     end
 
-    @tag :new
     test "all fields are loaded if no fields are specified when using strict?: true" do
       author =
         Author

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -1685,7 +1685,6 @@ defmodule Ash.Test.Actions.LoadTest do
       assert %Ash.NotLoaded{} = loaded_post.contents
     end
 
-    @tag :new
     test "all fields are loaded if no fields are specified when using strict?: true for Ash.load" do
       author =
         Author

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -1662,7 +1662,6 @@ defmodule Ash.Test.Actions.LoadTest do
       assert post.contents == loaded_post.contents
     end
 
-    @tag :new
     test "strict?: true option only loads specified fields on related resource for Ash.load" do
       author =
         Author


### PR DESCRIPTION
Enables more optimised data-fetching by only fetching the specified attributes of loaded/nested relationships.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
