### PR TITLE
Add ash_step wrapper.

### DIFF
--- a/lib/ash/reactor/builders/ash_step.ex
+++ b/lib/ash/reactor/builders/ash_step.ex
@@ -1,0 +1,87 @@
+defimpl Reactor.Dsl.Build, for: Ash.Reactor.Dsl.AshStep do
+  @moduledoc false
+
+  alias Ash.Reactor.AshStep
+  alias Reactor.Builder
+  alias Spark.Error.DslError
+  import Ash.Reactor.BuilderUtils
+
+  @doc false
+  @impl true
+  def build(ash_step, reactor) do
+    with {:ok, reactor} <- ensure_hooked(reactor) do
+      Builder.add_step(
+        reactor,
+        ash_step.name,
+        {AshStep, [run: ash_step.run, compensate: ash_step.compensate, undo: ash_step.undo]},
+        ash_step.arguments,
+        async?: ash_step.async?,
+        max_retries: ash_step.max_retries,
+        transform: ash_step.transform,
+        ref: :step_name
+      )
+    end
+  end
+
+  @doc false
+  @impl true
+  def transform(_update, dsl_state), do: {:ok, dsl_state}
+
+  @doc false
+  @impl true
+  def verify(_ash_step, _dsl_state), do: :ok
+
+  defp rewrite_step(step, module) when is_nil(step.impl) and is_nil(step.run),
+    do:
+      {:error,
+       DslError.exception(
+         module: module,
+         path: [:reactor, :step, step.name],
+         message: "Step has no implementation"
+       )}
+
+  defp rewrite_step(step, module) when not is_nil(step.impl) and not is_nil(step.run),
+    do:
+      {:error,
+       DslError.exception(
+         module: module,
+         path: [:reactor, :step, step.name],
+         message: "Step has both an implementation module and a run function"
+       )}
+
+  defp rewrite_step(step, module)
+       when not is_nil(step.impl) and not is_nil(step.compensate),
+       do:
+         {:error,
+          DslError.exception(
+            module: module,
+            path: [:reactor, :step, step.name],
+            message: "Step has both an implementation module and a compensate function"
+          )}
+
+  defp rewrite_step(step, module) when not is_nil(step.impl) and not is_nil(step.undo),
+    do:
+      {:error,
+       DslError.exception(
+         module: module,
+         path: [:reactor, :step, step.name],
+         message: "Step has both an implementation module and a undo function"
+       )}
+
+  defp rewrite_step(step, _dsl_state)
+       when is_nil(step.run) and is_nil(step.compensate) and is_nil(step.undo) and
+              not is_nil(step.impl),
+       do: {:ok, step}
+
+  defp rewrite_step(step, _dsl_state),
+    do:
+      {:ok,
+       %{
+         step
+         | impl:
+             {Ash.Reactor.AshStep, run: step.run, compensate: step.compensate, undo: step.undo},
+           run: nil,
+           compensate: nil,
+           undo: nil
+       }}
+end

--- a/lib/ash/reactor/dsl/ash_step.ex
+++ b/lib/ash/reactor/dsl/ash_step.ex
@@ -1,0 +1,134 @@
+defmodule Ash.Reactor.Dsl.AshStep do
+  @moduledoc """
+  The ash_step DSL module.
+
+  See `d:Reactor.step`.
+  """
+
+  defstruct __identifier__: nil,
+            arguments: [],
+            async?: true,
+            compensate: nil,
+            impl: nil,
+            max_retries: :infinity,
+            name: nil,
+            run: nil,
+            transform: nil,
+            undo: nil
+
+  alias Reactor.{Dsl, Step}
+
+  @type t :: %__MODULE__{
+          arguments: [Dsl.Argument.t()],
+          async?: boolean,
+          compensate:
+            nil | (any, Reactor.inputs(), Reactor.context() -> :ok | :retry | {:continue, any}),
+          impl: module | {module, keyword},
+          max_retries: non_neg_integer() | :infinity,
+          name: atom,
+          run:
+            nil
+            | (Reactor.inputs(), Reactor.context() ->
+                 {:ok, any} | {:ok, any, [Step.t()]} | {:halt | :error, any}),
+          transform: nil | (any -> any),
+          undo: nil | (any, Reactor.inputs(), Reactor.context() -> :ok | :retry | {:error, any}),
+          __identifier__: any
+        }
+
+  @doc false
+  def __entity__,
+    do: %Spark.Dsl.Entity{
+      name: :ash_step,
+      describe: """
+      Specifies a Ash.Reactor step.
+
+      This is basically a wrapper around `Reactor.step`, in order to handle
+      any returned notifications from the run step/function.
+
+      See the `Reactor.Step` behaviour for more information.
+      """,
+      examples: [
+        """
+        ash_step :create_post, MyApp.CreatePostStep do
+          argument :title, input(:title)
+        end
+        """,
+        """
+        ash_step :create_post do
+          argument :title, input(:title)
+
+          run fn %{title: title}, _ ->
+            MyApp.Post.create(title, return_notifications?: true)
+          end
+        end
+        """
+      ],
+      args: [:name, {:optional, :impl}],
+      target: __MODULE__,
+      identifier: :name,
+      no_depend_modules: [:impl],
+      entities: [arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      recursive_as: :steps,
+      schema: [
+        name: [
+          type: :atom,
+          required: true,
+          doc: """
+          A unique name for the step. Used when choosing the return value of the Reactor and for arguments into other steps.
+          """
+        ],
+        impl: [
+          type: {:or, [{:spark_behaviour, Step}, nil]},
+          required: false,
+          doc: """
+          A module that implements the `Reactor.Step` behaviour that provides the implementation.
+          """
+        ],
+        run: [
+          type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}]},
+          required: false,
+          doc: """
+          Provide an anonymous function which implements the `run/3` callback. Cannot be provided at the same time as the `impl` argument.
+          """
+        ],
+        undo: [
+          type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}, {:mfa_or_fun, 3}]},
+          required: false,
+          doc: """
+          Provide an anonymous function which implements the `undo/4` callback. Cannot be provided at the same time as the `impl` argument.
+          """
+        ],
+        compensate: [
+          type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}, {:mfa_or_fun, 3}]},
+          required: false,
+          doc: """
+          Provide an anonymous function which implements the `undo/4` callback. Cannot be provided at the same time as the `impl` argument.
+          """
+        ],
+        max_retries: [
+          type: {:or, [{:in, [:infinity]}, :non_neg_integer]},
+          required: false,
+          default: :infinity,
+          doc: """
+          The maximum number of times that the step can be retried before failing. Only used when the result of the `compensate/4` callback is `:retry`.
+          """
+        ],
+        async?: [
+          type: :boolean,
+          required: false,
+          default: true,
+          doc: """
+          When set to true the step will be executed asynchronously via Reactor's `TaskSupervisor`.
+          """
+        ],
+        transform: [
+          type: {:or, [{:spark_function_behaviour, Step, {Step.TransformAll, 1}}, nil]},
+          required: false,
+          default: nil,
+          doc: """
+          An optional transformation function which can be used to modify the entire argument map before it is passed to the step.
+          """
+        ]
+      ]
+    }
+end

--- a/lib/ash/reactor/dsl/ash_step.ex
+++ b/lib/ash/reactor/dsl/ash_step.ex
@@ -23,7 +23,7 @@ defmodule Ash.Reactor.Dsl.AshStep do
           async?: boolean,
           compensate:
             nil | (any, Reactor.inputs(), Reactor.context() -> :ok | :retry | {:continue, any}),
-          impl: module | {module, keyword},
+          impl: nil | module | {module, keyword},
           max_retries: non_neg_integer() | :infinity,
           name: atom,
           run:

--- a/lib/ash/reactor/reactor.ex
+++ b/lib/ash/reactor/reactor.ex
@@ -20,6 +20,7 @@ defmodule Ash.Reactor do
   }
   @type action ::
           Ash.Reactor.Dsl.Action.t()
+          | Ash.Reactor.Dsl.AshStep.t()
           | Ash.Reactor.Dsl.BulkCreate.t()
           | Ash.Reactor.Dsl.BulkUpdate.t()
           | Ash.Reactor.Dsl.Create.t()
@@ -34,6 +35,7 @@ defmodule Ash.Reactor do
     dsl_patches:
       [
         Ash.Reactor.Dsl.Action,
+        Ash.Reactor.Dsl.AshStep,
         Ash.Reactor.Dsl.BulkCreate,
         Ash.Reactor.Dsl.BulkUpdate,
         Ash.Reactor.Dsl.Change,

--- a/lib/ash/reactor/steps/ash_step.ex
+++ b/lib/ash/reactor/steps/ash_step.ex
@@ -1,0 +1,138 @@
+defmodule Ash.Reactor.AshStep do
+  @moduledoc """
+  A reactor step which runs a step-module or an anonymous function, and enqueues any returned
+  notifications before returning.
+
+  The following return values are supported: `{:ok, result}`, `{:ok, result, notifications}`,
+  `{:ok, result, notifications, new_steps}`
+
+  Example:
+
+  ```elixir
+  ash_step :maybe_update_post do
+    run fn %{post: post, new_amount_of_likes: new_amount_of_likes}, ctx ->
+      opts = Ash.Context.to_opts(ctx, return_notifications?: true)
+      if post.amount_of_likes != new_amount_of_likes do
+        Post.update(post, %{amount_of_likes: new_amount_of_likes}, opts)
+      else
+        {:ok, post}
+      end
+  end
+  ```
+  ## Options
+
+  * `run` - a one or two arity function or MFA which will be called as the run
+    function of the step.
+  * `compensate` - a one to three arity function or MFA which will be called as
+    the compensate function of the step.  Optional.
+  * `undo` - a one to three arity function or MFA which will be called as the
+    undo function of this step.  Optional.
+  """
+
+  use Reactor.Step
+
+  @doc false
+  @impl true
+  @spec run(Reactor.inputs(), Reactor.context(), keyword) :: {:ok | :error, any}
+  def run(arguments, context, options) do
+    case Keyword.fetch!(options, :run) do
+      fun when is_function(fun, 1) ->
+        fun.(arguments)
+
+      fun when is_function(fun, 2) ->
+        fun.(arguments, context)
+
+      {m, f, a} when is_atom(m) and is_atom(f) and is_list(a) ->
+        apply(m, f, [arguments, context] ++ a)
+    end
+    |> case do
+      {:ok, result, notifications} ->
+        with :ok <- Ash.Reactor.Notifications.enqueue_notifications(context, notifications),
+             do: {:ok, result}
+
+      {:ok, result, notifications, new_steps} ->
+        with :ok <- Ash.Reactor.Notifications.enqueue_notifications(context, notifications),
+             do: {:ok, result, new_steps}
+
+      result ->
+        result
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  @doc false
+  @impl true
+  @spec compensate(any, Reactor.inputs(), Reactor.context(), keyword) ::
+          {:continue, any} | :ok | :retry
+  def compensate(reason, arguments, context, options) do
+    case Keyword.fetch(options, :compensate) do
+      {:ok, fun} when is_function(fun, 1) ->
+        fun.(reason)
+
+      {:ok, fun} when is_function(fun, 2) ->
+        fun.(reason, arguments)
+
+      {:ok, fun} when is_function(fun, 3) ->
+        fun.(reason, arguments, context)
+
+      {:ok, {m, f, a}} when is_atom(m) and is_atom(f) and is_list(a) ->
+        apply(m, f, [reason, arguments, context] ++ a)
+
+      _ ->
+        :ok
+    end
+    |> case do
+      {:ok, result, notifications} ->
+        with :ok <- Ash.Reactor.Notifications.enqueue_notifications(context, notifications),
+             do: {:ok, result}
+
+      {:ok, result, notifications, new_steps} ->
+        with :ok <- Ash.Reactor.Notifications.enqueue_notifications(context, notifications),
+             do: {:ok, result, new_steps}
+
+      result ->
+        result
+    end
+  end
+
+  @doc false
+  @impl true
+  @spec undo(any, Reactor.inputs(), Reactor.context(), keyword) :: :ok | :retry | {:error, any}
+  def undo(value, arguments, context, options) do
+    case Keyword.fetch(options, :undo) do
+      {:ok, fun} when is_function(fun, 1) ->
+        fun.(value)
+
+      {:ok, fun} when is_function(fun, 2) ->
+        fun.(value, arguments)
+
+      {:ok, fun} when is_function(fun, 3) ->
+        fun.(value, arguments, context)
+
+      {:ok, {m, f, a}} when is_atom(m) and is_atom(f) and is_list(a) ->
+        apply(m, f, [value, arguments, context] ++ a)
+
+      _ ->
+        :ok
+    end
+    |> case do
+      {:ok, result, notifications} ->
+        with :ok <- Ash.Reactor.Notifications.enqueue_notifications(context, notifications),
+             do: {:ok, result}
+
+      {:ok, result, notifications, new_steps} ->
+        with :ok <- Ash.Reactor.Notifications.enqueue_notifications(context, notifications),
+             do: {:ok, result, new_steps}
+
+      result ->
+        result
+    end
+  end
+
+  @doc false
+  @impl true
+  def can?(%{impl: {_, opts}}, :undo), do: is_function(Keyword.get(opts, :undo))
+  def can?(%{impl: {_, opts}}, :compensate), do: is_function(Keyword.get(opts, :compensate))
+  def can?(_, _), do: false
+end


### PR DESCRIPTION
Adds a wrapper that handles enqueueing of any returned ash-notifications when running a regular step-module or an anonymous run-function.
