### PR TITLE
test: atomic only validation

### DIFF
--- a/lib/ash/error/framework/can_not_be_atomic.ex
+++ b/lib/ash/error/framework/can_not_be_atomic.ex
@@ -1,0 +1,14 @@
+defmodule Ash.Error.Framework.CanNotBeAtomic do
+  @moduledoc "Used when a change that is only atomic cannot be done atomically"
+  use Ash.Error.Exception
+
+  use Splode.Error, fields: [:resource, :change, :reason], class: :framework
+
+  def message(error) do
+    """
+    #{inspect(error.resource)} #{error.change} only has an atomic/3 callback, but cannot be performed atomically
+
+    Reason: #{error.reason}
+    """
+  end
+end

--- a/lib/ash/policy/info.ex
+++ b/lib/ash/policy/info.ex
@@ -143,10 +143,16 @@ defmodule Ash.Policy.Info do
     |> set_access_type(default_access_type(resource))
   end
 
-  @private_fields_policy_default Application.compile_env(:ash, :policies)[:private_fields] || :show
+  @private_fields_policy_default Application.compile_env(:ash, :policies)[:private_fields] ||
+                                   :show
 
   def private_fields_policy(resource) do
-    Extension.get_opt(resource, [:field_policies], :private_fields, @private_fields_policy_default)
+    Extension.get_opt(
+      resource,
+      [:field_policies],
+      :private_fields,
+      @private_fields_policy_default
+    )
   end
 
   def policies(domain, resource) do

--- a/lib/ash/policy/info.ex
+++ b/lib/ash/policy/info.ex
@@ -143,8 +143,10 @@ defmodule Ash.Policy.Info do
     |> set_access_type(default_access_type(resource))
   end
 
+  @private_fields_policy_default Application.compile_env(:ash, :policies)[:private_fields] || :show
+
   def private_fields_policy(resource) do
-    Extension.get_opt(resource, [:field_policies], :private_fields)
+    Extension.get_opt(resource, [:field_policies], :private_fields, @private_fields_policy_default)
   end
 
   def policies(domain, resource) do

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -135,6 +135,15 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     end
   end
 
+  defmodule AtomicOnlyValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def atomic(_, _, _) do
+      :ok
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource,
@@ -153,6 +162,11 @@ defmodule Ash.Test.Actions.BulkCreateTest do
       strategy :attribute
       attribute :org_id
       global? true
+    end
+
+    validations do
+      validate AtomicOnlyValidation,
+        on: [:create]
     end
 
     calculations do

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -95,6 +95,15 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
     end
   end
 
+  defmodule AtomicOnlyValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def atomic(_, _, _) do
+      :ok
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource,
@@ -109,6 +118,11 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
 
     code_interface do
       define :destroy_with_policy
+    end
+
+    validations do
+      validate AtomicOnlyValidation,
+        on: [:destroy]
     end
 
     actions do

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -171,6 +171,15 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
     end
   end
 
+  defmodule AtomicOnlyValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def atomic(_, _, _) do
+      :ok
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource,
@@ -181,6 +190,11 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
 
     ets do
       private? true
+    end
+
+    validations do
+      validate AtomicOnlyValidation,
+        on: [:update]
     end
 
     actions do

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -255,10 +255,6 @@ defmodule Ash.Test.Actions.CreateTest do
       private?(true)
     end
 
-    validations do
-      validate AtomicOnlyValidation
-    end
-
     actions do
       default_accept :*
       defaults [:read, :destroy, create: :*, update: :*]
@@ -269,6 +265,10 @@ defmodule Ash.Test.Actions.CreateTest do
 
       create :create_with_nested_array_argument do
         argument :array_of_names, {:array, {:array, :string}}
+      end
+
+      create :with_atomic_only_validations do
+        validate AtomicOnlyValidation
       end
     end
 
@@ -1424,5 +1424,15 @@ defmodule Ash.Test.Actions.CreateTest do
              |> Ash.create()
 
     assert_receive {:error, _error}
+  end
+
+  test "shows an error if an atomic only validation is used in a create" do
+    assert_raise Ash.Error.Framework.CanNotBeAtomic,
+                 ~r/Post AtomicOnlyValidation only has an atomic\/3 callback, but cannot be performed atomically/,
+                 fn ->
+                   Post
+                   |> Ash.Changeset.for_create(:with_atomic_only_validations, %{title: "foo"})
+                   |> Ash.create!()
+                 end
   end
 end

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -238,12 +238,25 @@ defmodule Ash.Test.Actions.CreateTest do
     end
   end
 
+  defmodule AtomicOnlyValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def atomic(_, _, _) do
+      :ok
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Ash.Test.Domain
 
     ets do
       private?(true)
+    end
+
+    validations do
+      validate AtomicOnlyValidation
     end
 
     actions do

--- a/test/actions/destroy_test.exs
+++ b/test/actions/destroy_test.exs
@@ -143,12 +143,26 @@ defmodule Ash.Test.Actions.DestroyTest do
     end
   end
 
+  defmodule AtomicOnlyValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def atomic(_, _, _) do
+      :ok
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
 
     ets do
       private?(true)
+    end
+
+    validations do
+      validate AtomicOnlyValidation,
+        on: [:create, :update, :destroy]
     end
 
     actions do

--- a/test/actions/update_test.exs
+++ b/test/actions/update_test.exs
@@ -8,12 +8,25 @@ defmodule Ash.Test.Actions.UpdateTest do
   require Ash.Expr
   alias Ash.Test.Domain, as: Domain
 
+  defmodule AtomicOnlyValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def atomic(_, _, _) do
+      :ok
+    end
+  end
+
   defmodule Authorized do
     @moduledoc false
     use Ash.Resource,
       domain: Domain,
       data_layer: Ash.DataLayer.Ets,
       authorizers: [Ash.Test.Authorizer]
+
+    validations do
+      validate AtomicOnlyValidation
+    end
 
     ets do
       private?(true)


### PR DESCRIPTION
Right now it's not always checked if a validation only has an atomic implementation and it throws an error. 

According to the docs this should be possible? https://hexdocs.pm/ash/dsl-ash-resource.html#validations-validate-always_atomic?

![image](https://github.com/user-attachments/assets/b16ddd6f-1b0f-423d-84c2-4e6d98f4bf41)
