### PR TITLE
allow exclusion of certain actions from publish_all

### DIFF
--- a/lib/ash/notifier/pub_sub/pub_sub.ex
+++ b/lib/ash/notifier/pub_sub/pub_sub.ex
@@ -481,7 +481,10 @@ defmodule Ash.Notifier.PubSub do
   defp publishable_value?(_, _), do: true
 
   defp matches?(%{action: action}, %{name: action}), do: true
-  defp matches?(%{type: type}, %{type: type}), do: true
+
+  defp matches?(%{type: type, except: except}, %{type: type, action: action}) do
+    action not in except
+  end
 
   defp matches?(_, _), do: false
 end

--- a/lib/ash/notifier/pub_sub/publication.ex
+++ b/lib/ash/notifier/pub_sub/publication.ex
@@ -6,6 +6,7 @@ defmodule Ash.Notifier.PubSub.Publication do
     :topic,
     :event,
     :type,
+    :except,
     :dispatcher,
     :previous_values?
   ]
@@ -43,6 +44,11 @@ defmodule Ash.Notifier.PubSub.Publication do
                       |> Keyword.put(:type,
                         type: {:in, [:create, :update, :destroy]},
                         doc: "Publish on all actions of a given type"
+                      )
+                      |> Keyword.put(:except,
+                        type: {:list, :atom},
+                        doc: "Exclude these actions from notifications",
+                        default: []
                       )
 
   def schema, do: @schema


### PR DESCRIPTION
This patch adds `except` option to `pub_sub.publish_all` that allows to exclude certain actions from notifications.

My motivation for this is the following scenario:

I have a resource that has multiple update actions that require notifications, and only one action for which notifications are not required (and are pointless since it is only used during application shutdown). Without this option, I have to list all actions separately and remember to update the notifications list each time I add a new action.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
