### PR TITLE
docs: fix Ash.Query.Function.Today doc

### DIFF
--- a/lib/ash/query/function/today.ex
+++ b/lib/ash/query/function/today.ex
@@ -1,7 +1,8 @@
 defmodule Ash.Query.Function.Today do
   @moduledoc """
-  Returns the current datetime
+  Returns the current date.
   """
+
   use Ash.Query.Function, name: :today, eager_evaluate?: false
 
   def args, do: [[]]


### PR DESCRIPTION
`today()` returns a Date, not a DateTime.

Doc fixed.