### PR TITLE
chore: Optionally use JSON when available

### DIFF
--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -647,4 +647,12 @@ defmodule Ash.Helpers do
 
     :ok
   end
+
+  def json_module do
+    if Code.ensure_loaded?(JSON) do
+      JSON
+    else
+      Jason
+    end
+  end
 end

--- a/lib/ash/query/function/error.ex
+++ b/lib/ash/query/function/error.ex
@@ -12,6 +12,9 @@ defmodule Ash.Query.Function.Error do
   def returns, do: :no_return
 
   def evaluate(%{arguments: [exception, input]}) do
-    {:error, Ash.Error.from_json(exception, Jason.decode!(Jason.encode!(Map.new(input))))}
+    json_module = Ash.Helpers.json_module()
+
+    {:error,
+     Ash.Error.from_json(exception, json_module.decode!(json_module.encode!(Map.new(input))))}
   end
 end

--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -1,4 +1,5 @@
 defmodule Ash.Query.Operator.Basic do
+  @moduledoc false
   require Decimal
 
   @operators [

--- a/lib/ash/type/keyword.ex
+++ b/lib/ash/type/keyword.ex
@@ -80,7 +80,7 @@ defmodule Ash.Type.Keyword do
   def cast_input(nil, _), do: {:ok, nil}
 
   def cast_input(value, constraints) when is_binary(value) do
-    case Jason.decode(value) do
+    case Ash.Helpers.json_module().decode(value) do
       {:ok, value} ->
         cast_input(value, constraints)
 

--- a/lib/ash/type/map.ex
+++ b/lib/ash/type/map.ex
@@ -81,7 +81,7 @@ defmodule Ash.Type.Map do
   def cast_input(nil, _), do: {:ok, nil}
 
   def cast_input(value, constraints) when is_binary(value) do
-    case Jason.decode(value) do
+    case Ash.Helpers.json_module().decode(value) do
       {:ok, value} ->
         cast_input(value, constraints)
 

--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -96,7 +96,7 @@ defmodule Ash.Type.Struct do
   def cast_input(nil, _), do: {:ok, nil}
 
   def cast_input(value, constraints) when is_binary(value) do
-    case Jason.decode(value) do
+    case Ash.Helpers.json_module().decode(value) do
       {:ok, value} ->
         cast_input(value, constraints)
 


### PR DESCRIPTION
- Add `Ash.Helpers.json_module/0` that uses Elixir's `JSON` module when loaded.  Otherwise it returns `Jason`.  This will enable `Jason` to be set as an optional dependency in future Ash versions and allow any libraries depending on Ash to leverage the same `json_module` Ash uses.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [x] Update dependencies
