### PR TITLE
Fix warning when actions.read.argument constraint is violated

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1943,7 +1943,12 @@ defmodule Ash.Query do
       message
       |> Ash.Type.Helpers.error_to_exception_opts(argument)
       |> Enum.reduce(query, fn opts, query ->
-        add_error(query, InvalidArgument.exception(Keyword.put(opts, :value, value)))
+        add_error(query, InvalidArgument.exception(
+              value: value,
+              field: Keyword.get(opts, :field),
+              message: Keyword.get(opts, :message),
+              vars: opts
+	    ))
       end)
     end)
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -27,6 +27,14 @@ defmodule Ash.Test.QueryTest do
 
         filter expr(id == ^arg(:id))
       end
+
+      read :list_by_name_substring do
+	argument :name_substring, :string do
+	  constraints [min_length: 4] 
+	end
+
+	filter expr(contains(name, ^arg(:name_substring)))
+      end
     end
 
     attributes do
@@ -52,6 +60,11 @@ defmodule Ash.Test.QueryTest do
     test "it returns an appropriate error when an argument is invalid" do
       query = Ash.Query.for_read(User, :by_id, %{id: "foobar"})
       assert [%Ash.Error.Query.InvalidArgument{field: :id}] = query.errors
+    end
+
+    test "it returns an appropriate error when an argument constraint is violated" do
+      query = Ash.Query.for_read(User, :list_by_name_substring, %{name_substring: "foo"})
+      assert [%Ash.Error.Query.InvalidArgument{field: :name_substring, vars: [min: 4]}] = query.errors
     end
   end
 


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

**Issue**
When an Ash resource read action has an argument with a 'constraints' option and a defined constraint is violated by the provided argument value, then the following Warning is printed:
```
warning: the following fields are unknown when raising Ash.Error.Query.InvalidArgument: [ ...
```

**Solution**
Ensure, that `Ash.Query` does not try to add unknown fields when creating `Ash.Error.Query.InvalidArgument`
