### PR TITLE
Expose type t() on Ash.Type.Enum implementations

### DIFF
--- a/test/type/enum_test.exs
+++ b/test/type/enum_test.exs
@@ -5,6 +5,7 @@ defmodule Ash.Test.Type.EnumTest do
   require Ash.Query
 
   alias Ash.Test.Domain, as: Domain
+  alias Ash.Type.DurationName
 
   defmodule Status do
     use Ash.Type.Enum, values: [:open, :Closed, :NeverHappened, :Always_Was]
@@ -102,5 +103,18 @@ defmodule Ash.Test.Type.EnumTest do
     assert DescriptiveEnum.description(:foo) == "Clearly a foo"
     assert DescriptiveEnum.description(:a_thing_with_no_description) == nil
     assert DescriptiveEnum.description(:another_thing_with_no_description) == nil
+  end
+
+  test "types are correctly generated" do
+    # Testing with DurationName instead of Status since modules defined in
+    # .exs files are not written to disc and their types therefore can't be
+    # loaded.
+    assert {:ok,
+            [
+              type:
+                {:t,
+                 {:type, 0, :union,
+                  [{:atom, 0, :microsecond}, _, _, _, _, _, _, _, {:atom, 0, :year}]}, []}
+            ]} = Code.Typespec.fetch_types(DurationName)
   end
 end


### PR DESCRIPTION
Implement the `@type t()` for `Ash.Type.Enum` implementations.

This allows users to write simpler typespecs in their applications.

Example:

```elixir
iex> t Ash.Type.DurationName
@type t() ::
        :microsecond
        | :millisecond
        | :second
        | :minute
        | :hour
        | :day
        | :week
        | :month
        | :year
```

The `quote` was switched to use `bind_quoted` instead of unquoting the values. This is because  the `unquote` in the `@type` was wrongly unquoting into the macro scope and not into the module scope as usual.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
