### PR TITLE
improvement: remove unnecessary Stream

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1128,8 +1128,9 @@ defmodule Ash.Changeset do
 
         atomic_conditions when is_list(atomic_conditions) ->
           atomic_conditions
-          |> Stream.map(fn {:atomic, _, expr, _as_error} -> expr end)
-          |> Enum.reduce(condition_expr, &atomic_condition_expr(&2, &1))
+          |> Enum.reduce(condition_expr, fn {:atomic, _, expr, _as_error}, reduced_expr ->
+            atomic_condition_expr(reduced_expr, expr)
+          end)
           |> then(&{:cont, {:atomic, &1}})
       end
     end)


### PR DESCRIPTION
The pattern matching can be done just as easily in the reduction which is more efficient.

I couldn't leave this, lol. Next time there's a minor thing, I'll just get to it before the merge unless a release needs to go out ASAP. I have a serious case of FauxCD.

I also realized how silly `Stream` was for _just one_ destructure anyway. That's even overkill for me.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
