### PR TITLE
Add `Ash.Type.EctoType.autogenerate/1` for drop in replacement with existing Ecto Schemas

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -1638,6 +1638,15 @@ defmodule Ash.Type do
 
         @impl true
         def embed_as(_, _), do: :self
+
+        if Keyword.get(unquote(opts), :autogenerate_enabled?) do
+          @impl true
+          def autogenerate(constraints) do
+            constraints
+            |> @parent.generator()
+            |> Enum.at(0)
+          end
+        end
       end
 
       @impl true

--- a/lib/ash/type/uuid.ex
+++ b/lib/ash/type/uuid.ex
@@ -5,7 +5,8 @@ defmodule Ash.Type.UUID do
   A builtin type that can be referenced via `:uuid`
   """
 
-  use Ash.Type
+  use Ash.Type,
+    autogenerate_enabled?: true
 
   @impl true
   def storage_type(_), do: :uuid

--- a/lib/ash/type/uuid_v7.ex
+++ b/lib/ash/type/uuid_v7.ex
@@ -5,7 +5,8 @@ defmodule Ash.Type.UUIDv7 do
   A builtin type that can be referenced via `:uuid_v7`
   """
 
-  use Ash.Type
+  use Ash.Type,
+    autogenerate_enabled?: true
 
   @impl true
   def storage_type(_), do: :uuid


### PR DESCRIPTION
# Contributor checklist

Closes #1714 

- Adds `autogenerate_enabled?` option to `Ash.Type`.  When true `Ash.Type.EctoType.autogenerate/1` is added to the module.
- Adds `Ash.Type.EctoType.autogenerate/1` which mirrors `Ecto.ParamaterizedType.autogenerate/1` so Ash types like `Ash.Type.UUID.EctoType` and `Ash.Type.UUIDv7.EctoType` can be drop ins for existing Ecto schemas `@primary_key` and `@foreign_key_type` schema module attributes.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
