### PR TITLE
Add a case for handling mapsets in Filter.map

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -1165,6 +1165,9 @@ defmodule Ash.Filter do
       value when is_list(value) ->
         Enum.map(value, &map(&1, func))
 
+      %MapSet{} = value ->
+        MapSet.new(value, &map(&1, func))
+
       %BooleanExpression{left: left, right: right} = expr ->
         %{expr | left: map(left, func), right: map(right, func)}
 


### PR DESCRIPTION
Filter.map is often called with data structures that include mapsets so we should handle those directly without unpacking the structs.