### PR TITLE
Fix bulk upsert condition

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -297,12 +297,6 @@ defmodule Ash.Actions.Create.Bulk do
   end
 
   defp base_changeset(resource, domain, opts, action) do
-    upsert_condition =
-      case opts[:upsert_condition] do
-        nil -> action && action.upsert_condition
-        other -> other
-      end
-
     resource
     |> Ash.Changeset.new()
     |> Map.put(:domain, domain)
@@ -314,17 +308,12 @@ defmodule Ash.Actions.Create.Bulk do
           Ash.Changeset.expand_upsert_fields(
             opts[:upsert_fields] || action.upsert_fields,
             resource
-          ),
-        upsert_condition: upsert_condition
+          )
       }
     })
     |> Ash.Actions.Helpers.add_context(opts)
     |> Ash.Changeset.set_context(opts[:context] || %{})
     |> Ash.Changeset.prepare_changeset_for_action(action, opts)
-    |> then(fn
-      changeset when upsert_condition != nil -> Ash.Changeset.filter(changeset, upsert_condition)
-      changeset -> changeset
-    end)
   end
 
   defp lazy_matching_default_values(resource) do

--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -297,6 +297,12 @@ defmodule Ash.Actions.Create.Bulk do
   end
 
   defp base_changeset(resource, domain, opts, action) do
+    upsert_condition =
+      case opts[:upsert_condition] do
+        nil -> action && action.upsert_condition
+        other -> other
+      end
+
     resource
     |> Ash.Changeset.new()
     |> Map.put(:domain, domain)
@@ -308,12 +314,17 @@ defmodule Ash.Actions.Create.Bulk do
           Ash.Changeset.expand_upsert_fields(
             opts[:upsert_fields] || action.upsert_fields,
             resource
-          )
+          ),
+        upsert_condition: upsert_condition
       }
     })
     |> Ash.Actions.Helpers.add_context(opts)
     |> Ash.Changeset.set_context(opts[:context] || %{})
     |> Ash.Changeset.prepare_changeset_for_action(action, opts)
+    |> then(fn
+      changeset when upsert_condition != nil -> Ash.Changeset.filter(changeset, upsert_condition)
+      changeset -> changeset
+    end)
   end
 
   defp lazy_matching_default_values(resource) do

--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -297,6 +297,12 @@ defmodule Ash.Actions.Create.Bulk do
   end
 
   defp base_changeset(resource, domain, opts, action) do
+    upsert_condition =
+      case opts[:upsert_condition] do
+        nil -> action && action.upsert_condition
+        other -> other
+      end
+
     resource
     |> Ash.Changeset.new()
     |> Map.put(:domain, domain)
@@ -308,12 +314,17 @@ defmodule Ash.Actions.Create.Bulk do
           Ash.Changeset.expand_upsert_fields(
             opts[:upsert_fields] || action.upsert_fields,
             resource
-          )
+          ),
+        upsert_condition: upsert_condition
       }
     })
     |> Ash.Actions.Helpers.add_context(opts)
     |> Ash.Changeset.set_context(opts[:context] || %{})
     |> Ash.Changeset.prepare_changeset_for_action(action, opts)
+    |> then(fn
+      changeset when upsert_condition != nil -> Ash.Changeset.filter(changeset, upsert_condition)
+      changeset -> changeset
+    end)
   end
 
   defp lazy_matching_default_values(resource) do
@@ -1185,7 +1196,11 @@ defmodule Ash.Actions.Create.Bulk do
                           opts[:upsert_fields] || action.upsert_fields,
                           resource
                         ),
-                      upsert_condition: opts[:upsert_condition] || action.upsert_condition,
+                      upsert_condition:
+                        case opts[:upsert_condition] do
+                          nil -> action && action.upsert_condition
+                          other -> other
+                        end,
                       tenant: Ash.ToTenant.to_tenant(opts[:tenant], resource)
                     }
                   )

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1245,7 +1245,11 @@ defmodule Ash.Changeset do
       get_action_entity(changeset.resource, action) ||
         raise_no_action(changeset.resource, action, :create)
 
-    upsert_condition = opts[:upsert_condition] || (action && action.upsert_condition)
+    upsert_condition =
+      case opts[:upsert_condition] do
+        nil -> action && action.upsert_condition
+        other -> other
+      end
 
     changeset
     |> set_context(%{

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -775,7 +775,7 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     assert product.price.max == 456
     assert product.price.rrp == 789
 
-    still_the_same_product =
+    result =
       Ash.bulk_create(
         [
           %{
@@ -797,13 +797,8 @@ defmodule Ash.Test.Actions.BulkCreateTest do
         # But the upsert_condition says "no!".
         upsert_condition: expr(false)
       )
-      |> then(fn result -> List.first(result.records) end)
 
-    assert still_the_same_product.gtin == product.gtin
-    assert still_the_same_product.title == product.title
-    assert still_the_same_product.price.min == product.price.min
-    assert still_the_same_product.price.max == product.price.max
-    assert still_the_same_product.price.rrp == product.price.rrp
+    assert result.records == []
   end
 
   test "can upsert with :replace" do

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.Actions.BulkCreateTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  require Ash.Expr
+
   import Ash.Expr, only: [expr: 1]
   import ExUnit.CaptureLog
 
@@ -631,6 +633,7 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                Post,
                :create,
                tenant: org.id,
+               return_errors?: true,
                return_records?: true,
                sorted?: true,
                authorize?: false
@@ -650,6 +653,7 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                ],
                Post,
                :create,
+               return_errors?: true,
                return_records?: true,
                tenant: org.id,
                upsert?: true,

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -2,8 +2,6 @@ defmodule Ash.Test.Actions.BulkCreateTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
-  require Ash.Expr
-
   import Ash.Expr, only: [expr: 1]
   import ExUnit.CaptureLog
 
@@ -447,6 +445,91 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     end
   end
 
+  defmodule Product do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept [:gtin, :title]
+      defaults [:read, :update, :destroy]
+
+      create :create do
+        primary? true
+
+        argument :price, :map
+        change manage_relationship(:price, type: :create)
+
+        upsert? true
+        upsert_fields {:replace_all_except, [:gtin, :id, :inserted_at]}
+        upsert_identity :unique_gtin
+        upsert_condition expr(false)
+      end
+    end
+
+    attributes do
+      uuid_v7_primary_key :id
+
+      attribute :gtin, :string do
+        allow_nil? false
+        public? true
+      end
+
+      attribute :title, :string, public?: true
+
+      timestamps()
+    end
+
+    relationships do
+      has_one :price, Ash.Test.Actions.BulkCreateTest.Price, public?: true
+    end
+
+    identities do
+      identity :unique_gtin, :gtin do
+        pre_check_with Ash.Test.Actions.BulkCreateTest.Domain
+      end
+    end
+  end
+
+  defmodule Price do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept [:max, :min, :rrp]
+
+      defaults [:read, :update, :destroy]
+
+      create :create do
+        primary? true
+        upsert? true
+        upsert_fields {:replace_all_except, [:inserted_at]}
+      end
+    end
+
+    attributes do
+      attribute :max, :integer, public?: true
+      attribute :min, :integer, public?: true
+      attribute :rrp, :integer, public?: true
+      timestamps()
+    end
+
+    relationships do
+      belongs_to :product, Product do
+        allow_nil? false
+        primary_key? true
+        public? false
+      end
+    end
+  end
+
   test "returns created records" do
     org =
       Org
@@ -663,6 +746,64 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                sorted?: true,
                authorize?: false
              )
+  end
+
+  test "respects upsert_condition despite we have a relationship" do
+    product =
+      Ash.bulk_create(
+        [
+          %{
+            gtin: "1234567891011",
+            title: "Nano Bubble Gum",
+            price: %{
+              min: 123,
+              max: 456,
+              rrp: 789
+            }
+          }
+        ],
+        Product,
+        :create,
+        return_errors?: true,
+        return_records?: true
+      )
+      |> then(fn result -> List.first(result.records) end)
+
+    assert product.gtin == "1234567891011"
+    assert product.title == "Nano Bubble Gum"
+    assert product.price.min == 123
+    assert product.price.max == 456
+    assert product.price.rrp == 789
+
+    still_the_same_product =
+      Ash.bulk_create(
+        [
+          %{
+            gtin: "1234567891011",
+            title: "Nano Bubble Gum",
+            price: %{
+              # Note: we try to change the price here.
+              min: 234,
+              max: 567,
+              rrp: 890
+            }
+          }
+        ],
+        Product,
+        :create,
+        return_errors?: true,
+        return_records?: true,
+        upsert?: true,
+        # But the upsert_condition says "no!".
+        upsert_condition: expr(false)
+      )
+      |> then(fn result -> List.first(result.records) end)
+
+    assert still_the_same_product.gtin == product.gtin
+    assert still_the_same_product.title == product.title
+    assert still_the_same_product.price.min == product.price.min
+    assert still_the_same_product.price.max == product.price.max
+    assert still_the_same_product.price.rrp == product.price.rrp
   end
 
   test "can upsert with :replace" do


### PR DESCRIPTION
While working on a bulk create operation, I encountered an issue where the upsert condition worked correctly for managed relationships but failed for the primary resource being upserted. Upon investigation, I traced the problem back to the base changeset, which lacked the necessary filter for the upsert condition.

Adding the missing filter, however, caused the existing bulk create test to fail. Further debugging revealed that the bulk create test had never actually functioned correctly - it was missing a require Ash.Expr statement. It's unclear how the test passed previously, given that the required macros were missing.

# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [x] Update dependencies
