### PR TITLE
test: cannot set_attribute on attribute with writable? false

### DIFF
--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -1482,4 +1482,36 @@ defmodule Ash.Test.Actions.CreateTest do
                    |> Ash.create!()
                  end
   end
+
+  defmodule Dummy do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Ash.Test.Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, public?: true, writable?: false, allow_nil?: false
+      timestamps()
+    end
+
+    actions do
+      create :create do
+        primary? true
+        accept []
+        change set_attribute(:title, "foo")
+      end
+    end
+  end
+
+  test "fail set_attribute writable?: false attribute" do
+    assert {:error, _reason} =
+             Dummy
+             |> Ash.Changeset.for_create(:create)
+             |> Ash.create()
+  end
 end


### PR DESCRIPTION
I think `writable? false` should stop `set_attribute`, but it doesn't.
Is this a bug?
If not, then how can I prevent `set_attribute`?

(+ What I wrote is a failing test case.)