### PR TITLE
chore: fix typespecs for `accepts` key in action entity structs.

### DIFF
--- a/lib/ash/resource/actions/create.ex
+++ b/lib/ash/resource/actions/create.ex
@@ -27,7 +27,7 @@ defmodule Ash.Resource.Actions.Create do
   @type t :: %__MODULE__{
           type: :create,
           name: atom,
-          accept: list(atom),
+          accept: nil | list(atom),
           require_attributes: list(atom),
           allow_nil_input: list(atom),
           manual: module | nil,

--- a/lib/ash/resource/actions/destroy.ex
+++ b/lib/ash/resource/actions/destroy.ex
@@ -37,7 +37,7 @@ defmodule Ash.Resource.Actions.Destroy do
           atomic_upgrade?: boolean(),
           atomic_upgrade_with: nil | atom(),
           require_atomic?: boolean,
-          accept: list(atom),
+          accept: nil | list(atom),
           require_attributes: list(atom),
           allow_nil_input: list(atom),
           delay_global_validations?: boolean,

--- a/lib/ash/resource/actions/update.ex
+++ b/lib/ash/resource/actions/update.ex
@@ -36,7 +36,7 @@ defmodule Ash.Resource.Actions.Update do
           atomic_upgrade?: boolean(),
           atomic_upgrade_with: nil | atom(),
           notifiers: list(module),
-          accept: list(atom),
+          accept: nil | list(atom),
           require_attributes: list(atom),
           allow_nil_input: list(atom),
           require_atomic?: boolean,


### PR DESCRIPTION
This was causing a CI failure for AshAuthentication.

https://github.com/team-alembic/ash_authentication/actions/runs/9994845281/job/27626214114?pr=747