### PR TITLE
Improvement: handle for read without args

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -523,7 +523,12 @@ defmodule Ash.Query do
   #{Spark.Options.docs(@for_read_opts)}
 
   """
-  def for_read(query, action_name, args \\ %{}, opts \\ []) do
+  def for_read(query, action_name, args \\ %{}, opts \\ [])
+
+  def for_read(query, action_name, opts, _) when is_list(opts),
+    do: for_read(query, action_name, %{}, opts)
+
+  def for_read(query, action_name, args, opts) do
     query = new(query)
 
     domain =

--- a/test/resource/preparations/lifecycle_hooks_test.exs
+++ b/test/resource/preparations/lifecycle_hooks_test.exs
@@ -69,7 +69,7 @@ defmodule Ash.Test.Resource.Preparations.LifecycleHooksTest do
   describe "before_action/1" do
     test "it is called before the action is run" do
       TimeMachine
-      |> Ash.Query.for_read(:read_with_before_action, caller: self())
+      |> Ash.Query.for_read(:read_with_before_action, %{caller: self()})
       |> Ash.read!()
 
       assert_received :before_action
@@ -77,7 +77,7 @@ defmodule Ash.Test.Resource.Preparations.LifecycleHooksTest do
 
     test "multiple before actions have the same phase" do
       TimeMachine
-      |> Ash.Query.for_read(:read_with_multiple_before_actions, caller: self())
+      |> Ash.Query.for_read(:read_with_multiple_before_actions, %{caller: self()})
       |> Ash.read!()
 
       assert_received {:before_action, 1}
@@ -88,7 +88,7 @@ defmodule Ash.Test.Resource.Preparations.LifecycleHooksTest do
   describe "after_action/1" do
     test "it is called after the action is run" do
       TimeMachine
-      |> Ash.Query.for_read(:read_with_after_action, caller: self())
+      |> Ash.Query.for_read(:read_with_after_action, %{caller: self()})
       |> Ash.read!()
 
       assert_received :after_action
@@ -96,7 +96,7 @@ defmodule Ash.Test.Resource.Preparations.LifecycleHooksTest do
 
     test "multiple after actions have the same phase" do
       TimeMachine
-      |> Ash.Query.for_read(:read_with_multiple_after_actions, caller: self())
+      |> Ash.Query.for_read(:read_with_multiple_after_actions, %{caller: self()})
       |> Ash.read!()
 
       assert_received {:after_action, 1}


### PR DESCRIPTION
#1551 
The
```
  def for_read(query, action_name, opts, _) when is_list(opts),
    do: for_read(query, action_name, %{}, opts)
```
kinda bugs me 🐞 but if it's better it's better. 🤷 
Also to note, some tests failed because caller was written as a keyword list and was considered as `args` and it worked. 🤔 
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
