### PR TITLE
fix: properly handle aggregate defaults in ets/mnesia

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -814,7 +814,7 @@ defmodule Ash.DataLayer.Ets do
         if include_nil? do
           case records do
             [] ->
-              default
+              nil
 
             [record | _rest] ->
               field_value(record, field)
@@ -939,6 +939,10 @@ defmodule Ash.DataLayer.Ets do
                 end
             end
         end
+    end
+    |> case do
+      nil -> default
+      other -> other
     end
   end
 


### PR DESCRIPTION
Right now ETS data layer (and Mnesia because of that) use aggregate default only in case of `first` aggregate kind and only when there are no records - so if the first record has a value of nil then it will return nil. That is not how it is in other data layers or in Ash runtime filter logic - if the resulted aggregate value is nil (because there are no records or because they have nil values) then the default is used. This PR aligns ETS logic with that of sql/runtime ash.