### PR TITLE
Improve caching for relationships and add caching for calculations

### DIFF
--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1485,6 +1485,7 @@ defmodule Ash.Resource.Dsl do
 
   @persisters [
     Ash.Resource.Transformers.CacheRelationships,
+    Ash.Resource.Transformers.CacheCalculations,
     Ash.Resource.Transformers.AttributesByName,
     Ash.Resource.Transformers.ValidationsAndChangesForType,
     Ash.Resource.Transformers.CacheUniqueKeys,

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -319,19 +319,12 @@ defmodule Ash.Resource.Info do
     end
   end
 
-  def relationship(resource, relationship_name) when is_binary(relationship_name) do
-    Extension.get_persisted(resource, :relationships_by_name)[relationship_name] ||
-      resource
-      |> relationships()
-      |> Enum.find(&(to_string(&1.name) == relationship_name))
+  def relationship(resource, relationship_name)
+      when is_binary(relationship_name) or is_atom(relationship_name) do
+    Extension.get_persisted(resource, :relationships_by_name)[relationship_name]
   end
 
-  def relationship(resource, relationship_name) do
-    Extension.get_persisted(resource, :relationships_by_name)[relationship_name] ||
-      resource
-      |> relationships()
-      |> Enum.find(&(&1.name == relationship_name))
-  end
+  def relationship(_, _), do: nil
 
   @doc "Returns all public relationships of a resource"
   @spec public_relationships(Spark.Dsl.t() | Ash.Resource.t()) ::
@@ -428,17 +421,11 @@ defmodule Ash.Resource.Info do
   @doc "Get a calculation by name"
   @spec calculation(Spark.Dsl.t() | Ash.Resource.t(), atom | String.t()) ::
           Ash.Resource.Calculation.t() | nil
-  def calculation(resource, name) when is_binary(name) do
-    resource
-    |> calculations()
-    |> Enum.find(&(to_string(&1.name) == name))
+  def calculation(resource, name) when is_binary(name) or is_atom(name) do
+    Extension.get_persisted(resource, :calculations_by_name)[name]
   end
 
-  def calculation(resource, name) do
-    resource
-    |> calculations()
-    |> Enum.find(&(&1.name == name))
-  end
+  def calculation(_, _), do: nil
 
   @doc "Returns all public calculations of a resource"
   @spec public_calculations(Spark.Dsl.t() | Ash.Resource.t()) ::

--- a/lib/ash/resource/transformers/cache_calculations.ex
+++ b/lib/ash/resource/transformers/cache_calculations.ex
@@ -1,0 +1,40 @@
+defmodule Ash.Resource.Transformers.CacheCalculations do
+  @moduledoc """
+  Persists commonly used calculation information.
+  """
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  def after?(_), do: true
+
+  def transform(dsl_state) do
+    calculations =
+      Ash.Resource.Info.calculations(dsl_state)
+
+    calculations_by_name =
+      calculations
+      |> Enum.reduce(%{}, fn %{name: name} = calc, acc ->
+        acc
+        |> Map.put(name, calc)
+        |> Map.put(to_string(name), calc)
+      end)
+
+    calculation_names = Enum.map(calculations, & &1.name)
+
+    {:ok,
+     persist(
+       dsl_state,
+       %{
+         calculation_names: calculation_names,
+         calculations_by_name: calculations_by_name
+       }
+     )}
+  end
+
+  defp persist(dsl, map) do
+    Enum.reduce(map, dsl, fn {key, value}, dsl ->
+      Transformer.persist(dsl, key, value)
+    end)
+  end
+end


### PR DESCRIPTION
Two performance optimizations:
- avoid falling back to a search on nil, which happens quite a lot because we often look up whether non relationships are relationships.
- add similar caching for calculations

But, it seems there's quite a lot of cases where we look up things other than string or atom keys. That seems like it's probably not the right thing to be doing.

In all these cases, in the current implementation we would be comparing relationship name with things like Attribute structs, calculation modules, Ash.Query. All of which would never match a string/atom name.

To get all the tests to pass without introducing a performance issue I add:
 def calculation(_resource, _relationship_name) do: nil
 def relationship(_resource, _relationship_name) do: nil

But I'm rather assuming that these are all examples of errors, and we should fix the root causes. I did have a go, but the question about where in the process it should be corrected was a bit too hard for me. It's not clear this is more broken than the pre-existing code though.