### PR TITLE
fix: Fix apply_constraints/2 for nil

### DIFF
--- a/lib/ash/type/integer.ex
+++ b/lib/ash/type/integer.ex
@@ -109,7 +109,7 @@ defmodule Ash.Type.Integer do
   def integer(value) when is_integer(value), do: {:ok, value}
   def integer(_), do: {:error, "must be an integer"}
 
-  def apply_constraints(nil, _), do: :ok
+  def apply_constraints(nil, _), do: {:ok, nil}
 
   def apply_constraints(value, constraints) do
     errors =

--- a/lib/ash/type/string.ex
+++ b/lib/ash/type/string.ex
@@ -168,7 +168,7 @@ defmodule Ash.Type.String do
     end
   end
 
-  def apply_constraints(nil, _), do: :ok
+  def apply_constraints(nil, _), do: {:ok, nil}
 
   def apply_constraints(value, constraints) do
     {value, errors} =

--- a/test/type/integer_test.exs
+++ b/test/type/integer_test.exs
@@ -24,9 +24,23 @@ defmodule Ash.Test.Type.IntegerTest do
     end
   end
 
-  describe "validation" do
+  describe "cast_input" do
     test "valid value" do
       assert {:ok, 1} = Ash.Type.Integer.cast_input(1, min: 0, max: 2)
+
+      assert {:ok, nil} = Ash.Type.Integer.cast_input(nil, min: 0, max: 2)
+    end
+
+    test "invalid value" do
+      assert :error = Ash.Type.Integer.cast_input("str", min: 0, max: 2)
+    end
+  end
+
+  describe "apply_constraints" do
+    test "valid values" do
+      assert {:ok, 3} = Ash.Type.Integer.apply_constraints(3, min: 2, max: 4)
+
+      assert {:ok, nil} = Ash.Type.Integer.apply_constraints(nil, min: 2, max: 4)
     end
 
     test "invalid values" do


### PR DESCRIPTION
Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I’m confused about how to fix this bug.

The spec for `Ash.Type::apply_constraints/2` can return `:ok`.
https://github.com/devall-org/ash/blob/44a8f60edd501b0e4084e2ff24711b1193c58036/lib/ash/type/type.ex#L365

`:ok` returned in this manner is safely handled as `{:ok, term}` in `Ash.Type.apply_constraints/2`.
https://github.com/devall-org/ash/blob/44a8f60edd501b0e4084e2ff24711b1193c58036/lib/ash/type/type.ex#L910

However, there is a problem because `cast_input/2` generated by a macro in `Ash.Type.NewType`, directly returns the result of `apply_constraints/2` from `subtype_of`, which can include `:ok`.
https://github.com/devall-org/ash/blob/44a8f60edd501b0e4084e2ff24711b1193c58036/lib/ash/type/new_type.ex#L158

This PR fixes the existing bug. But to ensure that this bug does not reoccur, I think one of the following actions should be taken:

1.	Remove the option to return `:ok` from the spec of `Ash.Type::apply_constraints/2`.
2.	Instead of calling `apply_constraints/3` of `subtype_of` in  `cast_input/2` of `Ash.Type.NewType`, modify it to call `Ash.Type.apply_constraints(unquote(sub_type_of), value, constraints)`.