### PR TITLE
fix(Ash.Query): calling `for_read/2..4` should raise an `ArgumentError` when the specified action doesn't exist.

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -572,7 +572,7 @@ defmodule Ash.Query do
         end
       end
     else
-      add_error(query, :action, "No such action #{inspect(action_name)}")
+      raise_no_action(query.resource, action_name)
     end
   end
 
@@ -611,6 +611,27 @@ defmodule Ash.Query do
     else
       query
     end
+  end
+
+  defp raise_no_action(resource, action_name) do
+    available_actions =
+      resource
+      |> Ash.Resource.Info.actions()
+      |> Enum.filter(&(&1.type == :read))
+      |> Enum.map_join("\n", &"    - `#{inspect(&1.name)}")
+
+    raise ArgumentError,
+      message: """
+      No such read action on resource #{inspect(resource)}: #{String.slice(inspect(action_name), 0..50)}
+
+      Example Call:
+
+        Ash.Query.for_read(query_or_resource, :action_name, input, options)
+
+      Available read actions:
+
+      #{available_actions}
+      """
   end
 
   defp require_arguments(query, action) do

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -1243,6 +1243,28 @@ defmodule Ash.Test.Changeset.ChangesetTest do
              ] =
                Ash.Changeset.for_create(Category, :with_name_validation, %{"name" => ""}).errors
     end
+
+    test "it fails when the requested create action doesn't exist on the resource" do
+      assert_raise(ArgumentError, ~r/no such create action/i, fn ->
+        Ash.Changeset.for_create(Category, :bananas, %{}, [])
+      end)
+    end
+
+    test "it fails when the requested update action doesn't exist on the resource" do
+      category = Ash.create!(Category, action: :create)
+
+      assert_raise(ArgumentError, ~r/no such update action/i, fn ->
+        Ash.Changeset.for_update(category, :bananas, %{}, [])
+      end)
+    end
+
+    test "it fails when the requested destroy action doesn't exist on the resource" do
+      category = Ash.create!(Category, action: :create)
+
+      assert_raise(ArgumentError, ~r/no such destroy action/i, fn ->
+        Ash.Changeset.for_destroy(category, :bananas, %{}, [])
+      end)
+    end
   end
 
   describe "update_change/3" do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -97,4 +97,12 @@ defmodule Ash.Test.QueryTest do
              |> Ash.read_one!()
     end
   end
+
+  describe "action validation" do
+    test "it fails when the action requested doesn't exist on the resource" do
+      assert_raise(ArgumentError, ~r/no such read action/i, fn ->
+        Ash.Query.for_read(User, :bananas)
+      end)
+    end
+  end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
