### PR TITLE
Allow context error message in Changing validation

### DIFF
--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -27,7 +27,7 @@ defmodule Ash.Resource.Validation.Builtins do
       validate changing(:first_name)
       validate changing(:comments)
   """
-  @spec changing(attribute :: atom) :: Validation.ref()
+  @spec changing(attribute_or_relationship :: atom) :: Validation.ref()
   def changing(field) do
     {Validation.Changing, field: field}
   end

--- a/lib/ash/resource/validation/changing.ex
+++ b/lib/ash/resource/validation/changing.ex
@@ -3,26 +3,26 @@ defmodule Ash.Resource.Validation.Changing do
 
   use Ash.Resource.Validation
 
+  import Ash.Changeset
+
   alias Ash.Error.Changes.InvalidAttribute
-  import Ash.Expr
-
-  @opt_schema [
-    field: [
-      type: :atom,
-      required: true,
-      doc: "The attribute to check"
-    ]
-  ]
-
-  opt_schema = @opt_schema
 
   defmodule Opts do
     @moduledoc false
 
-    use Spark.Options.Validator, schema: opt_schema
+    use Spark.Options.Validator,
+      schema: [
+        field: [
+          type: :atom,
+          required: true,
+          doc: "The attribute or relationship to check for changes."
+        ]
+      ]
   end
 
-  @impl true
+  @default_error_message "must be changing"
+
+  @impl Ash.Resource.Validation
   def init(opts) do
     case Opts.validate(opts) do
       {:ok, opts} ->
@@ -33,79 +33,73 @@ defmodule Ash.Resource.Validation.Changing do
     end
   end
 
-  @impl true
+  @impl Ash.Resource.Validation
   def validate(changeset, opts, context) do
-    case Ash.Resource.Info.relationship(changeset.resource, opts[:field]) do
-      nil ->
-        if Ash.Changeset.changing_attribute?(changeset, opts[:field]) do
-          :ok
-        else
-          {:error, exception(opts, context)}
-        end
+    if field_is_changing?(changeset, Keyword.fetch!(opts, :field)),
+      do: :ok,
+      else: {:error, exception(opts, context)}
+  end
 
-      %{type: :belongs_to, source_attribute: source_attribute} = relationship ->
-        if Ash.Changeset.changing_attribute?(changeset, source_attribute) ||
-             Ash.Changeset.changing_relationship?(changeset, relationship.name) do
-          :ok
-        else
-          {:error, exception(opts, context)}
-        end
+  defp field_is_changing?(changeset, field) do
+    case Ash.Resource.Info.relationship(changeset.resource, field) do
+      nil ->
+        changing_attribute?(changeset, field)
+
+      %{type: :belongs_to} = relationship ->
+        changing_attribute?(changeset, relationship.source_attribute) ||
+          changing_relationship?(changeset, relationship.name)
 
       relationship ->
-        if Ash.Changeset.changing_relationship?(changeset, relationship.name) do
-          :ok
-        else
-          {:error, exception(opts, context)}
-        end
+        changing_relationship?(changeset, relationship.name)
     end
   end
 
-  @impl true
+  @impl Ash.Resource.Validation
   def atomic(changeset, opts, context) do
-    case Ash.Resource.Info.relationship(changeset.resource, opts[:field]) do
-      nil ->
-        if Ash.Changeset.changing_attribute?(changeset, opts[:field]) do
-          {:atomic, [opts[:field]], expr(^atomic_ref(opts[:field]) == ^ref(opts[:field])),
-           expr(
-             error(^InvalidAttribute, %{
-               field: ^opts[:field],
-               value: ^atomic_ref(opts[:field]),
-               message: ^(context.message || "must be changing"),
-               vars: %{field: ^opts[:field]}
-             })
-           )}
-        else
-          {:error, exception(opts, context)}
-        end
+    case atomic_field(changeset, Keyword.fetch!(opts, :field)) do
+      {:changing, field} ->
+        {:atomic, [field], expr(^atomic_ref(field) == ^ref(field)),
+         expr(
+           error(^InvalidAttribute, %{
+             field: ^field,
+             value: ^atomic_ref(field),
+             message: ^(context.message || @default_error_message),
+             vars: %{field: ^field}
+           })
+         )}
 
-      %{type: :belongs_to, source_attribute: source_attribute} ->
-        if Ash.Changeset.changing_attribute?(changeset, source_attribute) do
-          {:atomic, [source_attribute],
-           expr(^atomic_ref(source_attribute) == ^ref(source_attribute)),
-           expr(
-             error(^InvalidAttribute, %{
-               field: ^opts[:field],
-               value: ^atomic_ref(opts[:field]),
-               message: ^(context.message || "must be changing"),
-               vars: %{field: ^opts[:field]}
-             })
-           )}
-        else
-          {:error, exception(opts, context)}
-        end
+      {:not_changing, _field} ->
+        {:error, exception(opts, context)}
 
-      relationship ->
-        {:not_atomic, "can't atomically check if #{relationship.name} relationship is changing"}
+      {:not_atomic, field} ->
+        {:not_atomic, "can't atomically check if #{field} relationship is changing"}
     end
   end
 
-  @impl true
-  def describe(_opts) do
-    [
-      message: "must be changing",
-      vars: []
-    ]
+  defp atomic_field(changeset, field) do
+    changeset.resource
+    |> Ash.Resource.Info.relationship(field)
+    |> case do
+      nil -> {:atomic, field}
+      %{type: :belongs_to} = relationship -> {:atomic, relationship.source_attribute}
+      _relationship -> {:not_atomic, field}
+    end
+    |> atomic_result(changeset)
   end
+
+  defp atomic_result({:atomic, field}, changeset) do
+    msg =
+      if changing_attribute?(changeset, field),
+        do: :changing,
+        else: :not_changing
+
+    {msg, field}
+  end
+
+  defp atomic_result(not_atomic, _changeset), do: not_atomic
+
+  @impl Ash.Resource.Validation
+  def describe(_opts), do: [message: @default_error_message, vars: []]
 
   defp exception(opts, context) do
     [field: opts[:field]]

--- a/test/resource/validation/changing_test.exs
+++ b/test/resource/validation/changing_test.exs
@@ -11,15 +11,12 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
 
     actions do
       default_accept :*
-      defaults [:read, :destroy, create: :*, update: :*]
+      defaults [:read, create: :*, update: :*]
     end
 
     attributes do
       uuid_primary_key :id
-
-      attribute :name, :string do
-        public?(true)
-      end
+      attribute :name, :string, public?: true
     end
   end
 
@@ -28,19 +25,16 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
 
     actions do
       default_accept :*
-      defaults [:read, :destroy, create: :*, update: :*]
+      defaults [:read, create: :*, update: :*]
     end
 
     attributes do
       uuid_primary_key :id
-
-      attribute :text, :string do
-        public?(true)
-      end
+      attribute :text, :string, public?: true
     end
 
     relationships do
-      belongs_to :post, Post
+      belongs_to :post, Post, public?: true
     end
   end
 
@@ -49,35 +43,25 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
 
     actions do
       default_accept :*
-      defaults [:read, :destroy, create: :*, update: :*]
+      defaults [:read, create: :*, update: :*]
 
       update :ensure_order_changing do
-        accept([:order])
-
-        validate(changing(:order))
+        validate changing(:order)
       end
 
       update :ensure_author_changing do
-        accept([:author_id])
-
-        validate(changing(:author))
+        validate changing(:author)
       end
 
       update :ensure_comments_changing do
-        validate(changing(:comments))
+        validate changing(:comments)
       end
     end
 
     attributes do
       uuid_primary_key :id
-
-      attribute :title, :string do
-        public?(true)
-      end
-
-      attribute :order, :integer do
-        public?(true)
-      end
+      attribute :title, :string, public?: true
+      attribute :order, :integer, public?: true
     end
 
     relationships do
@@ -86,12 +70,9 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
     end
   end
 
-  describe "Ash.Resource.Validation.Changing" do
-    test "fails atomic validation if attribute is not changing" do
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo", order: 1})
-        |> Ash.create!()
+  describe "Ash.Resource.Validation.Changing atomic validation" do
+    test "fails if attribute is not changing" do
+      post = Ash.create!(Post, %{title: "foo", order: 1})
 
       assert_raise Ash.Error.Invalid, ~r/must be changing/, fn ->
         Post
@@ -100,11 +81,8 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
       end
     end
 
-    test "fails atomic validation if attribute is being set to the same value" do
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo", order: 1})
-        |> Ash.create!()
+    test "fails if attribute is being set to the same value" do
+      post = Ash.create!(Post, %{title: "foo", order: 1})
 
       assert_raise Ash.Error.Invalid, ~r/must be changing/, fn ->
         Post
@@ -113,11 +91,8 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
       end
     end
 
-    test "succeeds atomic validation if attribute changing to another value" do
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo", order: 1})
-        |> Ash.create!()
+    test "succeeds if attribute changing to another value" do
+      post = Ash.create!(Post, %{title: "foo", order: 1})
 
       assert %Ash.BulkResult{status: :success} =
                Post
@@ -125,16 +100,9 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
                |> Ash.bulk_update!(:ensure_order_changing, %{order: 2})
     end
 
-    test "fails atomic validation if relationship is not changing" do
-      author =
-        Author
-        |> Ash.Changeset.for_create(:create, %{name: "fred"})
-        |> Ash.create!()
-
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo", author_id: author.id})
-        |> Ash.create!()
+    test "fails if relationship is not changing" do
+      author = Ash.create!(Author, %{name: "fred"})
+      post = Ash.create!(Post, %{title: "foo", author_id: author.id})
 
       assert_raise Ash.Error.Invalid, ~r/must be changing/, fn ->
         Post
@@ -143,16 +111,9 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
       end
     end
 
-    test "fails atomic validation if relationship is being set to the same value" do
-      author =
-        Author
-        |> Ash.Changeset.for_create(:create, %{name: "fred"})
-        |> Ash.create!()
-
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo", author_id: author.id})
-        |> Ash.create!()
+    test "fails if relationship is being set to the same value" do
+      author = Ash.create!(Author, %{name: "fred"})
+      post = Ash.create!(Post, %{title: "foo", author_id: author.id})
 
       assert_raise Ash.Error.Invalid, ~r/must be changing/, fn ->
         Post
@@ -161,21 +122,10 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
       end
     end
 
-    test "succeeds atomic validation if relationship is being set to another value" do
-      author1 =
-        Author
-        |> Ash.Changeset.for_create(:create, %{name: "fred"})
-        |> Ash.create!()
-
-      author2 =
-        Author
-        |> Ash.Changeset.for_create(:create, %{name: "george"})
-        |> Ash.create!()
-
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo", author_id: author1.id})
-        |> Ash.create!()
+    test "succeeds if relationship is being set to another value" do
+      author1 = Ash.create!(Author, %{name: "fred"})
+      author2 = Ash.create!(Author, %{name: "george"})
+      post = Ash.create!(Post, %{title: "foo", author_id: author1.id})
 
       assert %Ash.BulkResult{status: :success} =
                Post
@@ -183,11 +133,8 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
                |> Ash.bulk_update!(:ensure_author_changing, %{author_id: author2.id})
     end
 
-    test "returns not_atomic on has_many relationships" do
-      post =
-        Post
-        |> Ash.Changeset.for_create(:create, %{title: "foo"})
-        |> Ash.create!()
+    test "returns :not_atomic on has_many relationships" do
+      post = Ash.create!(Post, %{title: "foo"})
 
       assert_raise Ash.Error.Invalid, ~r/can't atomically check/, fn ->
         Post

--- a/test/resource/validation/changing_test.exs
+++ b/test/resource/validation/changing_test.exs
@@ -52,7 +52,7 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
 
       update :ensure_author_changing do
         require_atomic? false
-        validate changing(:author)
+        validate changing(:author), message: "change is inevitable!"
       end
 
       update :ensure_comments_changing do
@@ -128,7 +128,7 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
 
       Post
       |> Ash.create!(%{title: "foo", author_id: author.id})
-      |> assert_invalid_updates(:ensure_author_changing, %{})
+      |> assert_invalid_updates(:ensure_author_changing, %{}, "change is inevitable!")
     end
 
     test "fails if relationship is being set to the same value" do
@@ -136,7 +136,11 @@ defmodule Ash.Test.Resource.Validation.ChangingTest do
 
       Post
       |> Ash.create!(%{title: "foo", author_id: author.id})
-      |> assert_invalid_updates(:ensure_author_changing, %{author_id: author.id})
+      |> assert_invalid_updates(
+        :ensure_author_changing,
+        %{author_id: author.id},
+        "change is inevitable!"
+      )
     end
 
     test "succeeds if relationship is being set to another value" do


### PR DESCRIPTION
Non-atomic validation failures did not respect the `:message` provided in the context if it was present.

As is obvious, this little change took me down a bit of clean-up/refactor rabbit hole. It's a compulsion.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
