### PR TITLE
Fix typo in authorize-access-to-resources howto

### DIFF
--- a/documentation/how-to/authorize-access-to-resources.livemd
+++ b/documentation/how-to/authorize-access-to-resources.livemd
@@ -110,7 +110,7 @@ defmodule Tweet do
       description "If a tweet is hidden, only the author can read it. Otherwise, anyone can."
       # first check this. If true, then this policy passes
       authorize_if relates_to_actor_via(:user)
-      # the check this. If false, then this policy fails
+      # then check this. If false, then this policy fails
       forbid_if expr(hidden? == true)
       # otherwise, this policy passes
       authorize_if always()


### PR DESCRIPTION
"the check this" -> "then check this"

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
