### PR TITLE
fix: pass reuse_values? true when loading in Ash.Query.apply_to/2

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -2891,7 +2891,7 @@ defmodule Ash.Query do
          records <- Sort.runtime_sort(records, query.sort, domain: domain),
          records <- Enum.drop(records, query.offset),
          records <- do_limit(records, query.limit),
-         {:ok, records} <- Ash.load(records, query, domain: domain) do
+         {:ok, records} <- Ash.load(records, query, domain: domain, reuse_values?: true) do
       {:ok, records}
     else
       {:error, error} ->

--- a/test/actions/manual_read_test.exs
+++ b/test/actions/manual_read_test.exs
@@ -43,12 +43,51 @@ defmodule Ash.Test.Actions.ManualReadTest do
     end
   end
 
+  defmodule QueryableManualRead do
+    use Ash.Resource.ManualRead
+    alias Ash.Test.Actions.ManualReadTest.Post
+
+    def read(query, _data_layer_query, _opts, _context) do
+      results = [
+        Ash.create!(Post, %{id: "0a71151f-173c-40e9-b3b1-e3f29c49483f", name: "post1"}),
+        Ash.create!(Post, %{id: "4137893e-b28f-445e-9b63-e394953942e2", name: "post2"})
+      ]
+
+      Ash.Query.apply_to(query, results)
+    end
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Ash.Test.Actions.ManualReadTest.Domain
+
+    actions do
+      default_accept :*
+      defaults [:destroy, create: :*, update: :*]
+
+      read :read do
+        primary? true
+        manual QueryableManualRead
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+
+      attribute :name, :string do
+        public?(true)
+      end
+    end
+  end
+
   defmodule Domain do
     @moduledoc false
     use Ash.Domain
 
     resources do
       resource Author
+      resource Post
     end
   end
 
@@ -65,6 +104,23 @@ defmodule Ash.Test.Actions.ManualReadTest do
     assert [_] =
              Author
              |> Ash.Query.for_read(:all)
+             |> Ash.read!()
+  end
+
+  test "Ash.Query.apply_to/2 can be used" do
+    assert [%{name: "post1"}, %{name: "post2"}] =
+             Post
+             |> Ash.Query.for_read(:read)
+             |> Ash.read!()
+
+    assert [%{name: "post1"}] =
+             Post
+             |> Ash.Query.limit(1)
+             |> Ash.read!()
+
+    assert [%{name: "post2"}] =
+             Post
+             |> Ash.Query.filter(name == "post2")
              |> Ash.read!()
   end
 end


### PR DESCRIPTION
The function is meant to be used to act on data that is in-memory, so it makes sense to not read data again. Moreover this caused an infinite loop if using this at the end of a manual read.
Add a regression test for the manual read case.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
