### PR TITLE
fix: cast embedded time properly

### DIFF
--- a/lib/ash/type/time.ex
+++ b/lib/ash/type/time.ex
@@ -17,15 +17,6 @@ defmodule Ash.Type.Time do
   end
 
   @impl true
-  def cast_atomic(new_value, _constraints) do
-    {:atomic, new_value}
-  end
-
-  @impl true
-  def matches_type?(%Time{}, _), do: true
-  def matches_type?(_, _), do: false
-
-  @impl true
   def cast_input(nil, _), do: {:ok, nil}
 
   def cast_input(value, _) do
@@ -33,7 +24,20 @@ defmodule Ash.Type.Time do
   end
 
   @impl true
+  def matches_type?(%Time{}, _), do: true
+  def matches_type?(_, _), do: false
+
+  @impl true
+  def cast_atomic(new_value, _constraints) do
+    {:atomic, new_value}
+  end
+
+  @impl true
   def cast_stored(nil, _), do: {:ok, nil}
+
+  def cast_stored(value, constraints) when is_binary(value) do
+    cast_input(value, constraints)
+  end
 
   def cast_stored(value, _) do
     Ecto.Type.load(:time, value)


### PR DESCRIPTION
just like the commit d4a6feb58 for datetime but for time plus reordering the functions so its the same order as in naive_datetime.ex and date.ex


found this while using :time in an embedded resource 

got the following error:

```
↳ Ash.Actions.Create.Bulk.handle_batch/9, at: lib/ash/actions/create/bulk.ex:456
** (Ash.Error.Unknown) Unknown Error

* ** (ArgumentError) cannot load `[%{"day" => "monday", "from" => "08:00:00", "to" => "10:00:00"}]` as type {:array, #REDACTED.EctoType<[on_update: :update_on_match]>} for field :REDACTED in #REDACTEDh<address: #Ash.NotLoaded<:relationship,  ...>
  (ecto 3.12.3) lib/ecto/repo/queryable.ex:431: Ecto.Repo.Queryable.struct_load!/6
  (ecto 3.12.3) lib/ecto/repo/schema.ex:76: anonymous fn/4 in Ecto.Repo.Schema.postprocess/5
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (ecto 3.12.3) lib/ecto/repo/schema.ex:61: Ecto.Repo.Schema.do_insert_all/7
  (ash_postgres 2.3.1) lib/data_layer.ex:1786: AshPostgres.DataLayer.bulk_create/3
  (ash_postgres 2.3.1) lib/data_layer.ex:1956: AshPostgres.DataLayer.create/2
  (ash 3.4.8) lib/ash/actions/create/create.ex:380: anonymous fn/6 in Ash.Actions.Create.commit/3
  (ash 3.4.8) lib/ash/changeset/changeset.ex:3662: Ash.Changeset.run_around_actions/2
  (ash 3.4.8) lib/ash/changeset/changeset.ex:3197: anonymous fn/3 in Ash.Changeset.with_hooks/3
  (ash 3.4.8) lib/ash/data_layer/data_layer.ex:369: Ash.DataLayer.transaction/4
  (ash 3.4.8) lib/ash/changeset/changeset.ex:3195: anonymous fn/3 in Ash.Changeset.with_hooks/3
  (ash 3.4.8) lib/ash/changeset/changeset.ex:3339: anonymous fn/2 in Ash.Changeset.transaction_hooks/2
  (ash 3.4.8) lib/ash/changeset/changeset.ex:3176: Ash.Changeset.with_hooks/3
  (ash 3.4.8) lib/ash/actions/create/create.ex:240: Ash.Actions.Create.commit/3
  (ash 3.4.8) lib/ash/actions/create/create.ex:112: Ash.Actions.Create.do_run/4
  (ash 3.4.8) lib/ash/actions/create/create.ex:50: Ash.Actions.Create.run/4
  (ash 3.4.8) lib/ash/actions/managed_relationships.ex:474: Ash.Actions.ManagedRelationships.do_create_belongs_to_record/8
  (elixir 1.16.3) lib/enum.ex:4839: Enumerable.List.reduce/3
  (elixir 1.16.3) lib/enum.ex:2582: Enum.reduce_while/3
  (ash 3.4.8) lib/ash/actions/managed_relationships.ex:79: Ash.Actions.ManagedRelationships.setup_managed_belongs_to_relationships/3
    (ash 3.4.8) lib/ash.ex:2243: Ash.bulk_create!/4
    priv/repo/seeds.dev.exs:7: (file)
    (elixir 1.16.3) lib/code.ex:1489: Code.require_file/2
    (mix 1.16.3) lib/mix/tasks/run.ex:146: Mix.Tasks.Run.run/5
    (mix 1.16.3) lib/mix/tasks/run.ex:85: Mix.Tasks.Run.run/1
    (mix 1.16.3) lib/mix/task.ex:478: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.16.3) lib/mix/task.ex:544: Mix.Task.run_alias/6
    (mix 1.16.3) lib/mix/cli.ex:96: Mix.CLI.run_task/2
    /nix/store/77csv7vjyxjba36rpyn0jcqvcbfqp5qk-elixir-1.16.3/bin/mix:2: (file)
```

tried it with :naive_datetime and it was working -> found the diff between the types

