### PR TITLE
fix: remove redundant overload of `Ash.Expr.get_path`

### DIFF
--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -205,10 +205,6 @@ defmodule Ash.Expr do
   end
 
   @doc false
-  def get_path(map, [key]) when is_struct(map) do
-    Map.get(map, key)
-  end
-
   def get_path(map, [key]) when is_map(map) do
     Map.get(map, key)
   end

--- a/lib/ash/query/function/parent.ex
+++ b/lib/ash/query/function/parent.ex
@@ -1,6 +1,5 @@
 defmodule Ash.Query.Parent do
   @moduledoc """
-  true if the provided field is nil
   Used to access values from the "source" of a given expression.
 
   This is used in cases where expressions are given for some relationship path, for example:any()


### PR DESCRIPTION
Struct is a map, so no need for same but separate overloads for struct and map.

Also fixed doc for `Ash.Query.Parent`.