### PR TITLE
fix: Fix cast_input/2 of Ash.Type.NewType returning :ok

### DIFF
--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -155,7 +155,7 @@ defmodule Ash.Type.NewType do
       @impl Ash.Type
       def cast_input(value, constraints) do
         with {:ok, value} <- unquote(subtype_of).cast_input(value, constraints) do
-          unquote(subtype_of).apply_constraints(value, constraints)
+          Ash.Type.apply_constraints(unquote(subtype_of), value, constraints)
         end
       end
 

--- a/test/type/new_type_test.exs
+++ b/test/type/new_type_test.exs
@@ -10,6 +10,8 @@ defmodule Ash.Test.Type.NewTypeTest do
 
   test "it handles simple types" do
     assert {:ok, "123-45-6789"} = Ash.Type.cast_input(SSN, "123-45-6789")
+
+    assert {:ok, nil} = Ash.Type.cast_input(SSN, nil)
   end
 
   test "it applies the provided constraints" do


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Following #1318