### PR TITLE
Fix error with nil value

### DIFF
--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -246,6 +246,8 @@ defmodule Ash.Type.Struct do
     end
   end
 
+  defp handle_instance_of(nil, _), do: {:ok, nil}
+
   defp handle_instance_of(value, constraints) do
     case Keyword.fetch(constraints, :instance_of) do
       {:ok, struct} ->

--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -256,7 +256,7 @@ defmodule Ash.Type.Struct do
           is_struct(value) ->
             :error
 
-          value ->
+          true ->
             if constraints[:fields] do
               {:ok, struct(struct, value)}
             else

--- a/test/type/struct_test.exs
+++ b/test/type/struct_test.exs
@@ -17,7 +17,14 @@ defmodule Type.StructTest do
 
     actions do
       default_accept :*
-      defaults [:read, :destroy, create: :*, update: :*]
+      defaults [:read, :destroy, update: :*]
+
+      create :create do
+        primary? true
+        accept [:*]
+
+        argument :dummy_metadata, :struct, constraints: [instance_of: Metadata], allow_nil?: true
+      end
     end
 
     attributes do
@@ -184,5 +191,13 @@ defmodule Type.StructTest do
                path: [:metadata]
              }
            ] = changeset.errors
+  end
+
+  test "it handles nil argument" do
+    changeset =
+      Post
+      |> Ash.Changeset.for_create(:create, %{dummy_metadata: nil})
+
+    assert changeset.valid?
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

This PR fixes
- no cond clause evaluated to a truthy value
- error that occurs when nil is passed as an argument of type :struct.