### PR TITLE
fix: Compilation failure when using the `ash_step` Reactor DSL.

### DIFF
--- a/lib/ash/reactor/builders/ash_step.ex
+++ b/lib/ash/reactor/builders/ash_step.ex
@@ -14,13 +14,10 @@ defimpl Reactor.Dsl.Build, for: Ash.Reactor.Dsl.AshStep do
         ash_step.impl,
         ash_step.arguments,
         async?: ash_step.async?,
-        compensate: ash_step.compensate,
         guards: ash_step.guards,
         max_retries: ash_step.max_retries,
         ref: :step_name,
-        run: ash_step.run,
-        transform: ash_step.transform,
-        undo: ash_step.undo
+        transform: ash_step.transform
       )
     end
   end

--- a/test/reactor/ash_step_test.exs
+++ b/test/reactor/ash_step_test.exs
@@ -1,0 +1,22 @@
+defmodule Ash.Test.ReactorAshStepTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule GenericAshStep do
+    @moduledoc false
+    use Ash.Reactor
+    input(:title)
+
+    ash_step :generic_ash_step do
+      argument :title, input(:title)
+
+      run fn input, _context ->
+        {:ok, "hello #{input.title}"}
+      end
+    end
+  end
+
+  test "it runs the step" do
+    assert {:ok, "hello world"} = Reactor.run(GenericAshStep, %{title: "world"})
+  end
+end


### PR DESCRIPTION
These options were always just ignored but now are rejected because Reactor validations options now.
