### PR TITLE
fix "except" option handling

### DIFF
--- a/lib/ash/notifier/pub_sub/pub_sub.ex
+++ b/lib/ash/notifier/pub_sub/pub_sub.ex
@@ -482,7 +482,7 @@ defmodule Ash.Notifier.PubSub do
 
   defp matches?(%{action: action}, %{name: action}), do: true
 
-  defp matches?(%{type: type, except: except}, %{type: type, action: action}) do
+  defp matches?(%{type: type, except: except}, %{type: type, name: action}) do
     action not in except
   end
 

--- a/test/notifier/pubsub_test.exs
+++ b/test/notifier/pubsub_test.exs
@@ -30,6 +30,8 @@ defmodule Ash.Test.Notifier.PubSubTest do
       publish :update, ["foo", :id], previous_values?: true
       publish :update, ["bar", :name], event: "name_change", previous_values?: true
       publish :update_pkey, ["foo", :_pkey], previous_values?: true
+
+      publish_all :update, ["baz", :id], event: "any_update", except: [:update_pkey]
     end
 
     ets do
@@ -160,6 +162,8 @@ defmodule Ash.Test.Notifier.PubSubTest do
     assert_receive {:broadcast, ^message, "name_change", %Ash.Notifier.Notification{}}
     message = "post:bar:ted"
     assert_receive {:broadcast, ^message, "name_change", %Ash.Notifier.Notification{}}
+    message = "post:baz:#{post.id}"
+    assert_receive {:broadcast, ^message, "any_update", %Ash.Notifier.Notification{}}
   end
 
   test "publishing a message with a pkey matcher" do
@@ -179,6 +183,8 @@ defmodule Ash.Test.Notifier.PubSubTest do
 
     message = "post:foo:#{new_id}"
     assert_receive {:broadcast, ^message, "update_pkey", %Ash.Notifier.Notification{}}
+    message = "post:baz:#{new_id}"
+    refute_receive {:broadcast, ^message, "any_update", %Ash.Notifier.Notification{}}
   end
 
   test "publishing a message with a different delimiter" do

--- a/test/notifier/pubsub_test.exs
+++ b/test/notifier/pubsub_test.exs
@@ -32,6 +32,7 @@ defmodule Ash.Test.Notifier.PubSubTest do
       publish :update_pkey, ["foo", :_pkey], previous_values?: true
 
       publish_all :update, ["baz", :id], event: "any_update", except: [:update_pkey]
+      publish_all :update, ["fiz", :id], event: "any_update", except: [:doesnotexist]
     end
 
     ets do
@@ -164,6 +165,8 @@ defmodule Ash.Test.Notifier.PubSubTest do
     assert_receive {:broadcast, ^message, "name_change", %Ash.Notifier.Notification{}}
     message = "post:baz:#{post.id}"
     assert_receive {:broadcast, ^message, "any_update", %Ash.Notifier.Notification{}}
+    message = "post:fiz:#{post.id}"
+    assert_receive {:broadcast, ^message, "any_update", %Ash.Notifier.Notification{}}
   end
 
   test "publishing a message with a pkey matcher" do
@@ -185,6 +188,8 @@ defmodule Ash.Test.Notifier.PubSubTest do
     assert_receive {:broadcast, ^message, "update_pkey", %Ash.Notifier.Notification{}}
     message = "post:baz:#{new_id}"
     refute_receive {:broadcast, ^message, "any_update", %Ash.Notifier.Notification{}}
+    message = "post:fiz:#{new_id}"
+    assert_receive {:broadcast, ^message, "any_update", %Ash.Notifier.Notification{}}
   end
 
   test "publishing a message with a different delimiter" do


### PR DESCRIPTION
My previous patch had a bug – wrong key for action name