### PR TITLE
fix: check nil before calling Decimal.eq? in Type.Decimal.equal?

### DIFF
--- a/lib/ash/type/decimal.ex
+++ b/lib/ash/type/decimal.ex
@@ -228,9 +228,10 @@ defmodule Ash.Type.Decimal do
   def new(v), do: Decimal.new(v)
 
   @impl true
-  def equal?(left, right) do
-    Decimal.eq?(left, right)
-  end
+  def equal?(nil, nil), do: true
+  def equal?(nil, _right), do: false
+  def equal?(_left, nil), do: false
+  def equal?(left, right), do: Decimal.eq?(left, right)
 end
 
 import Ash.Type.Comparable


### PR DESCRIPTION
simple bug fix