### PR TITLE
fix: type struct handle instance of return error tuple

### DIFF
--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -271,7 +271,7 @@ defmodule Ash.Type.Struct do
             {:ok, value}
 
           is_struct(value) ->
-            {:error, "-> constraints: -> instance_of: #{struct}"}
+            {:error, "is invalid"}
 
           true ->
             if constraints[:fields] do

--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -271,7 +271,7 @@ defmodule Ash.Type.Struct do
             {:ok, value}
 
           is_struct(value) ->
-            :error
+            {:error, "-> constraints: -> instance_of: #{struct}"}
 
           true ->
             if constraints[:fields] do
@@ -300,7 +300,7 @@ defmodule Ash.Type.Struct do
         if is_struct(value) do
           {:ok, value}
         else
-          :error
+          {:error, "is invalid"}
         end
     end
   end

--- a/test/type/struct_test.exs
+++ b/test/type/struct_test.exs
@@ -246,7 +246,7 @@ defmodule Type.StructTest do
     assert [
              %Ash.Error.Changes.InvalidArgument{
                field: :dummy_metadata,
-               message: "-> constraints: -> instance_of: Elixir.NonExistingModule",
+               message: "is invalid",
                bread_crumbs: [],
                vars: [],
                path: []


### PR DESCRIPTION
#1754 

Not sure about the error messages, took a guess. I also added `"is invalid"` for the last error. Although I couldn't figure out how to trigger that.
Also should `Elixir.` part be shown 🤔 
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
