### PR TITLE
fix: Allow multi-line descriptions to be rendered in Livebook without error

### DIFF
--- a/lib/ash/domain/info/livebook.ex
+++ b/lib/ash/domain/info/livebook.ex
@@ -93,7 +93,7 @@ defmodule Ash.Domain.Info.Livebook do
   end
 
   def attr_section(attr) do
-    "| **#{attr.name}** | #{class_short_type(attr.type)} | #{attr.description} |"
+    "| **#{attr.name}** | #{class_short_type(attr.type)} | #{format_description(attr.description)} |"
   end
 
   def action_header do
@@ -104,7 +104,7 @@ defmodule Ash.Domain.Info.Livebook do
   end
 
   def action_section(resource, action) do
-    "| **#{action.name}** | _#{action.type}_ | <ul>#{action_input_section(resource, action)}</ul> | #{action.description} |"
+    "| **#{action.name}** | _#{action.type}_ | <ul>#{action_input_section(resource, action)}</ul> | #{format_description(action.description)} |"
   end
 
   def action_input_section(resource, action) do
@@ -127,7 +127,15 @@ defmodule Ash.Domain.Info.Livebook do
             description
         end
 
-      "<li><b>#{input.name}</b> <i>#{class_short_type(input.type)}</i> #{description}</li>"
+      "<li><b>#{input.name}</b> <i>#{class_short_type(input.type)}</i> #{format_description(description)}</li>"
     end
+  end
+
+  defp format_description(nil), do: ""
+
+  defp format_description(string) do
+    string
+    |> String.trim()
+    |> String.replace("\n", "<br />")
   end
 end

--- a/test/domain/livebook_test.exs
+++ b/test/domain/livebook_test.exs
@@ -74,7 +74,7 @@ defmodule Ash.Test.Domain.Info.LivebookTest do
              | **id** | UUID | PK |
              | **first_name** | String | User's first name |
              | **last_name** | String | User's last name |
-             | **email** | String | User's email address |
+             | **email** | String | User's email address.<br />This doesn't have any validation on it. |
              | **approved** | Boolean | Is the user approved? |
              | **org_id** | UUID |  |
 
@@ -86,7 +86,7 @@ defmodule Ash.Test.Domain.Info.LivebookTest do
              | **read** | _read_ | <ul></ul> |  |
              | **for_org** | _read_ | <ul><li><b>org</b> <i>UUID</i> </li></ul> |  |
              | **by_name** | _read_ | <ul><li><b>name</b> <i>String</i> </li></ul> |  |
-             | **create** | _create_ | <ul><li><b>org</b> <i>UUID</i> </li><li><b>first_name</b> <i>String</i> attribute</li><li><b>last_name</b> <i>String</i> attribute</li><li><b>email</b> <i>String</i> attribute</li></ul> |  |
+             | **create** | _create_ | <ul><li><b>org</b> <i>UUID</i> </li><li><b>first_name</b> <i>String</i> attribute</li><li><b>last_name</b> <i>String</i> attribute</li><li><b>email</b> <i>String</i> attribute</li></ul> | Creating is serious business.<br />For serious people. |
              | **update** | _update_ | <ul><li><b>first_name</b> <i>String</i> attribute</li><li><b>last_name</b> <i>String</i> attribute</li><li><b>email</b> <i>String</i> attribute</li></ul> |  |
              | **approve** | _update_ | <ul></ul> |  |
              | **unapprove** | _update_ | <ul></ul> |  |

--- a/test/support/flow/user.ex
+++ b/test/support/flow/user.ex
@@ -23,6 +23,11 @@ defmodule Ash.Test.Flow.User do
     end
 
     create :create do
+      description """
+      Creating is serious business.
+      For serious people.
+      """
+
       argument :org, :uuid, allow_nil?: false
       change manage_relationship(:org, type: :append_and_remove)
     end
@@ -50,7 +55,13 @@ defmodule Ash.Test.Flow.User do
     uuid_primary_key :id, description: "PK"
     attribute :first_name, :string, description: "User's first name", public?: true
     attribute :last_name, :string, description: "User's last name", public?: true
-    attribute :email, :string, description: "User's email address", public?: true
+
+    attribute :email, :string,
+      description: """
+      User's email address.
+      This doesn't have any validation on it.
+      """,
+      public?: true
 
     attribute :approved, :boolean do
       description "Is the user approved?"


### PR DESCRIPTION
The `mix ash.generate_livebook` task was generating bad Markdown for multiline attributes - the new lines were being included as-is which broke the tables.

This introduces a little helper to use breaks instead of newlines, and renders much better.

Before:

<img width="955" alt="Screenshot 2024-11-07 at 5 03 23 PM" src="https://github.com/user-attachments/assets/30b65dca-cc79-4cca-9d89-c572324004a2">

After: 

<img width="935" alt="Screenshot 2024-11-07 at 5 02 45 PM" src="https://github.com/user-attachments/assets/8a294fce-c5d5-4426-9555-223b84b95ad4">


# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
