### PR TITLE
Warn on bulk action `return_stream?` without any other `return_*?` options enabled.

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -381,6 +381,16 @@ defmodule Ash do
       `{:error, error}` - an error that occurred. May be changeset or an invidual error.
       """
     ],
+    return_nothing?: [
+      type: :boolean,
+      default: false,
+      doc: """
+      Mutes warnings about returning nothing.
+
+      Only relevant if `return_stream?` is set to `true` and all other
+      `return_*?` options are set to `false`.
+      """
+    ],
     stop_on_error?: [
       type: :boolean,
       default: false,
@@ -2185,6 +2195,7 @@ defmodule Ash do
   @doc spark_opts: [{3, @bulk_create_opts_schema}]
   def bulk_create(inputs, resource, action, opts \\ []) do
     Ash.Helpers.expect_options!(opts)
+    Ash.Helpers.verify_stream_options(opts)
     domain = Ash.Helpers.domain!(resource, opts)
 
     case inputs do
@@ -2229,6 +2240,8 @@ defmodule Ash do
           Ash.BulkResult.t() | no_return
   @doc spark_opts: [{3, @bulk_update_opts_schema}]
   def bulk_update!(stream_or_query, action, input, opts \\ []) do
+    Ash.Helpers.verify_stream_options(opts)
+
     stream_or_query
     |> bulk_update(action, input, opts)
     |> case do
@@ -2328,6 +2341,8 @@ defmodule Ash do
           Ash.BulkResult.t() | no_return
   @doc spark_opts: [{3, @bulk_destroy_opts_schema}]
   def bulk_destroy!(stream_or_query, action, input, opts \\ []) do
+    Ash.Helpers.verify_stream_options(opts)
+
     stream_or_query
     |> bulk_destroy(action, input, opts)
     |> case do

--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -1,6 +1,8 @@
 defmodule Ash.Helpers do
   @moduledoc false
 
+  require Logger
+
   @dialyzer {:nowarn_function, {:unwrap_or_raise!, 2}}
 
   @spec try_compile(term) :: :ok
@@ -612,5 +614,22 @@ defmodule Ash.Helpers do
     def redact(value), do: value
   else
     def redact(_value), do: "**redacted**"
+  end
+
+  @spec verify_stream_options(options :: Keyword.t()) :: :ok
+  def verify_stream_options(options) do
+    with true <- Keyword.get(options, :return_stream?, false),
+         false <- Keyword.get(options, :return_notifications?, false),
+         false <- Keyword.get(options, :return_records?, false),
+         false <- Keyword.get(options, :return_errors?, false),
+         false <- Keyword.get(options, :return_nothing?, false) do
+      Logger.warning("""
+      Bulk action was called with :return_stream? set to true, but no other :return_*? options were set.
+      You probably want to set :return_notifications?, :return_records?, or :return_errors? as well.
+      To disable this message, set :return_nothing? to true.\
+      """)
+    end
+
+    :ok
   end
 end


### PR DESCRIPTION
Resolves #1368

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
