### PR TITLE
improvement: Conditionally enable transactions on default actions.

### DIFF
--- a/lib/ash/resource/transformers/set_primary_actions.ex
+++ b/lib/ash/resource/transformers/set_primary_actions.ex
@@ -103,9 +103,12 @@ defmodule Ash.Resource.Transformers.SetPrimaryActions do
 
       primary? = !Enum.any?(actions, &(&1.type == type && &1.primary?))
 
+      transactions_enabled? = Ash.DataLayer.can?(:transact, dsl_state)
+
       if type == :read do
         Ash.Resource.Builder.prepend_action(dsl_state, type, type,
           primary?: primary?,
+          transaction?: false,
           pagination:
             Ash.Resource.Builder.build_pagination(
               required?: false,
@@ -120,12 +123,14 @@ defmodule Ash.Resource.Transformers.SetPrimaryActions do
             [
               require_atomic?: false,
               primary?: primary?,
-              accept: accept
+              accept: accept,
+              transaction?: transactions_enabled?
             ]
           else
             [
               primary?: primary?,
-              accept: accept
+              accept: accept,
+              transaction?: transactions_enabled?
             ]
           end
 

--- a/test/resource/default_actions_test.exs
+++ b/test/resource/default_actions_test.exs
@@ -1,0 +1,58 @@
+defmodule Ash.Test.Resource.DefaultActionsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Mimic
+
+  test "when the data layer does not support transactions, it doesn't enable them on the generated default actions" do
+    defmodule TransactionFree do
+      @moduledoc false
+      use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+      attributes do
+        uuid_primary_key :id
+      end
+
+      actions do
+        defaults [:read, :destroy, create: :*, update: :*]
+      end
+    end
+
+    transacting_actions =
+      TransactionFree
+      |> Ash.Resource.Info.actions()
+      |> Enum.filter(&(&1.transaction? == true))
+      |> Enum.map(& &1.name)
+
+    assert transacting_actions == []
+  end
+
+  test "when the data layer does support transactions, it enables them on the generated default actions" do
+    Ash.DataLayer
+    |> Mimic.stub(:can?, fn
+      :transact, _ -> true
+      cap, resource -> call_original(Ash.DataLayer, :can?, [cap, resource])
+    end)
+
+    defmodule TransactionFiend do
+      @moduledoc false
+      use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+      attributes do
+        uuid_primary_key :id
+      end
+
+      actions do
+        defaults [:read, :destroy, create: :*, update: :*]
+      end
+    end
+
+    transacting_actions =
+      TransactionFiend
+      |> Ash.Resource.Info.actions()
+      |> Enum.filter(&(&1.transaction? == true))
+      |> Enum.map(& &1.name)
+      |> Enum.sort()
+
+    assert transacting_actions == [:create, :destroy, :update]
+  end
+end


### PR DESCRIPTION
When the resource's data layer doesn't support transactions the generated default actions don't enable transactions.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
