### PR TITLE
improvement: add support for `strict?` in read options

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -108,6 +108,17 @@ defmodule Ash do
                           doc:
                             "Whether calculations are allowed to reuse values that have already been loaded, or must refetch them from the data layer."
                         ],
+                        strict?: [
+                          type: :boolean,
+                          default: false,
+                          doc: """
+                            If set to true, only specified attributes will be loaded when passing
+                            a list of fields to fetch on a relationship, which allows for more
+                            optimized data-fetching.
+
+                            See `Ash.Query.load/2`.
+                          """
+                        ],
                         authorize_with: [
                           type: {:one_of, [:filter, :error]},
                           default: :filter,
@@ -230,6 +241,17 @@ defmodule Ash do
                        default: false,
                        doc:
                          "Whether calculations are allowed to reuse values that have already been loaded, or must refetch them from the data layer."
+                     ],
+                     strict?: [
+                       type: :boolean,
+                       default: false,
+                       doc: """
+                         If set to true, only specified attributes will be loaded when passing
+                         a list of fields to fetch on a relationship, which allows for more
+                         optimized data-fetching.
+
+                         See `Ash.Query.load/2`.
+                       """
                      ]
                    ]
                    |> Spark.Options.merge(@global_opts, "Global Options")

--- a/lib/ash/actions/helpers.ex
+++ b/lib/ash/actions/helpers.ex
@@ -564,7 +564,7 @@ defmodule Ash.Actions.Helpers do
 
   def apply_opts_load(%Ash.Query{} = query, opts) do
     if opts[:load] do
-      Ash.Query.load(query, opts[:load])
+      Ash.Query.load(query, opts[:load], Keyword.take(opts, [:strict?]))
     else
       query
     end


### PR DESCRIPTION
`Ash.Query.load` has `strict?` option that limits loaded/selected fields to those that explicitly specified.

This PR allows passing that option to read methods - `Ash.get`/`Ash.read`/`Ash.read_one` and so on - that already do have `load`/`reuse_values?` options.

So now one will be able to write `Ash.get!(User, id, load: [:name], strict?: true)`.
