### PR TITLE
Fix generated `change/3` function when only implementing `batch_change/3`

### DIFF
--- a/lib/ash/resource/change/change.ex
+++ b/lib/ash/resource/change/change.ex
@@ -213,7 +213,7 @@ defmodule Ash.Resource.Change do
               Ash.Changeset.before_action(changeset, fn changeset ->
                 {[changeset], notifications} =
                   Enum.split_with(
-                    before_batch([changeset], opts, context),
+                    apply(__MODULE__, :before_batch, [[changeset], opts, context]),
                     fn %Ash.Notifier.Notification{} ->
                       false
                     end
@@ -230,8 +230,7 @@ defmodule Ash.Resource.Change do
             |> then(fn changeset ->
               if has_after_batch?() do
                 Ash.Changeset.after_action(changeset, fn changeset, result ->
-                  [{changeset, result}]
-                  |> after_batch(opts, context)
+                  apply(__MODULE__, :after_batch, [[{changeset, result}], opts, context])
                   |> Enum.reduce({[], [], []}, fn item, {records, errors, notifications} ->
                     case item do
                       {:ok, record} -> {[record | records], errors, notifications}

--- a/lib/ash/resource/change/change.ex
+++ b/lib/ash/resource/change/change.ex
@@ -224,7 +224,7 @@ defmodule Ash.Resource.Change do
             else
               changeset
             end
-            |> Ash.Changeset.before_action(changeset, fn change ->
+            |> Ash.Changeset.before_action(fn changeset ->
               Enum.at(batch_change([changeset], opts, context), 0)
             end)
             |> then(fn changeset ->

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -18,10 +18,6 @@ defmodule Ash.Test.Actions.BulkCreateTest do
   defmodule AddAfterToTitle do
     use Ash.Resource.Change
 
-    def change(_, _, _) do
-      raise "can't get here"
-    end
-
     def batch_change(changesets, _, _) do
       changesets
     end


### PR DESCRIPTION
According to the [docs](https://github.com/ash-project/ash/blob/55f1ead24fa708a6cc356f289adeb855b72a6bcd/lib/ash/resource/change/change.ex#L113-L114), implementing `change/3` should be optional when using `batch_change/3`. In this case, Ash will generate a `change/3` function as a wrapper around `batch_change/3`, but this had the following issues:

1. the arguments for `Changeset.before_action/2` were wrong
2. the generated code contains a call to `before_batch/3` and `after_batch/3`, which caused a compiler error if these functions were not implemented in the change module. I replaced these with `apply/3`, but maybe this could be refactored to generate these callbacks if they are missing.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
