### PR TITLE
improvement: More Descriptive Error Messages for ash.gen.resource

### DIFF
--- a/lib/ash/resource/actions/action/action.ex
+++ b/lib/ash/resource/actions/action/action.ex
@@ -38,26 +38,7 @@ defmodule Ash.Resource.Actions.Action do
   end
 
   def transform(%{returns: original_type, constraints: constraints} = thing) do
-    type = Ash.Type.get_type(original_type)
-
-    ash_type? =
-      try do
-        Ash.Type.ash_type?(type)
-      rescue
-        _ ->
-          false
-      end
-
-    unless ash_type? do
-      raise """
-      #{inspect(original_type)} is not a valid type.
-
-      Valid types include any custom types, or the following short codes (alongside the types they map to):
-
-      #{Enum.map_join(Ash.Type.short_names(), "\n", fn {name, type} -> "  #{inspect(name)} -> #{inspect(type)}" end)}
-
-      """
-    end
+    type = Ash.Type.get_type!(original_type)
 
     case Ash.Type.validate_constraints(type, constraints) do
       {:ok, constraints} ->

--- a/lib/mix/tasks/gen/ash.gen.resource.ex
+++ b/lib/mix/tasks/gen/ash.gen.resource.ex
@@ -313,6 +313,13 @@ defmodule Mix.Tasks.Ash.Gen.Resource do
 
       "sensitive" ->
         "sensitive? true"
+
+      unknown ->
+        raise ArgumentError,
+              """
+              Unrecognizeable attribute modifier: `#{unknown}`.
+              \tKnown modifiers are: primary_key, public, required, sensitive.
+              """
     end)
   end
 

--- a/lib/mix/tasks/gen/ash.gen.resource.ex
+++ b/lib/mix/tasks/gen/ash.gen.resource.ex
@@ -320,7 +320,8 @@ defmodule Mix.Tasks.Ash.Gen.Resource do
         raise ArgumentError,
               """
               Unrecognizeable attribute modifier: `#{unknown}`.
-              \tKnown modifiers are: primary_key, public, required, sensitive.
+
+              Known modifiers are: primary_key, public, required, sensitive.
               """
     end)
   end
@@ -380,10 +381,19 @@ defmodule Mix.Tasks.Ash.Gen.Resource do
   end
 
   defp resolve_type(value) do
-    if String.contains?(value, ".") do
-      Module.concat([value])
-    else
-      String.to_atom(value)
-    end
+    resolved_type =
+      if String.contains?(value, ".") do
+        Module.concat([value])
+      else
+        String.to_atom(value)
+      end
+
+    ensure_ash_type!(resolved_type)
+
+    resolved_type
+  end
+
+  defp ensure_ash_type!(original_type) do
+    _ = Ash.Type.get_type!(original_type)
   end
 end

--- a/lib/mix/tasks/gen/ash.gen.resource.ex
+++ b/lib/mix/tasks/gen/ash.gen.resource.ex
@@ -301,7 +301,9 @@ defmodule Mix.Tasks.Ash.Gen.Resource do
   end
 
   defp attribute_modifier_string(modifiers) do
-    Enum.map_join(modifiers, "\n", fn
+    modifiers
+    |> Enum.uniq()
+    |> Enum.map_join("\n", fn
       "primary_key" ->
         "primary_key? true"
 

--- a/lib/mix/tasks/gen/ash.gen.resource.ex
+++ b/lib/mix/tasks/gen/ash.gen.resource.ex
@@ -23,9 +23,9 @@ defmodule Mix.Tasks.Ash.Gen.Resource do
 
   * `--attribute` or `-a` - An attribute or comma separated list of attributes to add, as `name:type`. Modifiers: `primary_key`, `public`, `sensitive`, and `required`. i.e `-a name:string:required`
   * `--relationship` or `-r` - A relationship or comma separated list of relationships to add, as `type:name:dest`. Modifiers: `public`. `belongs_to` only modifiers: `primary_key`, `sensitive`, and `required`. i.e `-r belongs_to:author:MyApp.Accounts.Author:required`
-  * `--default-actions` - A csv list of default action types to add, i.e `-da read,create`. The `create` and `update` actions accept the public attributes being added.
+  * `--default-actions` - A csv list of default action types to add. The `create` and `update` actions accept the public attributes being added.
   * `--uuid-primary-key` or `-u` - Adds a UUIDv4 primary key with that name. i.e `-u id`
-  * `--uuid-v7-primary-key` - Adds a UUIDv7 primary key with that name. i.e `-u7 id`
+  * `--uuid-v7-primary-key` - Adds a UUIDv7 primary key with that name.
   * `--integer-primary-key` or `-i` - Adds an integer primary key with that name. i.e `-i id`
   * `--domain` or `-d` - The domain module to add the resource to. i.e `-d MyApp.MyDomain`. This defaults to the resource's module name, minus the last segment.
   * `--extend` or `-e` - A comma separated list of modules or builtins to extend the resource with. i.e `-e postgres,Some.Extension`


### PR DESCRIPTION
Hello!

Addressing issue [#1553](https://github.com/ash-project/ash/issues/1553).

Looking for feedback on the following

### Changes:
1. Meaningful error for unrecognized gen.resource task attribute modifier
2. Check attribute type is a valid ash type + bit refactoring
3. Filter out duplicate modifiers on an attribute
4. Delete removed alias examples from docs.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
