### PR TITLE
chore: Minor docs correction on update action

### DIFF
--- a/documentation/topics/actions/update-actions.md
+++ b/documentation/topics/actions/update-actions.md
@@ -103,7 +103,7 @@ Atomic updates are a special case of update actions that can be done completely 
 > ```elixir
 > update :increment_score do
 >   change fn changeset, _ ->
->     Ash.Changeset.set_attribute(changeset, :score, changeset.data.score + 1)
+>     Ash.Changeset.change_attribute(changeset, :score, changeset.data.score + 1)
 >   end
 > end
 > ```


### PR DESCRIPTION
Noticed a small mistake in docs `Ash.Changeset.set_attribute` does not exist, it should be `Ash.Changeset.change_attribute` instead


# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
