### PR TITLE
feat: add relating_to_actor_via policy check

### DIFF
--- a/lib/ash/policy/check/built_in_checks.ex
+++ b/lib/ash/policy/check/built_in_checks.ex
@@ -267,6 +267,39 @@ defmodule Ash.Policy.Check.Builtins do
     {Ash.Policy.Check.RelatingToActor, relationship: relationship}
   end
 
+  @doc """
+  This check passes if the data is being related to the actor via the specified relationship or path of relationships.
+
+  This only supports `belongs_to` and `has_one` relationships. 
+
+  `:target_field` is the field from the last resource in the path to match against the actor.
+
+  `:field` is the field from the actor to match against as the last resource in the path. 
+
+  Multiple values may be given for the `:target_field` and `:field` options but they must have the same number of 
+  elements and respective order.
+
+  For example:
+
+  ```elixir
+  policy action_type(:create) do
+    authorize_if relating_to_actor_via(:owner)
+
+    # Path of relationships:
+    authorize_if relating_to_actor_via([:comment, :post, :creator])
+
+    # When the actor relates to a target field of the last relationship:
+    authorize_if relating_to_actor_via([:comment, :post], target_field: :creator_id)
+
+    # When a field of the actor relates to a target field of the last relationship:
+    authorize_if relating_to_actor_via([:comment, :post], target_field: [:maintainer_id, :role], field: [:id, :role])
+  end
+  """
+  def relating_to_actor_via(relationships, opts \\ []) do
+    opts = Keyword.put(opts, :relationships, relationships)
+    {Ash.Policy.Check.RelatingToActorVia, opts}
+  end
+
   @doc "This check is true when the specified relationship is changing"
   def changing_relationship(relationship) do
     changing_relationships(relationship)

--- a/lib/ash/policy/check/relating_to_actor_via.ex
+++ b/lib/ash/policy/check/relating_to_actor_via.ex
@@ -1,0 +1,154 @@
+defmodule Ash.Policy.Check.RelatingToActorVia do
+  @moduledoc "This check is true when the specified relationship is related to the current actor."
+  use Ash.Policy.SimpleCheck
+
+  @default_field :id
+
+  defp configure_opts(opts) do
+    opts
+    |> Keyword.update!(:relationships, &List.wrap/1)
+    |> Keyword.put_new(:field, @default_field)
+  end
+
+  @impl true
+  def describe(opts) do
+    opts = configure_opts(opts)
+    path = Enum.join(opts[:relationships], ".")
+    field = Keyword.get(opts, :field, [@default_field])
+    target_field = Keyword.get(opts, :target_field)
+
+    target_field_part = if target_field, do: ".#{target_field}", else: ""
+    "relating this.#{path}#{target_field_part} == actor.#{field}"
+  end
+
+  @impl true
+  def match?(actor, %{changeset: %Ash.Changeset{} = changeset}, opts) when not is_nil(actor) do
+    opts = configure_opts(opts)
+    field = Keyword.get(opts, :field)
+    target_field = Keyword.get(opts, :target_field)
+    relationship_path = opts[:relationships]
+
+    unless has_attributes?(actor, field) do
+      raise "Actor does not have `#{inspect(field)}` attribute(s). Set `:field` in `relating_to_actor_via`."
+    end
+
+    first_relationship = first_relationship_info(changeset.resource, relationship_path)
+
+    remaining_path = Enum.drop(relationship_path, 1)
+
+    {last_relationship, to_many?} =
+      relationship_info(changeset.resource, relationship_path)
+
+    if to_many? do
+      raise "Can only use `belongs_to` and `has_one` relationships in `relating_to_actor_via` checks"
+    end
+
+    pkey = Ash.Resource.Info.primary_key(last_relationship.destination)
+    effective_target_field = target_field || pkey
+
+    unless has_attributes?(last_relationship.destination, effective_target_field) do
+      raise "Last resource in path does not have `#{inspect(effective_target_field)}` attribute(s). Set `:target_field` in `relating_to_actor_via`."
+    end
+
+    # get the key field to load by
+    key_value = Ash.Changeset.get_attribute(changeset, first_relationship.source_attribute)
+    id = Map.put(%{}, first_relationship.destination_attribute, key_value)
+
+    # load the first resource from the database, then load the remaining path
+    # grabbing the last item in the path
+    last_item =
+      first_relationship.destination
+      |> Ash.get!(id, actor: actor)
+      |> get_last_item(remaining_path, actor)
+
+    target_values = extract_key_values(last_item, effective_target_field)
+    actor_values = extract_key_values(actor, field)
+
+    # make sure it lines up with the actor
+    {:ok, target_values == actor_values}
+  end
+
+  def match?(_, _, _), do: false
+
+  defp has_attributes?(resource, keys) when is_list(keys) do
+    attributes = Ash.Resource.Info.attributes(resource)
+
+    num_keys =
+      Enum.reduce(attributes, 0, fn
+        %Ash.Resource.Attribute{name: name}, acc ->
+          if name in keys do
+            acc + 1
+          else
+            acc
+          end
+      end)
+
+    num_keys == length(keys)
+  end
+
+  defp has_attributes?(resource, key), do: has_attributes?(resource, [key])
+
+  defp extract_key_values(record, keys) when is_list(keys) do
+    Enum.reduce(keys, [], fn key, acc -> [Map.get(record, key) | acc] end)
+  end
+
+  defp extract_key_values(record, key), do: extract_key_values(record, [key])
+
+  # no relationships, so we're done
+  defp get_last_item(item, [], _actor), do: item
+
+  defp get_last_item(item, relationship_path, actor) do
+    load_path = relationship_path_to_load_path(relationship_path)
+
+    relationship_path = Enum.map(relationship_path, &Access.key!/1)
+
+    item
+    |> Ash.load!(load_path, actor: actor)
+    |> get_in(relationship_path)
+  end
+
+  defp relationship_path_to_load_path(relationship_path) do
+    relationship_path
+    |> Enum.reverse()
+    |> Enum.reduce([], fn
+      item_key, [] -> [item_key]
+      item_key, acc -> Keyword.put([], item_key, acc)
+    end)
+  end
+
+  defp first_relationship_info(resource, path, to_many? \\ false) do
+    first_path =
+      path
+      |> List.first()
+      |> List.wrap()
+
+    {rel, _} = relationship_info(resource, first_path, to_many?)
+    rel
+  end
+
+  defp relationship_info(resource, path, to_many? \\ false)
+
+  defp relationship_info(resource, [rel_key], to_many?) do
+    rel = Ash.Resource.Info.relationship(resource, rel_key)
+
+    raise_if_nil(rel, rel_key, resource)
+
+    {rel, to_many? || rel.cardinality == :many}
+  end
+
+  defp relationship_info(resource, [rel_key | rest], to_many?) do
+    rel = Ash.Resource.Info.relationship(resource, rel_key)
+
+    raise_if_nil(rel, rel_key, resource)
+
+    relationship_info(rel.destination, rest, to_many? || rel.cardinality == :many)
+  end
+
+  defp raise_if_nil(nil, rel_key, resource) do
+    raise "No such relationship ':#{rel_key}' for #{resource}, required in `relating_to_actor_via` check"
+  end
+
+  defp raise_if_nil(_, _, _) do
+    :ok
+  end
+end

--- a/test/policy/relating_to_actor_via_test.exs
+++ b/test/policy/relating_to_actor_via_test.exs
@@ -1,0 +1,438 @@
+defmodule Ash.Test.Policy.RelatingToActorViaTest do
+  @doc false
+  use ExUnit.Case
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule User do
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+
+      attribute(:c, :string, allow_nil?: false, public?: true)
+      attribute(:d, :string, allow_nil?: false, public?: true)
+    end
+  end
+
+  defmodule Maintainer do
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+
+      attribute(:post_id, :uuid)
+
+      attribute(:a, :string, allow_nil?: false, public?: true)
+      attribute(:b, :string, allow_nil?: false, public?: true)
+    end
+
+    relationships do
+      belongs_to :user, Ash.Test.Policy.RelatingToActorViaTest.User do
+        public?(true)
+      end
+
+      belongs_to :post, Ash.Test.Policy.RelatingToActorViaTest.Post do
+        public?(true)
+      end
+    end
+  end
+
+  defmodule Post do
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to :user, Ash.Test.Policy.RelatingToActorViaTest.User do
+        public?(true)
+      end
+
+      has_many :comments, Ash.Test.Policy.RelatingToActorViaTest.Comment do
+        public?(true)
+      end
+
+      has_one :maintainer, Ash.Test.Policy.RelatingToActorViaTest.Maintainer do
+        public?(true)
+      end
+    end
+  end
+
+  defmodule Comment do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to :post, Ash.Test.Policy.RelatingToActorViaTest.Post do
+        public?(true)
+      end
+    end
+  end
+
+  defmodule CommentMetadata do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to :comment, Ash.Test.Policy.RelatingToActorViaTest.Comment do
+        public?(true)
+      end
+    end
+
+    policies do
+      policy action_type(:create) do
+        authorize_if(relating_to_actor_via([:comment, :post], target_field: :user_id))
+      end
+    end
+  end
+
+  defmodule Reaction do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to :comment, Ash.Test.Policy.RelatingToActorViaTest.Comment do
+        public?(true)
+      end
+    end
+
+    policies do
+      policy action_type(:create) do
+        authorize_if(relating_to_actor_via([:comment, :post, :user]))
+      end
+    end
+  end
+
+  defmodule OtherThing do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to :comment, Ash.Test.Policy.RelatingToActorViaTest.Comment do
+        public?(true)
+      end
+    end
+
+    policies do
+      policy action_type(:create) do
+        authorize_if(
+          relating_to_actor_via([:comment, :post, :maintainer],
+            target_field: [:a, :b],
+            field: [:c, :d]
+          )
+        )
+      end
+    end
+  end
+
+  defmodule BadPolicyToMany do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to(:post, Ash.Test.Policy.RelatingToActorViaTest.Post)
+    end
+
+    policies do
+      policy action_type(:create) do
+        authorize_if(relating_to_actor_via([:post, :comments, :post, :user]))
+      end
+    end
+  end
+
+  defmodule BadPolicyRelName do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    policies do
+      policy always() do
+        authorize_if(relating_to_actor_via(:does_not_exist))
+      end
+    end
+  end
+
+  defmodule BadPolicyRelPathName do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    policies do
+      policy always() do
+        authorize_if(relating_to_actor_via([:does_not_exist, :neither_does_this]))
+      end
+    end
+  end
+
+  defmodule BadPolicyTargetField do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      belongs_to(:comment, Ash.Test.Policy.RelatingToActorViaTest.Comment) do
+        public?(true)
+      end
+    end
+
+    policies do
+      policy always() do
+        authorize_if(
+          relating_to_actor_via([:comment, :post, :user], target_field: :does_not_exist)
+        )
+      end
+    end
+  end
+
+  defp user_fixture do
+    User
+    |> Ash.Changeset.for_create(:create, %{c: "key1", d: "key2"})
+    |> Ash.create!()
+  end
+
+  setup do
+    user = user_fixture()
+
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create)
+      |> Ash.Changeset.manage_relationship(:user, user, type: :append)
+      |> Ash.create!(authorize?: false)
+
+    maintainer =
+      Maintainer
+      |> Ash.Changeset.for_create(:create, %{a: "key1", b: "key2"})
+      |> Ash.Changeset.manage_relationship(:post, post, type: :append)
+      |> Ash.create!(authorize?: false)
+
+    comment =
+      Comment
+      |> Ash.Changeset.for_create(:create)
+      |> Ash.Changeset.manage_relationship(:post, post, type: :append)
+      |> Ash.create!(authorize?: false)
+
+    %{comment: comment, maintainer: maintainer, post: post, user: user}
+  end
+
+  describe "no options" do
+    test "relating_to_actor_via with create attribute", %{comment: comment, user: user} do
+      assert {:ok, _} =
+               Reaction
+               |> Ash.Changeset.for_create(:create, %{comment_id: comment.id})
+               |> Ash.create(actor: user)
+    end
+
+    test "relating_to_actor_via errors with other actor", %{comment: comment} do
+      user = user_fixture()
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Reaction
+               |> Ash.Changeset.for_create(:create, %{comment_id: comment.id})
+               |> Ash.create(actor: user)
+    end
+
+    # TODO: how can we make this work?
+    @tag :skip
+    test "relating_to_actor_via with manage_relationship", %{comment: comment, user: user} do
+      assert {:ok, _} =
+               Reaction
+               |> Ash.Changeset.for_create(:create)
+               |> Ash.Changeset.manage_relationship(:comment, comment, type: :append)
+               |> Ash.create(actor: user)
+    end
+
+    test "relating_to_actor_via with to_many raises", %{user: user} do
+      assert_raise Ash.Error.Unknown, ~r/`belongs_to` and `has_one` relationships/, fn ->
+        BadPolicyToMany
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create!(authorize?: true, actor: user)
+      end
+    end
+
+    test "relating_to_actor_via raises if relationship does not exist", %{user: user} do
+      assert_raise Ash.Error.Unknown, ~r/does_not_exist/, fn ->
+        BadPolicyRelName
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create!(authorize?: true, actor: user)
+      end
+
+      assert_raise Ash.Error.Unknown, ~r/:does_not_exist/, fn ->
+        BadPolicyRelPathName
+        |> Ash.Changeset.for_create(:create)
+        |> Ash.create!(authorize?: true, actor: user)
+      end
+    end
+  end
+
+  describe "target_field option" do
+    test "relating_to_actor_via with target_field", %{comment: comment, user: user} do
+      assert {:ok, _} =
+               CommentMetadata
+               |> Ash.Changeset.for_create(:create, %{comment_id: comment.id})
+               |> Ash.create(authorize?: true, actor: user)
+    end
+
+    test "relating_to_actor_via with multi-field target_field and field", %{
+      comment: comment,
+      user: user
+    } do
+      assert {:ok, _} =
+               OtherThing
+               |> Ash.Changeset.for_create(:create, %{comment_id: comment.id})
+               |> Ash.create(authorize?: true, actor: user)
+    end
+
+    test "relating_to_actor_via raises with invalid target_field", %{comment: comment, user: user} do
+      assert_raise Ash.Error.Unknown, ~r/does_not_exist/, fn ->
+        BadPolicyTargetField
+        |> Ash.Changeset.for_create(:create, %{comment_id: comment.id})
+        |> Ash.create!(authorize?: true, actor: user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Adds a `relating_to_actor_via()` built-in policy check similar to `relating_to_actor` but supporting a relationship path to find where the entity relates to the actor.

This is PR is the result of this thread: https://elixir-lang.slack.com/archives/C0193AHFLPN/p1719753168326359 

I couldn't figure out how to make this work with `manage_relationship`. Any pointers here would be greatly appreciated! I added a test for this but marked it as skipped since it does not work.

Also, if there are better option names that better align with ash conventions please let me know. I tried to align them to the existing builtin option names but feel like the ones in the PR are not quite on point.