### PR TITLE
improvement!: Require `transaction? false` in actions where the data layer doesn't support transactions.

### DIFF
--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -101,6 +101,7 @@ defmodule Ash.DataLayer do
           | {:sort, Ash.Type.t()}
           | :upsert
           | :composite_primary_key
+          | :inhibit_transaction_validation
 
   @type lateral_join_link ::
           {Ash.Resource.t(), atom, atom, Ash.Resource.Relationships.relationship()}

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -216,6 +216,7 @@ defmodule Ash.DataLayer.Ets do
   def can?(_, :boolean_filter), do: true
   def can?(_, :distinct), do: true
   def can?(_, :transact), do: false
+  def can?(_, :inhibit_transaction_validation), do: true
   def can?(_, {:filter_expr, _}), do: true
 
   case Application.compile_env(:ash, :no_join_mnesia_ets) || false do

--- a/lib/ash/data_layer/simple/simple.ex
+++ b/lib/ash/data_layer/simple/simple.ex
@@ -25,6 +25,7 @@ defmodule Ash.DataLayer.Simple do
   def can?(_, :nested_expressions), do: true
   def can?(_, {:filter_expr, _}), do: true
   def can?(_, :multitenancy), do: true
+  def can?(_, :inhibit_transaction_validation), do: true
   def can?(_, _), do: false
 
   defmodule Query do

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1511,6 +1511,7 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Verifiers.VerifyActionsAtomic,
     Ash.Resource.Verifiers.VerifyNotifiers,
     Ash.Resource.Verifiers.VerifyPrimaryKeyPresent,
+    Ash.Resource.Verifiers.VerifyTransactionsSupported,
     Ash.Resource.Verifiers.VerifyGenericActionReactorInputs
   ]
 

--- a/lib/ash/resource/transformers/set_primary_actions.ex
+++ b/lib/ash/resource/transformers/set_primary_actions.ex
@@ -66,6 +66,8 @@ defmodule Ash.Resource.Transformers.SetPrimaryActions do
         )
       )
 
+    can_transact? = Ash.DataLayer.data_layer_can?(dsl_state, :transact)
+
     dsl_state
     |> Transformer.get_option([:actions], :defaults)
     |> Kernel.||(default_defaults)
@@ -120,12 +122,14 @@ defmodule Ash.Resource.Transformers.SetPrimaryActions do
             [
               require_atomic?: false,
               primary?: primary?,
-              accept: accept
+              accept: accept,
+              transaction?: can_transact?
             ]
           else
             [
               primary?: primary?,
-              accept: accept
+              accept: accept,
+              transaction?: can_transact?
             ]
           end
 

--- a/lib/ash/resource/verifiers/verify_transactions_supported.ex
+++ b/lib/ash/resource/verifiers/verify_transactions_supported.ex
@@ -1,0 +1,74 @@
+defmodule Ash.Resource.Verifiers.VerifyTransactionsSupported do
+  @moduledoc """
+  Validates that all actions have `transaction? false` when the resource's data layer says they're not supported
+  """
+  use Spark.Dsl.Verifier
+  alias Ash.Resource.Info
+  alias Spark.{Dsl.Verifier, Error.DslError}
+
+  @doc false
+  @impl true
+  def verify(dsl) do
+    resource = Verifier.get_persisted(dsl, :module)
+    data_layer = Info.data_layer(resource)
+
+    if function_exported?(data_layer, :can?, 2) do
+      cond do
+        data_layer.can?(resource, :transact) ->
+          :ok
+
+        data_layer.can?(resource, :inhibit_transaction_validation) ->
+          :ok
+
+        true ->
+          verify_action_transactions(dsl, data_layer, resource)
+      end
+    else
+      :ok
+    end
+  end
+
+  defp verify_action_transactions(dsl, data_layer, resource) do
+    dsl
+    |> Info.actions()
+    |> Enum.filter(&(&1.transaction? == true))
+    |> case do
+      [] ->
+        :ok
+
+      [action] ->
+        error =
+          DslError.exception(
+            path: [:actions, action.name],
+            module: resource,
+            message: """
+            The data layer `#{inspect(data_layer)}` does not support transactions.
+
+            Please set `transaction? false` for the `#{inspect(action.name)}` #{action.type} action.
+            """
+          )
+
+        {:error, error}
+
+      actions ->
+        actions =
+          actions
+          |> Enum.map_join("\n", &"  - #{&1.type} `#{inspect(&1.name)}`")
+
+        error =
+          DslError.exception(
+            path: [:actions],
+            module: resource,
+            message: """
+            The data layer `#{inspect(data_layer)}` does not support transactions.
+              
+            Please set `transaction? false` for the following actions:
+
+            #{actions}
+            """
+          )
+
+        {:error, error}
+    end
+  end
+end

--- a/test/actions/read_test.exs
+++ b/test/actions/read_test.exs
@@ -31,10 +31,6 @@ defmodule Ash.Test.Actions.ReadTest do
     actions do
       default_accept :*
       defaults [:read, :destroy, create: :*, update: :*]
-
-      read :in_transaction do
-        transaction? true
-      end
     end
 
     attributes do
@@ -291,12 +287,6 @@ defmodule Ash.Test.Actions.ReadTest do
       assert_raise ArgumentError, "Expected a keyword list in `Ash.read\/2`, got: \[1\]", fn ->
         Ash.read(Post, [1])
       end
-    end
-  end
-
-  describe "transaction true" do
-    test "with no records, returns an empty set" do
-      assert [] = Ash.read!(Author, action: :in_transaction)
     end
   end
 

--- a/test/resource/verifiers/verify_transactions_supported_test.exs
+++ b/test/resource/verifiers/verify_transactions_supported_test.exs
@@ -1,0 +1,64 @@
+defmodule Ash.Test.Resource.Verifiers.VerifyTransactionsSupportedTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Spark.Error.DslError
+
+  setup :set_mimic_global
+
+  describe "non transacting data layers" do
+    test "actions with transaction? enabled don't compile" do
+      Ash.DataLayer.Simple
+      |> stub(:can?, fn
+        _, :inhibit_transaction_validation -> false
+        resource, capability -> call_original(Ash.DataLayer.Simple, :can?, [resource, capability])
+      end)
+
+      assert_raise(DslError, ~r/transaction\? false/, fn ->
+        defmodule FailBecauseCantTransact do
+          @moduledoc false
+          use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Simple
+
+          attributes do
+            uuid_primary_key :id
+          end
+
+          actions do
+            read :read do
+              primary? true
+              transaction? true
+            end
+          end
+        end
+      end)
+    end
+  end
+
+  describe "tranacting data layers" do
+    test "actions with transaction? enabled compile file" do
+      Ash.DataLayer.Simple
+      |> stub(:can?, fn
+        _, :inhibit_transaction_validation -> false
+        _, :transact -> true
+        resource, capability -> call_original(Ash.DataLayer.Simple, :can?, [resource, capability])
+      end)
+
+      defmodule SucceedBecauseCanTransact do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Simple
+
+        attributes do
+          uuid_primary_key :id
+        end
+
+        actions do
+          read :read do
+            primary? true
+            transaction? true
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,7 @@
 # We compile modules with the same name often while testing the DSL
 Mimic.copy(Ash.Reactor.Notifications)
 Mimic.copy(Ash.DataLayer)
+Mimic.copy(Ash.DataLayer.Simple)
 
 Code.compiler_options(ignore_module_conflict: true)
 


### PR DESCRIPTION
When using a data layer that doesn't support transactions, it's a good idea to make them add `transaction? false` to their actions.

Default actions are generated with the correct transaction option.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
