### PR TITLE
fix: add checks for `around_transaction` and `around_action` in bulk

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -413,7 +413,8 @@ defmodule Ash.Actions.Create.Bulk do
         )
       end)
       |> Enum.reduce({[], []}, fn changeset, {batch, must_be_simple} ->
-        if changeset.after_transaction in [[], nil] do
+        if changeset.around_transaction in [[], nil] and changeset.after_transaction in [[], nil] and
+             changeset.around_action in [[], nil] do
           changeset = Ash.Changeset.run_before_transaction_hooks(changeset)
           {[changeset | batch], must_be_simple}
         else

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1293,7 +1293,8 @@ defmodule Ash.Actions.Destroy.Bulk do
 
     {batch, must_be_simple} =
       Enum.reduce(batch, {[], []}, fn changeset, {batch, must_be_simple} ->
-        if changeset.after_transaction in [[], nil] do
+        if changeset.around_transaction in [[], nil] and changeset.after_transaction in [[], nil] and
+             changeset.around_action in [[], nil] do
           changeset = Ash.Changeset.run_before_transaction_hooks(changeset)
           {[changeset | batch], must_be_simple}
         else

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -263,7 +263,7 @@ defmodule Ash.Changeset do
           around_action: [around_action_fun | {around_action_fun, map}],
           around_transaction: [around_transaction_fun | {around_transaction_fun, map}],
           attributes: %{optional(atom) => any},
-          before_action: [before_action_fun | {around_action_fun, map}],
+          before_action: [before_action_fun | {before_action_fun, map}],
           before_transaction: [before_transaction_fun | {before_transaction_fun, map}],
           context: map,
           filter: Ash.Filter.t() | nil,


### PR DESCRIPTION
Closes #1473.

Exact same change as in 66cc0e48f1298fc7e68f0b373f7e4ae978c0b650 applied to bulk create/destroy.

(Also fixed typespec for `before_action` of changeset.)