### PR TITLE
fix example of using string_length

### DIFF
--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -124,7 +124,7 @@ defmodule Ash.Resource.Validation.Builtins do
 
   ## Examples
 
-      validate string_length(:slug, exactly: 8)
+      validate string_length(:slug, exact: 8)
       validate string_length(:password, min: 6)
       validate string_length(:secret, min: 4, max: 12)
   """


### PR DESCRIPTION
Simple fix to docs to reflect actual api, where if you want to check the length of a string is exactly X, you should use the keyword `exact:`.