### PR TITLE
docs(filters): clarify how to use string maps

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -116,12 +116,10 @@ defmodule Ash.Filter do
 
   ## Security Concerns
 
-  If you are using a map with string keys, it is likely that you are parsing
-  input. It is important to note that, instead of passing a filter supplied from
-  an external source directly to `Ash.Query.filter/2`, you should call
-  `Ash.Filter.parse_input/2`.  This ensures that the filter only uses public
-  attributes, relationships, aggregates and calculations, honors field policies
-  and any policies on related resources.
+  Do not pass user input directly to `Ash.Query.filter/2`, it will not be sanitised. Instead use
+  `Ash.Filter.parse_input/2` or `Ash.Query.filter_input/2`.
+
+  Refer to those functions for more information on how to safely work with user input.
 
   ## Writing a filter
 


### PR DESCRIPTION
I personally struggled with the current description. I hope this reduced wording is more explicit, while re-using explanation from `Ash.Query.filter_input/2`.

Following on from my post [here](https://elixirforum.com/t/how-to-filter-an-array-attribute-to-find-at-least-one-instance-using-map-syntax/67887) while the iron is hot. If I've misunderstood things I'll remove/correct this PR as needed. 

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
