### PR TITLE
Fix/negate atomic where condition 1619

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -900,7 +900,7 @@ defmodule Ash.Changeset do
           {:atomic, _fields, condition_expr, error_expr}, changeset ->
             condition_expr =
               if where_condition do
-                expr(^where_condition and ^condition_expr)
+                expr(not ^where_condition and ^condition_expr)
               else
                 condition_expr
               end


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

Fixes #1619. Validations, when used as conditions, did not work correctly when used in fully atomic updates.