### PR TITLE
chore: Add failing test for `Ash.can?` for `get? true` actions with authorization applied

### DIFF
--- a/test/policy/rbac_test.exs
+++ b/test/policy/rbac_test.exs
@@ -95,6 +95,14 @@ defmodule Ash.Test.Policy.RbacTest do
     assert Ash.can?({File, :read, %{}}, user)
     refute Ash.can?({File, :read, %{}}, user, data: [file1, file2])
     assert Ash.can?({File, :read, %{}}, user, data: file_with_access)
+
+    assert Ash.can?({File, :get_by_id, %{id: file_with_access.id}}, user, data: file_with_access)
+    refute Ash.can?({File, :get_by_id, %{id: file1.id}}, user, data: file1)
+    refute Ash.can?({File, :get_by_id, %{id: file2.id}}, user, data: file2)
+
+    assert File.can_get_by_id?(user, file_with_access.id, data: file_with_access)
+    refute File.can_get_by_id?(user, file1.id, data: file1)
+    refute File.can_get_by_id?(user, file2.id, data: file2)
   end
 
   test "if the query can be performed, the can utility should return true", %{

--- a/test/support/policy_rbac/resources/file.ex
+++ b/test/support/policy_rbac/resources/file.ex
@@ -27,6 +27,16 @@ defmodule Ash.Test.Support.PolicyRbac.File do
   actions do
     default_accept :*
     defaults [:read, :destroy, create: :*, update: :*]
+
+    read :get_by_id do
+      get? true
+      argument :id, :string, allow_nil?: false
+      filter expr(id == ^arg(:id))
+    end
+  end
+
+  code_interface do
+    define :get_by_id, args: [:id]
   end
 
   attributes do


### PR DESCRIPTION
Add a failing test for arguments not being passed to queries when testing `can_*` actions for code interfaces.

Prior to [df66222](https://github.com/ash-project/ash/commit/df6622207d04c1b23cc6398946c42d1f645f04ab) this test failed with the following error:

```
  1) test if the action can be performed, the can utility should return true (Ash.Test.Policy.RbacTest)
     test/policy/rbac_test.exs:82
     ** (Ash.Error.Invalid)
     Invalid Error

     * argument id is required
       (ash 3.4.54) lib/ash/error/query/required.ex:5: Ash.Error.Query.Required.exception/1
       (ash 3.4.54) lib/ash/query/query.ex:674: anonymous fn/2 in Ash.Query.require_arguments/2
       (elixir 1.18.0) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ash 3.4.54) lib/ash/query/query.ex:591: Ash.Query.for_read/4
       (ash 3.4.54) lib/ash/code_interface.ex:688: Ash.Test.Support.PolicyRbac.File.can_get_by_id?/4
```