### PR TITLE
Make action ctx-values from reactor-ctx take precedence if set.

### DIFF
--- a/lib/ash/reactor/steps/action_step.ex
+++ b/lib/ash/reactor/steps/action_step.ex
@@ -9,12 +9,16 @@ defmodule Ash.Reactor.ActionStep do
 
   @doc false
   @impl true
-  def run(arguments, _context, options) do
+  def run(arguments, context, options) do
     action_input_options =
       options
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       []
@@ -27,12 +31,16 @@ defmodule Ash.Reactor.ActionStep do
 
   @doc false
   @impl true
-  def undo(record, arguments, _context, options) do
+  def undo(record, arguments, context, options) do
     action_input_options =
       options
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       []

--- a/lib/ash/reactor/steps/action_step.ex
+++ b/lib/ash/reactor/steps/action_step.ex
@@ -12,13 +12,13 @@ defmodule Ash.Reactor.ActionStep do
   def run(arguments, context, options) do
     action_input_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       []
@@ -34,13 +34,13 @@ defmodule Ash.Reactor.ActionStep do
   def undo(record, arguments, context, options) do
     action_input_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       []

--- a/lib/ash/reactor/steps/bulk_create_step.ex
+++ b/lib/ash/reactor/steps/bulk_create_step.ex
@@ -38,13 +38,13 @@ defmodule Ash.Reactor.BulkCreateStep do
         :upsert_identity,
         :upsert?
       ])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
-      |> maybe_set_kw(:notification_metadata, arguments[:notification_metadata])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:notification_metadata, arguments[:notification_metadata])
 
     success_states =
       options[:success_state]
@@ -75,13 +75,14 @@ defmodule Ash.Reactor.BulkCreateStep do
   def undo(bulk_result, arguments, context, options) when is_struct(bulk_result, BulkResult) do
     action_options =
       options
-      |> Keyword.take([:authorize?, :domain])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> Keyword.take([:domain])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     options[:resource]
     |> Ash.ActionInput.for_action(options[:undo_action], %{bulk_result: bulk_result})

--- a/lib/ash/reactor/steps/bulk_create_step.ex
+++ b/lib/ash/reactor/steps/bulk_create_step.ex
@@ -41,6 +41,10 @@ defmodule Ash.Reactor.BulkCreateStep do
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:notification_metadata, arguments[:notification_metadata])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     success_states =
       options[:success_state]
@@ -68,12 +72,16 @@ defmodule Ash.Reactor.BulkCreateStep do
 
   @doc false
   @impl true
-  def undo(bulk_result, arguments, _context, options) when is_struct(bulk_result, BulkResult) do
+  def undo(bulk_result, arguments, context, options) when is_struct(bulk_result, BulkResult) do
     action_options =
       options
       |> Keyword.take([:authorize?, :domain])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     options[:resource]
     |> Ash.ActionInput.for_action(options[:undo_action], %{bulk_result: bulk_result})

--- a/lib/ash/reactor/steps/bulk_update_step.ex
+++ b/lib/ash/reactor/steps/bulk_update_step.ex
@@ -47,6 +47,10 @@ defmodule Ash.Reactor.BulkUpdateStep do
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:notification_metadata, arguments[:notification_metadata])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     success_states =
       options[:success_state]
@@ -74,12 +78,16 @@ defmodule Ash.Reactor.BulkUpdateStep do
 
   @doc false
   @impl true
-  def undo(bulk_result, arguments, _context, options) when is_struct(bulk_result, BulkResult) do
+  def undo(bulk_result, arguments, context, options) when is_struct(bulk_result, BulkResult) do
     action_options =
       options
       |> Keyword.take([:authorize?, :domain])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     options[:resource]
     |> Ash.ActionInput.for_action(options[:undo_action], %{bulk_result: bulk_result})

--- a/lib/ash/reactor/steps/bulk_update_step.ex
+++ b/lib/ash/reactor/steps/bulk_update_step.ex
@@ -81,13 +81,14 @@ defmodule Ash.Reactor.BulkUpdateStep do
   def undo(bulk_result, arguments, context, options) when is_struct(bulk_result, BulkResult) do
     action_options =
       options
-      |> Keyword.take([:authorize?, :domain])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> Keyword.take([:domain])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     options[:resource]
     |> Ash.ActionInput.for_action(options[:undo_action], %{bulk_result: bulk_result})

--- a/lib/ash/reactor/steps/create_step.ex
+++ b/lib/ash/reactor/steps/create_step.ex
@@ -17,6 +17,10 @@ defmodule Ash.Reactor.CreateStep do
       |> maybe_set_kw(:upsert?, options[:upsert?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: true, domain: options[:domain]]
@@ -60,6 +64,10 @@ defmodule Ash.Reactor.CreateStep do
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: true, return_destroyed?: false, domain: options[:domain]]

--- a/lib/ash/reactor/steps/create_step.ex
+++ b/lib/ash/reactor/steps/create_step.ex
@@ -12,15 +12,15 @@ defmodule Ash.Reactor.CreateStep do
   def run(arguments, context, options) do
     changeset_options =
       options
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:upsert_identity, options[:upsert_identity])
       |> maybe_set_kw(:upsert?, options[:upsert?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
-      |> maybe_set_kw(:authorize?, context[:authorize?])
-      |> maybe_set_kw(:actor, context[:actor])
-      |> maybe_set_kw(:tenant, context[:tenant])
-      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: true, domain: options[:domain]]
@@ -61,13 +61,13 @@ defmodule Ash.Reactor.CreateStep do
   def undo(record, arguments, context, options) do
     changeset_options =
       []
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       [return_notifications?: true, return_destroyed?: false, domain: options[:domain]]

--- a/lib/ash/reactor/steps/destroy_step.ex
+++ b/lib/ash/reactor/steps/destroy_step.ex
@@ -14,14 +14,14 @@ defmodule Ash.Reactor.DestroyStep do
 
     changeset_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
-      |> maybe_set_kw(:return_destroyed?, return_destroyed?)
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:return_destroyed?, return_destroyed?)
 
     action_options =
       [return_notifications?: true]
@@ -56,13 +56,13 @@ defmodule Ash.Reactor.DestroyStep do
   def undo(record, arguments, context, options) do
     changeset_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       [return_notifications?: false]

--- a/lib/ash/reactor/steps/destroy_step.ex
+++ b/lib/ash/reactor/steps/destroy_step.ex
@@ -18,6 +18,10 @@ defmodule Ash.Reactor.DestroyStep do
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:return_destroyed?, return_destroyed?)
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: true]
@@ -49,12 +53,16 @@ defmodule Ash.Reactor.DestroyStep do
 
   @doc false
   @impl true
-  def undo(record, arguments, _context, options) do
+  def undo(record, arguments, context, options) do
     changeset_options =
       options
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: false]

--- a/lib/ash/reactor/steps/read_one_step.ex
+++ b/lib/ash/reactor/steps/read_one_step.ex
@@ -10,13 +10,13 @@ defmodule Ash.Reactor.ReadOneStep do
   def run(arguments, context, options) do
     query_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
-      |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       []

--- a/lib/ash/reactor/steps/read_one_step.ex
+++ b/lib/ash/reactor/steps/read_one_step.ex
@@ -7,12 +7,16 @@ defmodule Ash.Reactor.ReadOneStep do
 
   alias Ash.Query
 
-  def run(arguments, _context, options) do
+  def run(arguments, context, options) do
     query_options =
       options
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       []

--- a/lib/ash/reactor/steps/read_step.ex
+++ b/lib/ash/reactor/steps/read_step.ex
@@ -10,13 +10,13 @@ defmodule Ash.Reactor.ReadStep do
   def run(arguments, context, options) do
     query_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       []

--- a/lib/ash/reactor/steps/read_step.ex
+++ b/lib/ash/reactor/steps/read_step.ex
@@ -7,12 +7,16 @@ defmodule Ash.Reactor.ReadStep do
 
   alias Ash.Query
 
-  def run(arguments, _context, options) do
+  def run(arguments, context, options) do
     query_options =
       options
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       []

--- a/lib/ash/reactor/steps/update_step.ex
+++ b/lib/ash/reactor/steps/update_step.ex
@@ -15,6 +15,10 @@ defmodule Ash.Reactor.UpdateStep do
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: true]
@@ -47,6 +51,10 @@ defmodule Ash.Reactor.UpdateStep do
       |> maybe_set_kw(:authorize?, options[:authorize?])
       |> maybe_set_kw(:actor, arguments[:actor])
       |> maybe_set_kw(:tenant, arguments[:tenant])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:tracer, context[:tracer])
 
     action_options =
       [return_notifications?: false]

--- a/lib/ash/reactor/steps/update_step.ex
+++ b/lib/ash/reactor/steps/update_step.ex
@@ -12,13 +12,13 @@ defmodule Ash.Reactor.UpdateStep do
   def run(arguments, context, options) do
     changeset_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       [return_notifications?: true]
@@ -48,13 +48,13 @@ defmodule Ash.Reactor.UpdateStep do
   def undo(record, arguments, context, options) do
     changeset_options =
       options
-      |> maybe_set_kw(:authorize?, options[:authorize?])
-      |> maybe_set_kw(:actor, arguments[:actor])
-      |> maybe_set_kw(:tenant, arguments[:tenant])
       |> maybe_set_kw(:authorize?, context[:authorize?])
       |> maybe_set_kw(:actor, context[:actor])
       |> maybe_set_kw(:tenant, context[:tenant])
       |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
 
     action_options =
       [return_notifications?: false]


### PR DESCRIPTION
This fix uses the passed action context when running a Reactor from a generic resource action, which is currently ignored.

I'm not sure if there are good and valid reasons for having the opportunity to specify actor/tenant/authorize? as step attributes (`Ash.Reactor.ReadStep` for example), or if those values could just be placed in the context as well when invoking `Reactor.run` directly? At least that would simplify the logic a tiny bit, if possible 😅 

Anyway, this is not a breaking change, and fixes running a reactor that requires access to values from the generated action-context, which will currently break if any of the steps require access to the actor/tenant etc from the action's opts.
