### PR TITLE
Warn when `manage_relationship` is called without opts

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -4285,6 +4285,10 @@ defmodule Ash.Changeset do
   end
 
   def manage_relationship(changeset, relationship, input, opts) do
+    if opts == [] do
+      IO.warn("Calling `manage_relationship` without any options will not do anything")
+    end
+
     opts =
       if opts[:type] == :replace do
         Logger.warning(


### PR DESCRIPTION
Should it perhaps be implemented as a separate clause to avoid doing any needless work? E.g.:

```
def manage_relationship(changeset, _, _) do
  IO.warn("...")
  changeset
end
```

Fixes:  #1407