### PR TITLE
Pass context into `data_layer_query` in Ash.Actions.Aggregate

### DIFF
--- a/lib/ash/actions/aggregate.ex
+++ b/lib/ash/actions/aggregate.ex
@@ -84,7 +84,8 @@ defmodule Ash.Actions.Aggregate do
                      distinct: query.distinct,
                      domain: query.domain,
                      tenant: query.tenant,
-                     to_tenant: query.to_tenant
+                     to_tenant: query.to_tenant,
+                     context: query.context
                    }),
                  {:ok, result} <-
                    Ash.DataLayer.run_aggregate_query(


### PR DESCRIPTION
The context provided to `Ash.aggregate!` does not bubble down to the data layer. 

# Contributor checklist

- [x] Bug fixes ~include regression tests~
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

