### PR TITLE
test: use other resource's calculation in inline filter policy

### DIFF
--- a/test/policy/filter_condition_test.exs
+++ b/test/policy/filter_condition_test.exs
@@ -60,4 +60,121 @@ defmodule Ash.Test.Policy.FilterConditionTest do
 
     assert visible_resource.visible == true
   end
+
+  test "can use other resource's calculation in expr" do
+    defmodule Author do
+      @moduledoc false
+      use Ash.Resource,
+        domain: Ash.Test.Policy.FilterConditionTest.Diary,
+        data_layer: Ash.DataLayer.Ets,
+        authorizers: [Ash.Policy.Authorizer]
+
+      ets do
+        private?(true)
+      end
+
+      actions do
+        default_accept :*
+        defaults([:read, :destroy, create: :*, update: :*])
+      end
+
+      attributes do
+        uuid_primary_key :id
+        attribute :is_active, :boolean, public?: true
+      end
+
+      calculations do
+        calculate :is_deactivated, :boolean, expr(not is_active)
+      end
+
+      policies do
+        policy action_type(:create) do
+          authorize_if always()
+        end
+
+        policy action_type(:read) do
+          authorize_if always()
+        end
+
+        policy action_type(:update) do
+          authorize_if expr(id == ^actor(:id))
+        end
+      end
+    end
+
+    defmodule Post do
+      @moduledoc false
+      use Ash.Resource,
+        domain: Ash.Test.Policy.FilterConditionTest.Diary,
+        data_layer: Ash.DataLayer.Ets,
+        authorizers: [Ash.Policy.Authorizer]
+
+      ets do
+        private?(true)
+      end
+
+      actions do
+        default_accept :*
+        defaults([:read, :destroy, create: :*, update: :*])
+      end
+
+      attributes do
+        uuid_primary_key :id
+        attribute :title, :string, public?: true
+        attribute :is_active, :boolean, default: true, public?: true
+      end
+
+      relationships do
+        belongs_to :author, Author, public?: true
+      end
+
+      changes do
+        change relate_actor(:author)
+      end
+
+      policies do
+        policy action_type(:create) do
+          authorize_if always()
+        end
+
+        policy action_type(:read) do
+          authorize_if always()
+        end
+
+        policy action_type(:update) do
+          forbid_if expr(author.is_deactivated)
+          authorize_if always()
+        end
+      end
+    end
+
+    defmodule Diary do
+      @moduledoc false
+      use Ash.Domain
+
+      authorization do
+        authorize :by_default
+      end
+
+      resources do
+        resource Author
+        resource Post
+      end
+    end
+
+    assert author =
+             Author
+             |> Ash.Changeset.for_create(:create, %{is_active: false})
+             |> Ash.create!()
+
+    assert post =
+             Post
+             |> Ash.Changeset.for_create(:create, %{title: "title 1"}, actor: author)
+             |> Ash.create!()
+
+    assert {:error, %Ash.Error.Forbidden{}} =
+             post
+             |> Ash.Changeset.for_update(:update, %{title: "title 2"}, actor: author)
+             |> Ash.update()
+  end
 end


### PR DESCRIPTION
This is just an failing test case.
If you comment out `attribute :is_active, :boolean, default: true, public?: true`(filter_condition_test.exs:124) in Post,
then this test would pass.

Here's what I found. (This could be wrong...)

1. Author has `is_active` attribute.
2. Post has `is_active` attribute, too.
3. Author's `is_deactivated` calculation uses `is_active` in expr.
4. Post's policy uses `Author.is_deactivated`.
With these conditions, `Author.is_deactivated` should check `Author.is_active`,
but it actually checks `Post.is_active`, I think.
