### PR TITLE
docs: Stop the `*` in `Ash.Type.*` italicising everything when converted to Markdown

### DIFF
--- a/lib/ash/resource/attribute.ex
+++ b/lib/ash/resource/attribute.ex
@@ -124,7 +124,7 @@ defmodule Ash.Resource.Attribute do
     default: [
       type: {:or, [{:mfa_or_fun, 0}, :literal]},
       doc: """
-      A value to be set on all creates, unless a value is being provided already.  Note: The default value is casted according to the type's Ash.Type.* module, before it is saved.  For `:string`, for example, if `constraints: [allow_empty?: _]` is false, the value `\"\"` will be cast to `nil`.  See the `:constraints` option, the `:allow_nil?` option, and the relevant `Ash.Type.*` documentation.
+      A value to be set on all creates, unless a value is being provided already.  Note: The default value is casted according to the type's `Ash.Type.*` module, before it is saved.  For `:string`, for example, if `constraints: [allow_empty?: _]` is false, the value `\"\"` will be cast to `nil`.  See the `:constraints` option, the `:allow_nil?` option, and the relevant `Ash.Type.*` documentation.
       """
     ],
     update_default: [


### PR DESCRIPTION
Noticed this funny one when browsing the docs today:

<img width="862" alt="Screenshot 2024-08-19 at 4 02 20 PM" src="https://github.com/user-attachments/assets/cc5148a2-7e49-4802-941c-77fa0cf8a42e">

Fixed it!

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
