### PR TITLE
docs: Format default options for special attributes as code, in Ash.Resource DSL

### DIFF
--- a/documentation/dsls/DSL:-Ash.Resource.md
+++ b/documentation/dsls/DSL:-Ash.Resource.md
@@ -120,11 +120,13 @@ Declares a non-writable attribute with a create default of `&DateTime.utc_now/0`
 Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except it sets
 the following different defaults:
 
+```elixir
 writable? false
 default &DateTime.utc_now/0
 match_other_defaults? true
 type Ash.Type.UTCDatetimeUsec
 allow_nil? false
+```
 
 
 
@@ -162,12 +164,14 @@ Declares a non-writable attribute with a create and update default of `&DateTime
 Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except it sets
 the following different defaults:
 
+```elixir
 writable? false
 default &DateTime.utc_now/0
 match_other_defaults? true
 update_default &DateTime.utc_now/0
 type Ash.Type.UTCDatetimeUsec
 allow_nil? false
+```
 
 
 
@@ -207,11 +211,13 @@ Generated integer primary keys must be supported by the data layer.
 Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except for `allow_nil?`, but it sets
 the following different defaults:
 
+```elixir
 public? true
 writable? false
 primary_key? true
 generated? true
 type :integer
+```
 
 
 
@@ -249,11 +255,13 @@ Declares a non writable, non-nil, primary key column of type `uuid`, which defau
 Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except for `allow_nil?`, but it sets
 the following different defaults:
 
+```elixir
 writable? false
 public? true
 default &Ash.UUID.generate/0
 primary_key? true
 type :uuid
+```
 
 
 
@@ -291,11 +299,13 @@ Declares a non writable, non-nil, primary key column of type `uuid_v7`, which de
 Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except for `allow_nil?`, but it sets
 the following different defaults:
 
+```elixir
 writable? false
 public? true
 default &Ash.UUIDv7.generate/0
 primary_key? true
 type :uuid_v7
+```
 
 
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -55,11 +55,13 @@ defmodule Ash.Resource.Dsl do
     Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except it sets
     the following different defaults:
 
-        writable? false
-        default &DateTime.utc_now/0
-        match_other_defaults? true
-        type Ash.Type.UTCDatetimeUsec
-        allow_nil? false
+    ```elixir
+    writable? false
+    default &DateTime.utc_now/0
+    match_other_defaults? true
+    type Ash.Type.UTCDatetimeUsec
+    allow_nil? false
+    ```
     """,
     examples: [
       "create_timestamp :inserted_at"
@@ -78,12 +80,14 @@ defmodule Ash.Resource.Dsl do
     Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except it sets
     the following different defaults:
 
-        writable? false
-        default &DateTime.utc_now/0
-        match_other_defaults? true
-        update_default &DateTime.utc_now/0
-        type Ash.Type.UTCDatetimeUsec
-        allow_nil? false
+    ```elixir
+    writable? false
+    default &DateTime.utc_now/0
+    match_other_defaults? true
+    update_default &DateTime.utc_now/0
+    type Ash.Type.UTCDatetimeUsec
+    allow_nil? false
+    ```
     """,
     examples: [
       "update_timestamp :updated_at"
@@ -104,11 +108,13 @@ defmodule Ash.Resource.Dsl do
     Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except for `allow_nil?`, but it sets
     the following different defaults:
 
-        public? true
-        writable? false
-        primary_key? true
-        generated? true
-        type :integer
+    ```elixir
+    public? true
+    writable? false
+    primary_key? true
+    generated? true
+    type :integer
+    ```
     """,
     examples: [
       "integer_primary_key :id"
@@ -128,11 +134,13 @@ defmodule Ash.Resource.Dsl do
     Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except for `allow_nil?`, but it sets
     the following different defaults:
 
-        writable? false
-        public? true
-        default &Ash.UUID.generate/0
-        primary_key? true
-        type :uuid
+    ```elixir
+    writable? false
+    public? true
+    default &Ash.UUID.generate/0
+    primary_key? true
+    type :uuid
+    ```
     """,
     examples: [
       "uuid_primary_key :id"
@@ -152,11 +160,13 @@ defmodule Ash.Resource.Dsl do
     Accepts all the same options as `d:Ash.Resource.Dsl.attributes.attribute`, except for `allow_nil?`, but it sets
     the following different defaults:
 
-        writable? false
-        public? true
-        default &Ash.UUIDv7.generate/0
-        primary_key? true
-        type :uuid_v7
+    ```elixir
+    writable? false
+    public? true
+    default &Ash.UUIDv7.generate/0
+    primary_key? true
+    type :uuid_v7
+    ```
     """,
     examples: [
       "uuid_v7_primary_key :id"


### PR DESCRIPTION
I noticed that the defaults weren't being formatted as code, eg. here https://hexdocs.pm/ash/dsl-ash-resource.html#attributes-uuid_v7_primary_key

<img width="897" alt="Screenshot 2024-07-24 at 6 01 30 PM" src="https://github.com/user-attachments/assets/95588d5e-5425-428c-b904-d799e93df70b">

Now they are!

<img width="876" alt="Screenshot 2024-07-24 at 6 01 55 PM" src="https://github.com/user-attachments/assets/1f5f794f-1953-4c67-80e2-e3e5f4b4773c">

(repeated for all special attributes in this DSL that formatted things like this)

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
