### PR TITLE
Add default code interface options

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -65,6 +65,7 @@ spark_locals_without_parens = [
   default_context: 1,
   default_domain: 1,
   default_limit: 1,
+  default_options: 1,
   defaults: 1,
   define: 1,
   define: 2,

--- a/documentation/dsls/DSL-Ash.Domain.md
+++ b/documentation/dsls/DSL-Ash.Domain.md
@@ -126,7 +126,7 @@ define :get_user_by_id, action: :get_by_id, args: [:id], get?: true
 | [`get?`](#resources-resource-define-get?){: #resources-resource-define-get? } | `boolean` | `false` | Expects to only receive a single result from a read action or a bulk update/destroy, and returns a single result instead of a list. Sets `require_reference?` to false automatically. |
 | [`get_by`](#resources-resource-define-get_by){: #resources-resource-define-get_by } | `atom \| list(atom)` |  | Takes a list of fields and adds those fields as arguments, which will then be used to filter. Sets `get?` to true and `require_reference?` to false automatically. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
 | [`get_by_identity`](#resources-resource-define-get_by_identity){: #resources-resource-define-get_by_identity } | `atom` |  | Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
-| [`default_options`](#resources-resource-define-default_options){: #resources-resource-define-default_options } | `any` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
+| [`default_options`](#resources-resource-define-default_options){: #resources-resource-define-default_options } | `keyword` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
 
 
 

--- a/documentation/dsls/DSL-Ash.Domain.md
+++ b/documentation/dsls/DSL-Ash.Domain.md
@@ -126,7 +126,7 @@ define :get_user_by_id, action: :get_by_id, args: [:id], get?: true
 | [`get?`](#resources-resource-define-get?){: #resources-resource-define-get? } | `boolean` | `false` | Expects to only receive a single result from a read action or a bulk update/destroy, and returns a single result instead of a list. Sets `require_reference?` to false automatically. |
 | [`get_by`](#resources-resource-define-get_by){: #resources-resource-define-get_by } | `atom \| list(atom)` |  | Takes a list of fields and adds those fields as arguments, which will then be used to filter. Sets `get?` to true and `require_reference?` to false automatically. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
 | [`get_by_identity`](#resources-resource-define-get_by_identity){: #resources-resource-define-get_by_identity } | `atom` |  | Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
-| [`default_options`](#resources-resource-define-default_options){: #resources-resource-define-default_options } | `keyword` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
+| [`default_options`](#resources-resource-define-default_options){: #resources-resource-define-default_options } | `keyword` | `[]` | Default options to be merged with client-provided options. These can override domain or action defaults. |
 
 
 

--- a/documentation/dsls/DSL-Ash.Domain.md
+++ b/documentation/dsls/DSL-Ash.Domain.md
@@ -126,6 +126,7 @@ define :get_user_by_id, action: :get_by_id, args: [:id], get?: true
 | [`get?`](#resources-resource-define-get?){: #resources-resource-define-get? } | `boolean` | `false` | Expects to only receive a single result from a read action or a bulk update/destroy, and returns a single result instead of a list. Sets `require_reference?` to false automatically. |
 | [`get_by`](#resources-resource-define-get_by){: #resources-resource-define-get_by } | `atom \| list(atom)` |  | Takes a list of fields and adds those fields as arguments, which will then be used to filter. Sets `get?` to true and `require_reference?` to false automatically. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
 | [`get_by_identity`](#resources-resource-define-get_by_identity){: #resources-resource-define-get_by_identity } | `atom` |  | Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
+| [`default_options`](#resources-resource-define-default_options){: #resources-resource-define-default_options } | `any` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
 
 
 

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -2031,7 +2031,7 @@ define :get_user_by_id, action: :get_by_id, args: [:id], get?: true
 | [`get?`](#code_interface-define-get?){: #code_interface-define-get? } | `boolean` | `false` | Expects to only receive a single result from a read action or a bulk update/destroy, and returns a single result instead of a list. Sets `require_reference?` to false automatically. |
 | [`get_by`](#code_interface-define-get_by){: #code_interface-define-get_by } | `atom \| list(atom)` |  | Takes a list of fields and adds those fields as arguments, which will then be used to filter. Sets `get?` to true and `require_reference?` to false automatically. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
 | [`get_by_identity`](#code_interface-define-get_by_identity){: #code_interface-define-get_by_identity } | `atom` |  | Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
-| [`default_options`](#code_interface-define-default_options){: #code_interface-define-default_options } | `any` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
+| [`default_options`](#code_interface-define-default_options){: #code_interface-define-default_options } | `keyword` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
 
 
 

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -2031,7 +2031,7 @@ define :get_user_by_id, action: :get_by_id, args: [:id], get?: true
 | [`get?`](#code_interface-define-get?){: #code_interface-define-get? } | `boolean` | `false` | Expects to only receive a single result from a read action or a bulk update/destroy, and returns a single result instead of a list. Sets `require_reference?` to false automatically. |
 | [`get_by`](#code_interface-define-get_by){: #code_interface-define-get_by } | `atom \| list(atom)` |  | Takes a list of fields and adds those fields as arguments, which will then be used to filter. Sets `get?` to true and `require_reference?` to false automatically. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
 | [`get_by_identity`](#code_interface-define-get_by_identity){: #code_interface-define-get_by_identity } | `atom` |  | Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
-| [`default_options`](#code_interface-define-default_options){: #code_interface-define-default_options } | `keyword` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
+| [`default_options`](#code_interface-define-default_options){: #code_interface-define-default_options } | `keyword` | `[]` | Default options to be merged with client-provided options. These can override domain or action defaults. |
 
 
 

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -2031,6 +2031,7 @@ define :get_user_by_id, action: :get_by_id, args: [:id], get?: true
 | [`get?`](#code_interface-define-get?){: #code_interface-define-get? } | `boolean` | `false` | Expects to only receive a single result from a read action or a bulk update/destroy, and returns a single result instead of a list. Sets `require_reference?` to false automatically. |
 | [`get_by`](#code_interface-define-get_by){: #code_interface-define-get_by } | `atom \| list(atom)` |  | Takes a list of fields and adds those fields as arguments, which will then be used to filter. Sets `get?` to true and `require_reference?` to false automatically. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
 | [`get_by_identity`](#code_interface-define-get_by_identity){: #code_interface-define-get_by_identity } | `atom` |  | Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument. |
+| [`default_options`](#code_interface-define-default_options){: #code_interface-define-default_options } | `any` | `[]` | Default options used when none are supplied. These can override domain or action defaults. |
 
 
 

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -492,23 +492,15 @@ defmodule Ash.CodeInterface do
               |> unquote(interface_options).validate!()
               |> unquote(interface_options).to_options()
 
-            params =
-              if is_list(params) do
-                to_merge =
-                  unquote(args)
-                  |> Enum.zip([unquote_splicing(arg_vars)])
-                  |> Map.new()
+            arg_params =
+              unquote(args)
+              |> Enum.zip([unquote_splicing(arg_vars)])
+              |> Map.new()
 
-                Enum.map(params, fn params ->
-                  Map.merge(params, to_merge)
-                end)
-              else
-                unquote(args)
-                |> Enum.zip([unquote_splicing(arg_vars)])
-                |> Enum.reduce(params, fn {key, value}, params ->
-                  Map.put(params, key, value)
-                end)
-              end
+            params =
+              if is_list(params),
+                do: Enum.map(params, &Map.merge(&1, arg_params)),
+                else: Map.merge(params, arg_params)
           end
 
         {subject, subject_args, resolve_subject, act, act!} =

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -508,9 +508,6 @@ defmodule Ash.CodeInterface do
             {params, opts} =
               Ash.CodeInterface.params_and_opts(params_or_opts, opts, fn opts ->
                 unquote(Macro.escape(interface.default_options))
-                |> Enum.reduce(opts, fn {key, default}, opts_with_defaults ->
-                  Keyword.put_new(opts_with_defaults, key, default)
-                end)
                 |> Keyword.merge(opts)
                 |> unquote(interface_options).validate!()
                 |> unquote(interface_options).to_options()

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -234,6 +234,7 @@ defmodule Ash.CodeInterface do
 
     {params, opts}
   end
+
   @doc """
   Defines the code interface for a given resource + domain combination in the current module. For example:
 
@@ -483,7 +484,7 @@ defmodule Ash.CodeInterface do
 
         interface_options = Ash.Resource.Interface.interface_options(action.type, interface)
 
-        resolve_opts_params =
+        resolve_params_and_opts =
           quote do
             {params, opts} = Ash.CodeInterface.params_and_opts(params_or_opts, opts)
 
@@ -1263,7 +1264,7 @@ defmodule Ash.CodeInterface do
                {first_opts_location + 1, interface_options.schema()}
              ]
         def unquote(interface.name)(unquote_splicing(common_args)) do
-          unquote(resolve_opts_params)
+          unquote(resolve_params_and_opts)
           unquote(resolve_subject)
           unquote(act)
         end
@@ -1287,7 +1288,7 @@ defmodule Ash.CodeInterface do
                {first_opts_location + 1, interface_options.schema()}
              ]
         def unquote(:"#{interface.name}!")(unquote_splicing(common_args)) do
-          unquote(resolve_opts_params)
+          unquote(resolve_params_and_opts)
           unquote(resolve_subject)
           unquote(act!)
         end
@@ -1325,7 +1326,7 @@ defmodule Ash.CodeInterface do
                  {first_opts_location + 1, subject_opts}
                ]
           def unquote(:"#{subject_name}_to_#{interface.name}")(unquote_splicing(common_args)) do
-            unquote(resolve_opts_params)
+            unquote(resolve_params_and_opts)
             unquote(resolve_subject)
             unquote(subject)
           end

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -216,7 +216,7 @@ defmodule Ash.CodeInterface do
     2. A list of maps for bulk operations.
 
   Additionally, if options are set explicitly (i.e. at least one option has
-  been set), a keywork list will be converted to a map.
+  been set), a keyword list will be converted to a map.
   """
   @spec params_and_opts(params_or_opts :: map() | [map()] | keyword(), keyword()) ::
           {params :: map() | [map()], opts :: keyword()}

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -454,27 +454,6 @@ defmodule Ash.CodeInterface do
             {params, opts} =
               if opts == [] && Keyword.keyword?(params_or_opts),
                 do:
-                  {%{},
-                   unquote(interface_options).validate!(params_or_opts)
-                   |> unquote(interface_options).to_options()},
-                else:
-                  {params_or_opts,
-                   unquote(interface_options).validate!(opts)
-                   |> unquote(interface_options).to_options()}
-
-            params =
-              unquote(args)
-              |> Enum.zip([unquote_splicing(arg_vars)])
-              |> Enum.reduce(params, fn {key, value}, params ->
-                Map.put(params, key, value)
-              end)
-          end
-
-        resolve_bang_opts_params =
-          quote do
-            {params, opts} =
-              if opts == [] && Keyword.keyword?(params_or_opts),
-                do:
                   {if(params_or_opts != [], do: %{}, else: []),
                    unquote(interface_options).validate!(params_or_opts)
                    |> unquote(interface_options).to_options()},
@@ -1289,7 +1268,7 @@ defmodule Ash.CodeInterface do
                {first_opts_location + 1, interface_options.schema()}
              ]
         def unquote(:"#{interface.name}!")(unquote_splicing(common_args)) do
-          unquote(resolve_bang_opts_params)
+          unquote(resolve_opts_params)
           unquote(resolve_subject)
           unquote(act!)
         end

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -224,7 +224,9 @@ defmodule Ash.CodeInterface do
 
   def params_and_opts([], opts), do: {[], opts}
 
-  def params_and_opts(opts, []) when is_list(opts), do: {%{}, opts}
+  def params_and_opts([%{} | _] = params_list, opts), do: {params_list, opts}
+
+  def params_and_opts(opts, []), do: {%{}, opts}
 
   def params_and_opts(params_or_list, opts) do
     params =

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -217,6 +217,23 @@ defmodule Ash.CodeInterface do
 
   Additionally, if options are set explicitly (i.e. at least one option has
   been set), a keyword list will be converted to a map.
+
+  ## Examples
+
+      iex> params_and_opts(%{key: :param}, [key: :opt])
+      {%{key: :param}, [key: :opt]}
+
+      iex> params_and_opts([key: :opt], [])
+      {%{}, [key: :opt]}
+
+      iex> params_and_opts([], [])
+      {[], []}
+
+      iex> params_and_opts([%{key: :param}], [])
+      {[%{key: :param}], []}
+
+      iex> params_and_opts([key: :param], [key: :opt])
+      {%{key: :param}, [key: :opt]}
   """
   @spec params_and_opts(params_or_opts :: map() | [map()] | keyword(), keyword()) ::
           {params :: map() | [map()], opts :: keyword()}
@@ -274,6 +291,23 @@ defmodule Ash.CodeInterface do
       client value is a keyword list, they'll be merged.
     * `:load` - The default value and the client value will be combined in this
       case.
+
+  ## Examples
+
+      iex> merge_default_opts([key1: 1], key2: 2)
+      [key2: 2, key1: 1]
+
+      iex> merge_default_opts([key2: :client], key1: :default, key2: :default)
+      [key2: :client, key1: :default]
+
+      iex> merge_default_opts([page: false], page: [limit: 100])
+      [page: false]
+
+      iex> merge_default_opts([page: [offset: 2]], page: [limit: 100])
+      [page: [limit: 100, offset: 2]]
+
+      iex> merge_default_opts([load: [:calc2, :rel4]], load: [:calc1, rel1: [:rel2, :rel3]])
+      [load: [:calc1, {:rel1, [:rel2, :rel3]}, :calc2, :rel4]]
   """
   @spec merge_default_opts(keyword(), keyword()) :: keyword()
   def merge_default_opts(opts, default_opts) do

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -507,7 +507,11 @@ defmodule Ash.CodeInterface do
           quote do
             {params, opts} =
               Ash.CodeInterface.params_and_opts(params_or_opts, opts, fn opts ->
-                opts
+                unquote(Macro.escape(interface.default_options))
+                |> Enum.reduce(opts, fn {key, default}, opts_with_defaults ->
+                  Keyword.put_new(opts_with_defaults, key, default)
+                end)
+                |> Keyword.merge(opts)
                 |> unquote(interface_options).validate!()
                 |> unquote(interface_options).to_options()
               end)

--- a/lib/ash/resource/interface.ex
+++ b/lib/ash/resource/interface.ex
@@ -251,7 +251,7 @@ defmodule Ash.Resource.Interface do
       type: :keyword_list,
       default: [],
       doc:
-        "Default options used when none are supplied. These can override domain or action defaults."
+        "Default options to be merged with client-provided options. These can override domain or action defaults."
     ]
   ]
 

--- a/lib/ash/resource/interface.ex
+++ b/lib/ash/resource/interface.ex
@@ -251,7 +251,7 @@ defmodule Ash.Resource.Interface do
       type: :keyword_list,
       default: [],
       doc:
-        "Default options to be merged with client-provided options. These can override domain or action defaults."
+        "Default options to be merged with client-provided options. These can override domain or action defaults. `:load`, `:bulk_options`, and `:page` options will be deep merged."
     ]
   ]
 

--- a/lib/ash/resource/interface.ex
+++ b/lib/ash/resource/interface.ex
@@ -10,6 +10,7 @@ defmodule Ash.Resource.Interface do
     :get_by,
     :get_by_identity,
     :not_found_error?,
+    default_options: [],
     require_reference?: true
   ]
 
@@ -245,6 +246,12 @@ defmodule Ash.Resource.Interface do
       doc: """
       Takes an identity, gets its field list, and performs the same logic as `get_by` with those fields. Adds filters for read, update and destroy actions, replacing the `record` first argument.
       """
+    ],
+    default_options: [
+      type: :any,
+      default: [],
+      doc:
+        "Default options used when none are supplied. These can override domain or action defaults."
     ]
   ]
 

--- a/lib/ash/resource/interface.ex
+++ b/lib/ash/resource/interface.ex
@@ -248,7 +248,7 @@ defmodule Ash.Resource.Interface do
       """
     ],
     default_options: [
-      type: :any,
+      type: :keyword_list,
       default: [],
       doc:
         "Default options used when none are supplied. These can override domain or action defaults."

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -388,6 +388,9 @@ defmodule Ash.Test.CodeInterfaceTest do
   end
 
   test "it handles keyword inputs properly" do
-    assert User.create!("fred", [last_name: "weasley"], actor: nil)
+    assert {:ok, %{last_name: "weasley"}} =
+             User.create("fred", [last_name: "weasley"], actor: nil)
+
+    assert %{last_name: "weasley"} = User.create!("fred", [last_name: "weasley"], actor: nil)
   end
 end

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -27,7 +27,7 @@ defmodule Ash.Test.CodeInterfaceTest do
       define :get_by_id, action: :by_id, get?: true, args: [:id]
       define :create, args: [{:optional, :first_name}]
       define :hello, args: [:name]
-      define :hello_actor, default_options: %{actor: %{name: "William Shatner"}}
+      define :hello_actor, default_options: [actor: %{name: "William Shatner"}]
       define :create_with_map, args: [:map]
       define :update_with_map, args: [:map]
 

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -27,6 +27,7 @@ defmodule Ash.Test.CodeInterfaceTest do
       define :get_by_id, action: :by_id, get?: true, args: [:id]
       define :create, args: [{:optional, :first_name}]
       define :hello, args: [:name]
+      define :hello_actor, default_options: %{actor: %{name: "William Shatner"}}
       define :create_with_map, args: [:map]
       define :update_with_map, args: [:map]
 
@@ -82,6 +83,12 @@ defmodule Ash.Test.CodeInterfaceTest do
 
         run(fn input, _ ->
           {:ok, "Hello #{input.arguments.name}"}
+        end)
+      end
+
+      action :hello_actor, :string do
+        run(fn input, _ ->
+          {:ok, "Hello, #{input.context.private.actor.name}."}
         end)
       end
     end
@@ -392,5 +399,10 @@ defmodule Ash.Test.CodeInterfaceTest do
              User.create("fred", [last_name: "weasley"], actor: nil)
 
     assert %{last_name: "weasley"} = User.create!("fred", [last_name: "weasley"], actor: nil)
+  end
+
+  test "default options" do
+    assert "Hello, Leonard Nimoy." = User.hello_actor!(actor: %{name: "Leonard Nimoy"})
+    assert "Hello, William Shatner." = User.hello_actor!()
   end
 end

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -2,6 +2,8 @@ defmodule Ash.Test.CodeInterfaceTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  doctest Ash.CodeInterface, import: true
+
   alias Ash.Test.Domain, as: Domain
 
   defmodule Notifier do


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

We had discussed [this feature in Discord](https://discord.com/channels/711271361523351632/711271361523351636/1303019179472977930) when I first started messing around with Ash. I figured I'd finally give it a crack.

I did more refactoring. It's probably easier to understand specifically what happened going through the changes commit by commit rather than just looking over the files changed. I left a pretty good trail of what I did.

I wonder if `Ash.CodeInterface.params_and_opts/2` should exist there specifically or perhaps elsewhere. That pattern seems like it's really common.

What is the purpose of allowing keyword parameters? It seems like such a weird feature since it _must_ be paired with non-empty options. 