### PR TITLE
fix(Reactor): Don't validate `inputs` keys when being transformed.

### DIFF
--- a/lib/ash/reactor/dsl/action_transformer.ex
+++ b/lib/ash/reactor/dsl/action_transformer.ex
@@ -243,6 +243,7 @@ defmodule Ash.Reactor.Dsl.ActionTransformer do
 
     provided_input_names =
       entity.inputs
+      |> Enum.filter(&is_nil(&1.transform))
       |> Enum.flat_map(&Map.keys(&1.template))
       |> MapSet.new()
 

--- a/test/reactor/inputs_test.exs
+++ b/test/reactor/inputs_test.exs
@@ -1,0 +1,83 @@
+defmodule Ash.Test.ReactorInputTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Ash.Test.Domain
+
+    ets do
+      private? true
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+    end
+
+    actions do
+      defaults create: :*
+    end
+  end
+
+  test "when there is no input transform, the and valid keys are input, it works" do
+    defmodule ValidatedValidKeysReactor do
+      @moduledoc false
+      use Reactor, extensions: [Ash.Reactor]
+
+      input :title
+
+      create :create_post, Post, :create do
+        inputs(%{title: input(:title)})
+      end
+    end
+
+    assert {:ok, _post} =
+             Reactor.run(ValidatedValidKeysReactor, %{
+               title: "10 reasons you'll love Ash actions!"
+             })
+  end
+
+  test "when there is no input transform, and invalid keys are input, it fails to compile" do
+    assert_raise(Spark.Error.DslError, ~r/sub_title.*doesn't exist/, fn ->
+      defmodule ValidatedInvalidKeysReactor do
+        @moduledoc false
+        use Reactor, extensions: [Ash.Reactor]
+
+        input :sub_title
+
+        create :create_post, Post, :create do
+          inputs(%{sub_title: input(:sub_title)})
+        end
+      end
+    end)
+  end
+
+  test "when there is an input transform, keys are not validated" do
+    defmodule UnvalidatedInvalidKeysReactor do
+      @moduledoc false
+      use Reactor, extensions: [Ash.Reactor]
+
+      input :title
+      input :sub_title
+
+      create :create_post, Post, :create do
+        inputs %{
+          title: input(:title),
+          sub_title: input(:sub_title)
+        } do
+          transform &%{title: "#{&1.title}: #{&1.sub_title}"}
+        end
+      end
+    end
+
+    assert {:ok, post} =
+             Reactor.run(UnvalidatedInvalidKeysReactor, %{
+               title: "Dr StrangeDesign",
+               sub_title: "Or how I learned to quit worrying and love declarative design"
+             })
+
+    assert post.title ==
+             "Dr StrangeDesign: Or how I learned to quit worrying and love declarative design"
+  end
+end


### PR DESCRIPTION
Closes [#126](https://github.com/ash-project/reactor/issues/126).

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
