### PR TITLE
Cache always selected fields and use mapsets for building select list

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -845,21 +845,26 @@ defmodule Ash.Query do
   """
   def select(query, fields, opts \\ []) do
     query = new(query)
+    existing_fields = Ash.Resource.Info.attribute_names(query.resource)
     fields = MapSet.new(List.wrap(fields))
 
-    {fields, non_existent} =
-      MapSet.split_with(fields, &Ash.Resource.Info.attribute(query.resource, &1))
+    valid_fields = MapSet.intersection(fields, existing_fields)
 
     query =
-      Enum.reduce(non_existent, query, fn field, query ->
-        Ash.Query.add_error(
-          query,
-          Ash.Error.Query.NoSuchAttribute.exception(resource: query.resource, attribute: field)
-        )
-      end)
+      if MapSet.size(valid_fields) != MapSet.size(fields) do
+        MapSet.difference(fields, existing_fields)
+        |> Enum.reduce(query, fn field, query ->
+          Ash.Query.add_error(
+            query,
+            Ash.Error.Query.NoSuchAttribute.exception(resource: query.resource, attribute: field)
+          )
+        end)
+      else
+        query
+      end
 
     always_select =
-      fields
+      valid_fields
       |> MapSet.union(Ash.Resource.Info.always_selected_attribute_names(query.resource))
       |> MapSet.union(MapSet.new(Ash.Resource.Info.primary_key(query.resource)))
 

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -755,6 +755,11 @@ defmodule Ash.Resource.Info do
     end
   end
 
+  @spec always_selected_attribute_names(Spark.Dsl.t() | Ash.Resource.t()) :: MapSet.t()
+  def always_selected_attribute_names(resource) do
+    Extension.get_persisted(resource, :always_selected_attribute_names)
+  end
+
   @doc "Returns all attributes, aggregates, calculations and relationships of a resource"
   @spec fields(
           Spark.Dsl.t() | Ash.Resource.t(),

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -633,6 +633,11 @@ defmodule Ash.Resource.Info do
     Extension.get_entities(resource, [:attributes])
   end
 
+  @spec attribute_names(Spark.Dsl.t() | Ash.Resource.t()) :: MapSet.t()
+  def attribute_names(resource) do
+    Extension.get_persisted(resource, :attribute_names)
+  end
+
   @doc "Returns all attributes of a resource with lazy non-matching-defaults"
   @spec lazy_non_matching_default_attributes(
           Spark.Dsl.t() | Ash.Resource.t(),

--- a/lib/ash/resource/transformers/attributes_by_name.ex
+++ b/lib/ash/resource/transformers/attributes_by_name.ex
@@ -20,7 +20,7 @@ defmodule Ash.Resource.Transformers.AttributesByName do
         |> Map.put(to_string(name), attr)
       end)
 
-    attribute_names = Enum.map(attributes, & &1.name)
+    attribute_names = Enum.map(attributes, & &1.name) |> MapSet.new()
 
     create_attributes_with_static_defaults =
       attributes

--- a/lib/ash/resource/transformers/attributes_by_name.ex
+++ b/lib/ash/resource/transformers/attributes_by_name.ex
@@ -61,6 +61,11 @@ defmodule Ash.Resource.Transformers.AttributesByName do
           (is_function(attribute.update_default) or match?({_, _, _}, attribute.update_default))
       end)
 
+    always_selected_attribute_names =
+      Enum.filter(attributes, & &1.always_select?)
+      |> Enum.map(& &1.name)
+      |> MapSet.new()
+
     {:ok,
      persist(
        dsl_state,
@@ -74,7 +79,8 @@ defmodule Ash.Resource.Transformers.AttributesByName do
          update_attributes_with_static_defaults: update_attributes_with_static_defaults,
          update_attributes_with_non_matching_lazy_defaults:
            update_attributes_with_non_matching_lazy_defaults,
-         update_attributes_with_matching_defaults: update_attributes_with_matching_defaults
+         update_attributes_with_matching_defaults: update_attributes_with_matching_defaults,
+         always_selected_attribute_names: always_selected_attribute_names
        }
      )}
   end


### PR DESCRIPTION
When building select lists we can use a cached version of the list of always selected attributes.

And using Mapsets improves efficiency when combining the lists

Note that I returned a mapset from the Info function to be slightly more optimal but this isn't quite consistent with other such functions which return ordinary lists.