### PR TITLE
fix: finish conversion from `append?` to `prepend?` option

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -3061,17 +3061,13 @@ defmodule Ash.Changeset do
            module.has_validate?()
          end) do
       if validation.before_action? do
-        before_action(
-          changeset,
-          fn changeset ->
-            if validation.only_when_valid? and not changeset.valid? do
-              changeset
-            else
-              do_validation(changeset, validation, tracer, metadata, actor)
-            end
-          end,
-          append?: true
-        )
+        before_action(changeset, fn changeset ->
+          if validation.only_when_valid? and not changeset.valid? do
+            changeset
+          else
+            do_validation(changeset, validation, tracer, metadata, actor)
+          end
+        end)
       else
         if validation.only_when_valid? and not changeset.valid? do
           changeset
@@ -5552,11 +5548,11 @@ defmodule Ash.Changeset do
   |> Ash.Changeset.before_action(fn changeset ->
     IO.puts("first before")
     changeset
-  end, append?: true)
+  end)
   |> Ash.Changeset.before_action(fn changeset ->
     IO.puts("second before")
     changeset
-  end, append?: true)
+  end)
   |> Ash.Changeset.after_action(fn changeset, result ->
     IO.puts("first after")
     {:ok, result}
@@ -5626,11 +5622,11 @@ defmodule Ash.Changeset do
   |> Ash.Changeset.before_transaction(fn changeset ->
     IO.puts("first before")
     changeset
-  end, append?: true)
+  end)
   |> Ash.Changeset.before_transaction(fn changeset ->
     IO.puts("second before")
     changeset
-  end, append?: true)
+  end)
   |> Ash.Changeset.after_transaction(fn changeset, result ->
     IO.puts("first after")
     result

--- a/lib/ash/resource/change/before_action.ex
+++ b/lib/ash/resource/change/before_action.ex
@@ -10,7 +10,7 @@ defmodule Ash.Resource.Change.BeforeAction do
       fn changeset ->
         opts[:callback].(changeset, context)
       end,
-      append?: opts[:append?]
+      prepend?: opts[:prepend?]
     )
   end
 end

--- a/lib/ash/resource/change/before_transaction.ex
+++ b/lib/ash/resource/change/before_transaction.ex
@@ -10,7 +10,7 @@ defmodule Ash.Resource.Change.BeforeTransaction do
       fn changeset ->
         opts[:callback].(changeset, context)
       end,
-      append?: opts[:append?]
+      prepend?: opts[:prepend?]
     )
   end
 end

--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -424,7 +424,7 @@ defmodule Ash.Resource.Change.Builtins do
 
   See `Ash.Changeset.before_action/3` for more information.
 
-  Provide the option `append?: true` to place the hook after all other hooks instead of before.
+  Provide the option `prepend?: true` to place the hook before all other hooks instead of after.
 
   ## Example
 
@@ -442,7 +442,7 @@ defmodule Ash.Resource.Change.Builtins do
       unquote(function)
 
       {Ash.Resource.Change.BeforeAction,
-       callback: unquote(value), append?: unquote(Keyword.get(opts, :append?, false))}
+       callback: unquote(value), prepend?: unquote(Keyword.get(opts, :prepend?, false))}
     end
   end
 
@@ -451,7 +451,7 @@ defmodule Ash.Resource.Change.Builtins do
 
   See `Ash.Changeset.before_transaction/3` for more information.
 
-  Provide the option `append?: true` to place the hook after all other hooks instead of before.
+  Provide the option `prepend?: true` to place the hook before all other hooks instead of after.
 
   ## Example
 
@@ -469,7 +469,7 @@ defmodule Ash.Resource.Change.Builtins do
       unquote(function)
 
       {Ash.Resource.Change.BeforeTransaction,
-       callback: unquote(value), append?: unquote(Keyword.get(opts, :append?, false))}
+       callback: unquote(value), prepend?: unquote(Keyword.get(opts, :prepend?, false))}
     end
   end
 end


### PR DESCRIPTION
Since Ash 4 changed order of execution for before hooks there is no more `append?` option - it was replaced with `prepend?`. But built-in helpers (`before_action` and `before_transaction`) and some other places are still referencing and specifying `append?`.