### PR TITLE
fix: Fix issues in `Ash.Generator.generate_many/2`

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -12,7 +12,7 @@ defmodule Ash.Generator do
     use Ash.Generator
 
     # using `seed_generator`, bypasses the action and saves directly to the data layer
-    def blog_post(opts \\ []) do
+    def blog_post(opts \\\\ []) do
       seed_generator(
         %MyApp.Blog.Post{
           name: sequence(:title, &"My Blog Post \#{&1}")
@@ -23,7 +23,7 @@ defmodule Ash.Generator do
     end
 
     # using `changeset_generator`, calls the action when passed to `generate`
-    def blog_post_comment(opts \\ []) do
+    def blog_post_comment(opts \\\\ []) do
       blog_post_id = opts[:blog_post_id] || once(:default_blog_post_id, fn -> generate(blog_post()).id end)
 
       changeset_generator(
@@ -641,7 +641,7 @@ defmodule Ash.Generator do
   Generate input meant to be passed into `Ash.Seed.seed!/2`.
 
   A map of custom `StreamData` generators can be provided to add to or overwrite the generated input,
-  for example: `Ash.Generator.for_seed(Post, %{text: StreamData.constant("Post")})`
+  for example: `Ash.Generator.seed_input(Post, %{text: StreamData.constant("Post")})`
   """
   @spec seed_input(Ash.Resource.t(), map()) :: StreamData.t(map())
   def seed_input(resource, generators \\ %{}) do

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -513,7 +513,8 @@ defmodule Ash.Generator do
         Ash.bulk_create!(Enum.map(batch, & &1.params), first.resource, first.action.name,
           after_action: after_action,
           return_records?: true,
-          return_errors?: true
+          return_errors?: true,
+          actor: first.context[:private][:actor]
         ).records || []
 
       batch ->

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -519,6 +519,10 @@ defmodule Ash.Generator do
             actor: first.context[:private][:actor]
           )
 
+        if result.status != :success do
+          raise Ash.Error.to_error_class(result.errors)
+        end
+
         Ash.Notifier.notify(result.notifications)
 
         result.records || []

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -505,11 +505,15 @@ defmodule Ash.Generator do
             fn _changeset, record ->
               {:ok, after_action.(record)}
             end
+          else
+            # Do nothing
+            fn _changeset, record -> {:ok, record} end
           end
 
-        Ash.bulk_create!(Enum.map(batch, & &1.params), first.resource, first.action,
+        Ash.bulk_create!(Enum.map(batch, & &1.params), first.resource, first.action.name,
           after_action: after_action,
-          return_records?: true
+          return_records?: true,
+          return_errors?: true
         ).records || []
 
       batch ->

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -510,12 +510,18 @@ defmodule Ash.Generator do
             fn _changeset, record -> {:ok, record} end
           end
 
-        Ash.bulk_create!(Enum.map(batch, & &1.params), first.resource, first.action.name,
-          after_action: after_action,
-          return_records?: true,
-          return_errors?: true,
-          actor: first.context[:private][:actor]
-        ).records || []
+        result =
+          Ash.bulk_create!(Enum.map(batch, & &1.params), first.resource, first.action.name,
+            after_action: after_action,
+            return_records?: true,
+            return_errors?: true,
+            return_notifications?: true,
+            actor: first.context[:private][:actor]
+          )
+
+        Ash.Notifier.notify(result.notifications)
+
+        result.records || []
 
       batch ->
         Enum.map(batch, fn record ->


### PR DESCRIPTION
When testing out `generate_many/2` I found there were a couple of issues with it:

* It would error if `after_action: nil` was passed to `bulk_create`
* It would error if the full action struct was passed to `bulk_create` (instead of just the action name)
* It would error if the action passed to `bulk_create` required authorization (no actor being passed in)
* It would raise warnings if the action used in `bulk_create` generated any notifications (tbh I'm not sure *why* the action I'm testing with is generating notifications, but that's a different story)
* It would ignore partial success results, leading to random test failures due to intermittent erroneous generator data

With these changes I can successfully call `generate_many` like `generate_many(artist(), 2)` and get two Artist records back.