### PR TITLE
chore(`Ash.Test`): Updates to `assert_has_error` and `refute_has_error` to accept `:ok` tuples

### DIFF
--- a/lib/ash/test.ex
+++ b/lib/ash/test.ex
@@ -95,11 +95,43 @@ defmodule Ash.Test do
   Use the optional second argument to assert that the errors (all together) are of a specific class.
   """
   @spec refute_has_error(
-          Ash.Changeset.t() | Ash.Query.t() | Ash.ActionInput.t(),
+          Ash.Changeset.t() | Ash.Query.t() | Ash.ActionInput.t() | {:ok, term} | {:error, term},
           error_class :: Ash.Error.class_module(),
           (Ash.Error.t() -> boolean)
         ) :: Ash.Error.t() | no_return
-  def refute_has_error(changeset_query_or_input, error_class \\ nil, callback, opts \\ []) do
+  def refute_has_error(changeset_query_or_input, error_class \\ nil, callback, opts \\ [])
+
+  # An :ok tuple doesn't have any errors!
+  def refute_has_error({:ok, _record}, _error_class, _callback, _opts), do: :ok
+
+  def refute_has_error({:error, %{splode: splode} = error}, error_class, callback, opts) do
+    error = splode.to_class(error)
+
+    if error_class do
+      ExUnit.Assertions.assert(error.__struct__ != error_class,
+        message:
+          "Expected the value not to have errors of class #{inspect(error_class)}, got: #{inspect(error, pretty: true)}"
+      )
+    end
+
+    match = Enum.find(error.errors, callback)
+
+    ExUnit.Assertions.assert(!match,
+      message:
+        opts[:message] ||
+          """
+          Expected no errors to match the provided callback, but one did.
+
+          Errors:
+
+          #{inspect(match, pretty: true)}
+          """
+    )
+
+    match
+  end
+
+  def refute_has_error(changeset_query_or_input, error_class, callback, opts) do
     type =
       case changeset_query_or_input do
         %Ash.Changeset{} -> "changeset"

--- a/lib/ash/test.ex
+++ b/lib/ash/test.ex
@@ -11,7 +11,7 @@ defmodule Ash.Test do
   Use the optional second argument to assert that the errors (all together) are of a specific class.
   """
   @spec assert_has_error(
-          Ash.Changeset.t() | Ash.Query.t() | Ash.ActionInput.t() | {:error, term},
+          Ash.Changeset.t() | Ash.Query.t() | Ash.ActionInput.t() | {:error, term} | {:ok, term},
           error_class :: Ash.Error.class_module(),
           (Ash.Error.t() -> boolean)
         ) :: Ash.Error.t() | no_return
@@ -42,6 +42,17 @@ defmodule Ash.Test do
     )
 
     match
+  end
+
+  def assert_has_error({:ok, _record}, error_class, _callback, _opts) do
+    message =
+      if error_class do
+        "Expected the value to have errors of class #{inspect(error_class)}, but it had no errors"
+      else
+        "Expected the value to have errors matching the provided callback, but it had no errors"
+      end
+
+    ExUnit.Assertions.assert(false, message: message)
   end
 
   def assert_has_error(changeset_query_or_input, error_class, callback, opts) do

--- a/lib/ash/test.ex
+++ b/lib/ash/test.ex
@@ -100,7 +100,7 @@ defmodule Ash.Test do
   @doc """
   Refute that the given changeset, query, or action input has a matching error.
 
-  Use the optional second argument to assert that the errors (all together) are of a specific class.
+  The `error_class` argument has been deprecated and should not be used.
   """
   @spec refute_has_error(
           Ash.Changeset.t()
@@ -119,15 +119,11 @@ defmodule Ash.Test do
   def refute_has_error({:ok, _record}, _error_class, _callback, _opts), do: :ok
 
   def refute_has_error({:error, error}, error_class, callback, opts) do
-    error = Ash.Error.to_error_class(error)
-
-    if error_class do
-      ExUnit.Assertions.assert(error.__struct__ != error_class,
-        message:
-          "Expected the value not to have errors of class #{inspect(error_class)}, got: #{inspect(error, pretty: true)}"
-      )
+    if error_class != nil do
+      IO.warn("`error_class` argument to `refute_has_error` is deprecated and will be ignored")
     end
 
+    error = Ash.Error.to_error_class(error)
     match = Enum.find(error.errors, callback)
 
     ExUnit.Assertions.assert(!match,
@@ -146,22 +142,11 @@ defmodule Ash.Test do
   end
 
   def refute_has_error(changeset_query_or_input, error_class, callback, opts) do
-    type =
-      case changeset_query_or_input do
-        %Ash.Changeset{} -> "changeset"
-        %Ash.Query{} -> "query"
-        %Ash.ActionInput{} -> "action input"
-      end
-
-    error = Ash.Error.to_error_class(changeset_query_or_input)
-
-    if error_class do
-      ExUnit.Assertions.assert(error.__struct__ == error_class,
-        message:
-          "Expected the #{type} to have errors of class #{inspect(error_class)}, got: #{inspect(error.__struct__)}"
-      )
+    if error_class != nil do
+      IO.warn("`error_class` argument to `refute_has_error` is deprecated and will be ignored")
     end
 
+    error = Ash.Error.to_error_class(changeset_query_or_input)
     match = Enum.find(error.errors, callback)
 
     ExUnit.Assertions.refute(match,

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -198,9 +198,7 @@ defmodule Ash.Test.ErrorTest do
         err.error == "whoops!"
       end)
 
-      Ash.Test.refute_has_error(cs, Ash.Error.Unknown, fn err ->
-        err.error == "yay!"
-      end)
+      Ash.Test.refute_has_error(cs, fn err -> err.error == "yay!" end)
 
       assert clean(Ash.Error.to_error_class(cs)) ==
                clean(Ash.Error.to_error_class([error1, error2], changeset: cs))

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -29,6 +29,10 @@ defmodule Ash.Test.ErrorTest do
     actions do
       default_accept :*
       defaults [:read, :destroy, create: :*, update: :*]
+
+      create :create_with_error do
+        validate attribute_equals(:id, false)
+      end
     end
 
     attributes do
@@ -230,6 +234,122 @@ defmodule Ash.Test.ErrorTest do
       error = Ash.Error.to_ash_error("whoops!", nil, bread_crumbs: "some context")
 
       assert error.bread_crumbs == ["some context"]
+    end
+  end
+
+  describe "assert_has_error" do
+    test "raises if the value is :ok" do
+      assert_raise ExUnit.AssertionError, ~r/it had no errors/, fn ->
+        Ash.Test.assert_has_error(:ok, Ash.Error.Invalid, fn _err -> true end)
+      end
+    end
+
+    test "raises if the value is an :ok tuple" do
+      assert_raise ExUnit.AssertionError, ~r/it had no errors/, fn ->
+        Ash.Test.assert_has_error(
+          {:ok, :something_successful},
+          Ash.Error.Invalid,
+          fn _err -> true end
+        )
+      end
+    end
+
+    test "raises if the value doesn't have any errors of the expected type" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected the changeset to have errors of class Ash.Error.Unknown/,
+                   fn ->
+                     Ash.Test.assert_has_error(changeset, Ash.Error.Unknown, fn _err -> true end)
+                   end
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected the value to have errors of class Ash.Error.Unknown/,
+                   fn ->
+                     Ash.Test.assert_has_error(error, Ash.Error.Unknown, fn _err -> true end)
+                   end
+    end
+
+    test "raises if the value has an error of the expected type but doesn't pass the callback" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected at least one error to match the provided callback/,
+                   fn ->
+                     Ash.Test.assert_has_error(changeset, Ash.Error.Invalid, fn _err -> false end)
+                   end
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected at least one error to match the provided callback/,
+                   fn ->
+                     Ash.Test.assert_has_error(error, Ash.Error.Invalid, fn _err -> false end)
+                   end
+    end
+
+    test "raises if the value doesn't pass the callback" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected at least one error to match the provided callback/,
+                   fn -> Ash.Test.assert_has_error(changeset, fn _err -> false end) end
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected at least one error to match the provided callback/,
+                   fn -> Ash.Test.assert_has_error(error, fn _err -> false end) end
+    end
+
+    test "passes if the value matches the type and passes the callback" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      assert Ash.Test.assert_has_error(changeset, Ash.Error.Invalid, fn _err -> true end)
+      assert Ash.Test.assert_has_error(error, Ash.Error.Invalid, fn _err -> true end)
+    end
+
+    test "passes if the value passes the callback" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      assert Ash.Test.assert_has_error(changeset, fn _err -> true end)
+      assert Ash.Test.assert_has_error(error, fn _err -> true end)
+    end
+  end
+
+  describe "refute_has_error" do
+    test "passes if the value is :ok" do
+      Ash.Test.refute_has_error(:ok, fn _err -> true end)
+    end
+
+    test "passes if the value is an :ok tuple" do
+      Ash.Test.refute_has_error({:ok, :something_successful}, fn _err -> true end)
+    end
+
+    test "passes if the value doesn't pass the callback" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      Ash.Test.refute_has_error(changeset, fn _err -> false end)
+      Ash.Test.refute_has_error(error, fn _err -> false end)
+    end
+
+    test "raises if the value passes the callback" do
+      changeset = Ash.Changeset.for_create(TestResource, :create_with_error)
+      error = Ash.create(changeset)
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected no errors to match the provided callback/,
+                   fn ->
+                     Ash.Test.refute_has_error(changeset, fn _err -> true end)
+                   end
+
+      assert_raise ExUnit.AssertionError,
+                   ~r/Expected no errors to match the provided callback/,
+                   fn ->
+                     Ash.Test.refute_has_error(error, fn _err -> true end)
+                   end
     end
   end
 


### PR DESCRIPTION
Currently if you set up an assertion like the following:

```elixir
%{artist_id: artist.id, name: "test 1960", year_released: 1960}
|> Music.create_album(actor: admin)
|> assert_has_error(Ash.Error.Invalid, "a dummy callback")
```

when the `create_album` call actually succeeds, `assert_has_error` will have a `CaseClauseError`:

```
 1) test validations year_released must be between 1950 and now (TunezWeb.Music.AlbumTest)
     test/tunez/music/album_test.exs:156
     ** (CaseClauseError) no case clause matching: {:ok, #Tunez.Music.Album<duration: #Ash.NotLoaded<:calculation, field: :duration>, ...>}
     code: |> assert_has_error(Ash.Error.Invalid)
     stacktrace:
       (ash 3.4.54) lib/ash/test.ex:49: Ash.Test.assert_has_error/4
       test/tunez/music/album_test.exs:190: (test)
```

In this case, I think it's pretty safe to generate a failed assertion - you were expecting a specific error, there were no errors at all, so the test will always fail. Now it will show:

```
  1) test validations year_released must be between 1950 and now (TunezWeb.Music.AlbumTest)
     test/tunez/music/album_test.exs:156
     Expected the value to have errors of class Ash.Error.Invalid, but it had no errors
     code: |> assert_has_error(Ash.Error.Invalid)
```

`refute_has_error` has similar issues, though it won't accept either `:ok` tuples *or* `:error` tuples. Now it will:

```elixir
# This now passes instead of case clause error
%{artist_id: artist.id, name: "test 1960", year_released: 1960}
|> Music.create_album(actor: admin)
|> refute_has_error(Ash.Error.Invalid)

# This has an error of the listed type
%{artist_id: artist.id, name: "test 1930", year_released: 1930}
|> Music.create_album(actor: admin)
|> refute_has_error(Ash.Error.Invalid, fn _ -> true end)
```
```
  1) test validations year_released must be between 1950 and now (TunezWeb.Music.AlbumTest)
     test/tunez/music/album_test.exs:156
     Expected the value not to have errors of class Ash.Error.Invalid, got: %Ash.Error.Invalid{
       bread_crumbs: ["Error returned from: Tunez.Music.Album.create"],
       changeset: "#Changeset<>",
       errors: [
         %Ash.Error.Changes.InvalidAttribute{...
```
```elixir        
# This has an error of a different type, but matching the callback
%{artist_id: artist.id, name: "test 1930", year_released: 1930}
|> Music.create_album(actor: admin)
|> refute_has_error(Ash.Error.Invalid2, fn _ -> true end)
```
```
  1) test validations year_released must be between 1950 and now (TunezWeb.Music.AlbumTest)
     test/tunez/music/album_test.exs:156
     Expected no errors to match the provided callback, but one did.

     Errors:

     %Ash.Error.Changes.InvalidAttribute{...

```

If you'll accept this PR, I can add new tests to cover the functionality.