### PR TITLE
Emit Batch Status for Bulk Actions

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -388,9 +388,19 @@ defmodule Ash do
 
       Potential elements:
 
-      `{:notification, notification}` - if `return_notifications?` is set to `true`
       `{:ok, record}` - if `return_records?` is set to `true`
+      `{:notification, notification}` - if `return_notifications?` is set to `true`
+      `%Ash.BulkResult.BatchStatus{}` - if `return_batch_status?` is set to `true`.
       `{:error, error}` - an error that occurred. May be changeset or an invidual error.
+      """
+    ],
+    return_batch_status?: [
+      type: :boolean,
+      default: false,
+      doc: """
+      The returned stream will emit `Ash.BulkResult.BatchStatus.t()` elements when set to `true`.
+
+      Only applies if `return_stream?` is set to `true`.
       """
     ],
     return_nothing?: [

--- a/lib/ash/bulk_result/batch_status.ex
+++ b/lib/ash/bulk_result/batch_status.ex
@@ -1,0 +1,81 @@
+defmodule Ash.BulkResult.BatchStatus do
+  @moduledoc """
+  The element value for bulk actions with streaming.
+  """
+
+  @type t :: %__MODULE__{
+          inputs: pos_integer(),
+          affected: non_neg_integer(),
+          total_inputs: pos_integer(),
+          total_affected: non_neg_integer()
+        }
+
+  @typedoc false
+  @type unaccumulated() :: %__MODULE__{
+          inputs: pos_integer(),
+          affected: non_neg_integer(),
+          total_inputs: nil,
+          total_affected: nil
+        }
+
+  defstruct [
+    :inputs,
+    :affected,
+    :total_inputs,
+    :total_affected
+  ]
+
+  @doc false
+  @spec accumulate(enumerable :: Enumerable.t(unaccumulated() | other)) ::
+          Enumerable.t(t() | other)
+        when other: term()
+  def accumulate(enumerable) do
+    Stream.transform(enumerable, {0, 0}, fn
+      %__MODULE__{inputs: inputs, affected: affected} = status, {total_inputs, total_affected} ->
+        total_inputs = total_inputs + inputs
+        total_affected = total_affected + affected
+
+        {[%__MODULE__{status | total_inputs: total_inputs, total_affected: total_affected}],
+         {total_inputs, total_affected}}
+
+      element, acc ->
+        {[element], acc}
+    end)
+  end
+
+  @doc false
+  # When return_records? is false, a batch status is automatically appended to the batch stream
+  # However when return_records? is true, we don't know the number of affected records until
+  # the stream is executed.
+  @spec tally_records(
+          enumerable :: Enumerable.t(unaccumulated() | {:ok, record} | other),
+          inputs :: non_neg_integer()
+        ) :: Enumerable.t(unaccumulated() | {:ok, record} | other)
+        when record: Ash.Resource.record(), other: term()
+  def tally_records(enumerable, inputs) do
+    Stream.transform(
+      enumerable,
+      fn -> %__MODULE__{inputs: inputs, affected: 0} end,
+      fn
+        {:ok, record}, acc ->
+          acc =
+            if Ash.Resource.get_metadata(record, :upsert_skipped),
+              do: acc,
+              else: %__MODULE__{acc | affected: acc.affected + 1}
+
+          {[{:ok, record}], acc}
+
+        %__MODULE__{} = batch_status, %__MODULE__{affected: 0} ->
+          {[], batch_status}
+
+        other, acc ->
+          {[other], acc}
+      end,
+      fn
+        %__MODULE__{} = batch_status -> {[batch_status], :already_emitted}
+        affected -> {[%__MODULE__{inputs: inputs, affected: affected}], :new}
+      end,
+      & &1
+    )
+  end
+end

--- a/lib/ash/bulk_result/bulk_result.ex
+++ b/lib/ash/bulk_result/bulk_result.ex
@@ -7,6 +7,7 @@ defmodule Ash.BulkResult do
           status: :success | :partial_success | :error,
           notifications: list(Ash.Notifier.Notification.t()) | nil,
           records: list(Ash.Resource.record()) | nil,
+          record_count: non_neg_integer() | nil,
           errors: list(Ash.Error.t() | Ash.Changeset.t()) | nil,
           error_count: non_neg_integer()
         }
@@ -16,6 +17,7 @@ defmodule Ash.BulkResult do
     :errors,
     :records,
     :notifications,
-    error_count: 0
+    error_count: 0,
+    record_count: 0
   ]
 end

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -194,6 +194,7 @@ defmodule Ash.DataLayer do
               options :: bulk_create_options()
             ) ::
               :ok
+              | {:ok, {:affected, non_neg_integer()}}
               | {:ok, Enumerable.t(Ash.Resource.record())}
               | {:error, Ash.Error.t()}
               | {:error, :no_rollback, Ash.Error.t()}
@@ -218,6 +219,7 @@ defmodule Ash.DataLayer do
               opts :: bulk_update_options()
             ) ::
               :ok
+              | {:ok, {:affected, non_neg_integer()}}
               | {:ok, Enumerable.t(Ash.Resource.record())}
               | {:error, Ash.Error.t()}
               | {:error, :no_rollback, Ash.Error.t()}
@@ -229,6 +231,7 @@ defmodule Ash.DataLayer do
               opts :: bulk_update_options()
             ) ::
               :ok
+              | {:ok, {:affected, non_neg_integer()}}
               | {:ok, Enumerable.t(Ash.Resource.record())}
               | {:error, Ash.Error.t()}
               | {:error, :no_rollback, Ash.Error.t()}

--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -622,6 +622,7 @@ defmodule Ash.Helpers do
          false <- Keyword.get(options, :return_notifications?, false),
          false <- Keyword.get(options, :return_records?, false),
          false <- Keyword.get(options, :return_errors?, false),
+         false <- Keyword.get(options, :return_batch_status?, false),
          false <- Keyword.get(options, :return_nothing?, false) do
       Logger.warning("""
       Bulk action was called with :return_stream? set to true, but no other :return_*? options were set.


### PR DESCRIPTION
Resolves #1367
Based on #1389 

# Scope

* Introduces the option `return_batch_status?` to all `Ash.bulk_*` operations.
* Adds `record_count` to `Ash.BulkResult`
* Adds `Ash.BulkResult.BatchStatus` and yields it in the result stream when enabled

# TODO

* [x] Support bulk_create
* [ ] Support bulk_update with list
* [ ] Support bulk_update with query
* [ ] Support bulk_destroy with list
* [ ] Support bulk_destroy with query

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
