### PR TITLE
fix: apply constraints to NewType even when casting an array

### DIFF
--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -159,13 +159,10 @@ defmodule Ash.Type.NewType do
         end
       end
 
-      if function_exported?(subtype_of, :cast_input_array, 2) do
-        @impl Ash.Type
-        def cast_input_array(value, constraints) do
-          unquote(subtype_of).cast_input_array(
-            value,
-            constraints
-          )
+      @impl Ash.Type
+      def cast_input_array(value, constraints) do
+        with {:ok, value} <- unquote(subtype_of).cast_input_array(value, constraints) do
+          Ash.Type.apply_constraints({:array, unquote(subtype_of)}, value, items: constraints)
         end
       end
 

--- a/test/type/new_type_test.exs
+++ b/test/type/new_type_test.exs
@@ -8,6 +8,21 @@ defmodule Ash.Test.Type.NewTypeTest do
       constraints: [match: ~r/^(?!0{3})(?!6{3})[0-8]\d{2}-(?!0{2})\d{2}-(?!0{4})\d{4}$/]
   end
 
+  defmodule CustomMap do
+    use Ash.Type.NewType,
+      subtype_of: :map,
+      constraints: [
+        fields: [
+          foo: [
+            type: :string
+          ],
+          bar: [
+            type: :integer
+          ]
+        ]
+      ]
+  end
+
   test "it handles simple types" do
     assert {:ok, "123-45-6789"} = Ash.Type.cast_input(SSN, "123-45-6789")
 
@@ -19,5 +34,17 @@ defmodule Ash.Test.Type.NewTypeTest do
             message: "must match the pattern %{regex}",
             regex: "~r/^(?!0{3})(?!6{3})[0-8]\\d{2}-(?!0{2})\\d{2}-(?!0{4})\\d{4}$/"} =
              Ash.Type.cast_input(SSN, "hello world")
+  end
+
+  test "it casts maps correctly" do
+    assert {:ok, %{foo: "baz", bar: 42}} ==
+             Ash.Type.cast_input(CustomMap, %{"foo" => "baz", "bar" => "42", "other" => "ignored"})
+  end
+
+  test "it casts array of maps correctly" do
+    assert {:ok, [%{foo: "baz", bar: 42}]} ==
+             Ash.Type.cast_input({:array, CustomMap}, [
+               %{"foo" => "baz", "bar" => "42", "other" => "ignored"}
+             ])
   end
 end


### PR DESCRIPTION
The previous implementation was behaving differently when dealing with single values and arrays.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
