### PR TITLE
fix(ensure_select): properly escape changeset.select

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -448,7 +448,7 @@ defmodule Ash.Changeset do
         %MapSet{} ->
           %{
             changeset
-            | select: MapSet.union(MapSet.new(changeset.select), fields) |> MapSet.to_list()
+            | select: MapSet.union(MapSet.new(changeset.select || []), fields) |> MapSet.to_list()
           }
 
         fields ->


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Hi @zachdaniel 

The change to changeset.select leads to runtime errors if we use `change ensure_selected(attr)`. If we escape the `changeset.select || []` properly, the runtime errors are gone. Not sure if this is the right place and I do not have time to add some tests, sorry.