### PR TITLE
Update string/ci_string generators to ensure min_length

### DIFF
--- a/lib/ash/type/ci_string.ex
+++ b/lib/ash/type/ci_string.ex
@@ -59,7 +59,7 @@ defmodule Ash.Type.CiString do
   @impl true
   def generator(constraints) do
     StreamData.string(
-      :printable,
+      :alphanumeric,
       Keyword.take(constraints, [:max_length, :min_length])
     )
     |> StreamData.map(fn value ->

--- a/lib/ash/type/string.ex
+++ b/lib/ash/type/string.ex
@@ -155,16 +155,23 @@ defmodule Ash.Type.String do
   def generator(constraints) do
     base_generator =
       StreamData.string(
-        :alphanumeric,
+        :printable,
         Keyword.take(constraints, [:max_length, :min_length])
       )
 
-    if constraints[:trim?] && constraints[:min_length] do
-      StreamData.filter(base_generator, fn value ->
-        value |> String.trim() |> String.length() |> Kernel.>=(constraints[:min_length])
-      end)
-    else
-      base_generator
+    cond do
+      constraints[:trim?] && constraints[:min_length] ->
+        StreamData.filter(base_generator, fn value ->
+          value |> String.trim() |> String.length() |> Kernel.>=(constraints[:min_length])
+        end)
+
+      constraints[:min_length] ->
+        StreamData.filter(base_generator, fn value ->
+          value |> String.length() |> Kernel.>=(constraints[:min_length])
+        end)
+
+      true ->
+        base_generator
     end
   end
 

--- a/lib/ash/type/string.ex
+++ b/lib/ash/type/string.ex
@@ -155,7 +155,7 @@ defmodule Ash.Type.String do
   def generator(constraints) do
     base_generator =
       StreamData.string(
-        :printable,
+        :alphanumeric,
         Keyword.take(constraints, [:max_length, :min_length])
       )
 


### PR DESCRIPTION
This closes https://github.com/ash-project/ash/issues/1333.

This ensures the min_length is respected whenever using the default generator for string/ci_string types.