### PR TITLE
add pattern for Ash.Query.Call in Filter.map

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -1187,6 +1187,9 @@ defmodule Ash.Filter do
         # you have to map over the internals of exists yourself
         func.(expr)
 
+      %Ash.Query.Call{args: args} = op ->
+        %{op | args: map(args, func)}
+
       %{__operator__?: true, left: left, right: right} = op ->
         %{op | left: map(left, func), right: map(right, func)}
 


### PR DESCRIPTION
Adding specific handling for Ash.Query.Call in Filter.map to avoid unnecessary recursion into the internals of the struct.
