### PR TITLE
fix - handle soft destroys with manage_relationship

### DIFF
--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -1706,6 +1706,8 @@ defmodule Ash.Actions.ManagedRelationships do
             end
 
           {:destroy, action_name} ->
+            record_id = record.id
+
             record
             |> Ash.Changeset.new()
             |> Ash.Changeset.set_context(%{
@@ -1721,6 +1723,9 @@ defmodule Ash.Actions.ManagedRelationships do
             |> Ash.destroy(return_notifications?: true)
             |> case do
               {:ok, notifications} ->
+                {:cont, {:ok, current_value, notifications ++ all_notifications}}
+
+              {:ok, %{id: ^record_id} = _soft_destroyed_record, notifications} ->
                 {:cont, {:ok, current_value, notifications ++ all_notifications}}
 
               {:error, error} ->

--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -1706,8 +1706,6 @@ defmodule Ash.Actions.ManagedRelationships do
             end
 
           {:destroy, action_name} ->
-            record_id = record.id
-
             record
             |> Ash.Changeset.new()
             |> Ash.Changeset.set_context(%{
@@ -1725,7 +1723,7 @@ defmodule Ash.Actions.ManagedRelationships do
               {:ok, notifications} ->
                 {:cont, {:ok, current_value, notifications ++ all_notifications}}
 
-              {:ok, %{id: ^record_id} = _soft_destroyed_record, notifications} ->
+              {:ok, _soft_destroyed_record, notifications} ->
                 {:cont, {:ok, current_value, notifications ++ all_notifications}}
 
               {:error, error} ->

--- a/test/manage_relationship_test.exs
+++ b/test/manage_relationship_test.exs
@@ -12,17 +12,21 @@ defmodule Ash.Test.ManageRelationshipTest do
 
       create :create do
         accept [:name]
-        argument :related_resource, :map, allow_nil?: false
+        argument :related_resource, :map
+        argument :other_resources, {:array, :map}
 
         change manage_relationship(:related_resource, :related_resource, type: :create)
+        change manage_relationship(:other_resources, type: :direct_control)
       end
 
       update :update do
         require_atomic? false
         accept [:name]
-        argument :related_resource, :map, allow_nil?: false
+        argument :related_resource, :map
+        argument :other_resources, {:array, :map}
 
         change manage_relationship(:related_resource, :related_resource, type: :direct_control)
+        change manage_relationship(:other_resources, type: :direct_control)
       end
     end
 
@@ -34,6 +38,8 @@ defmodule Ash.Test.ManageRelationshipTest do
     relationships do
       has_one :related_resource, Ash.Test.ManageRelationshipTest.RelatedResource,
         destination_attribute: :parent_resource_id
+
+      has_many :other_resources, Ash.Test.ManageRelationshipTest.OtherResource
     end
   end
 
@@ -58,6 +64,33 @@ defmodule Ash.Test.ManageRelationshipTest do
     attributes do
       uuid_primary_key :id
       attribute :required_attribute, :string, allow_nil?: false, public?: true
+    end
+
+    relationships do
+      belongs_to :parent_resource, ParentResource
+    end
+  end
+
+  defmodule OtherResource do
+    use Ash.Resource,
+      domain: Ash.Test.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      fragments: [RelatedResourceFragment]
+
+    actions do
+      defaults [:read, create: :*, update: :*]
+
+      destroy :archive do
+        primary? true
+        soft? true
+        change set_attribute(:archived_at, &DateTime.utc_now/0)
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :required_attribute, :string, allow_nil?: false, public?: true
+      attribute :archived_at, :utc_datetime_usec
     end
 
     relationships do
@@ -109,5 +142,46 @@ defmodule Ash.Test.ManageRelationshipTest do
              |> Ash.load(:related_resource)
 
     assert parent.related_resource.required_attribute == "other_string"
+  end
+
+  test "can create and destroy arrays" do
+    assert {:ok, parent} =
+             ParentResource
+             |> Ash.Changeset.for_create(:create, %{
+               name: "Test Parent Resource",
+               other_resources: [
+                 %{required_attribute: "first"},
+                 %{required_attribute: "second"}
+               ]
+             })
+             |> Ash.create!()
+             |> Ash.load(:other_resources)
+
+    assert Enum.map(parent.other_resources, & &1.required_attribute) |> Enum.sort() == [
+             "first",
+             "second"
+           ]
+
+    other_resources = Enum.reject(parent.other_resources, &(&1.required_attribute == "first"))
+
+    assert {:ok, updated_parent} =
+             parent
+             |> Ash.Changeset.for_update(:update, %{
+               other_resources: other_resources
+             })
+             |> Ash.update!()
+             |> Ash.load(:other_resources)
+
+    # Since we did a soft destroy, we should still have all other resources
+    assert Enum.map(updated_parent.other_resources, & &1.required_attribute) |> Enum.sort() == [
+             "first",
+             "second"
+           ]
+
+    first_other = Enum.find(updated_parent.other_resources, &(&1.required_attribute == "first"))
+    assert not is_nil(first_other.archived_at)
+
+    second_other = Enum.find(updated_parent.other_resources, &(&1.required_attribute == "second"))
+    assert is_nil(second_other.archived_at)
   end
 end


### PR DESCRIPTION
Technically, [line 1689](https://github.com/lardcanoe/ash/blob/soft-deletes-manage-relationship/lib/ash/actions/managed_relationships.ex#L1689) also has this issue, but not sure how to target it.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
