### PR TITLE
fix: Fix typo in `initial_data`

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -201,7 +201,7 @@ defmodule Ash.Actions.Read do
           initial_limit: query.limit,
           initial_offset: query.offset,
           page_opts:
-            if !opts[:inital_data] do
+            if !opts[:initial_data] do
               page_opts
             end,
           initial_query: query,


### PR DESCRIPTION
I randomly came across this typo while looking at a diff for another issue I'm facing.

Now, I don't know what this code is for, and this condition would have never passed before, so this change might have unintended effects.

The tests pass both before and after making the change, so either it's not tested or the conditional has no impact here anyway.