### PR TITLE
Fix `ensure_selected` for cases where `query.select` is nil

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1060,7 +1060,9 @@ defmodule Ash.Query do
     else
       to_select = Ash.Resource.Info.selected_by_default_attribute_names(query.resource)
 
-      Ash.Query.select(query, to_select)
+      query
+      |> Ash.Query.select(to_select)
+      |> Ash.Query.select(List.wrap(fields))
     end
   end
 

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1058,10 +1058,10 @@ defmodule Ash.Query do
     if query.select do
       Ash.Query.select(query, List.wrap(fields))
     else
-      to_select = Ash.Resource.Info.selected_by_default_attribute_names(query.resource)
+      default_attributes = Ash.Resource.Info.selected_by_default_attribute_names(query.resource)
 
       query
-      |> Ash.Query.select(to_select)
+      |> Ash.Query.select(default_attributes)
       |> Ash.Query.select(List.wrap(fields))
     end
   end


### PR DESCRIPTION
The current functionality just sets the default select fields but does not ensure the fields requested by the user are selected.

# Contributor checklist

- [x] Bug fixes ~include regression tests~

It is not possible to test select related functionality on the ETS or Simple datalayers since both return `false` for `can?(_, :select)`. Otherwise, we would add the following to `Ash.Test.QueryTest`:

```elixir
  defmodule User do
    ...
    attributes do
      ...
      attribute :unselected_list, {:array, :string}, select_by_default?: false
    end
end

  describe "ensure_selected" do
    test "it does not deselect default fields" do
      assert User
              |> Ash.Query.for_read(:read)
              |> Ash.Query.ensure_selected([:unselected_list])
              |> Ash.Query.loading?(:name)
    end

    test "it selects non-default fields" do
      assert User
              |> Ash.Query.for_read(:read)
              |> Ash.Query.ensure_selected([:unselected_list])
              |> Ash.Query.loading?(:unselected_list)
    end
  end
```