### PR TITLE
docs: Fix examples for builtin `before_action` and `after_action` preparations

### DIFF
--- a/lib/ash/resource/preparation/builtins.ex
+++ b/lib/ash/resource/preparation/builtins.ex
@@ -39,11 +39,12 @@ defmodule Ash.Resource.Preparation.Builtins do
   @doc ~S"""
   Directly attach a `before_action` function to the query.
 
-  See `Ash.Query.before_action/2` for more information.
+  This function will be called by `Ash.Query.before_action/2`,
+  with an additional `context` argument.
 
   ## Example
 
-      prepare before_action(fn query ->
+      prepare before_action(fn query, _context ->
         Logger.debug("About to execute query for #{query.action.name} on #{inspect(query.resource)}")
 
         query
@@ -63,11 +64,12 @@ defmodule Ash.Resource.Preparation.Builtins do
   @doc ~S"""
   Directly attach an `after_action` function to the query.
 
-  See `Ash.Query.after_action/2` for more information.
+  This function will be called by `Ash.Query.after_action/2`,
+  with an additional `context` argument.
 
   ## Example
 
-      prepare after_action(fn query, records ->
+      prepare after_action(fn query, records, _context ->
         Logger.debug("Query for #{query.action.name} on resource #{inspect(query.resource)} returned #{length(records)} records")
 
         {:ok, records}


### PR DESCRIPTION
Also attempted to clarify that these aren't the same functions as in the arguments to `Ash.Query.before_action` and `after_action` - they take an additional argument for `context`

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
