### PR TITLE
Fix: Include warning for arguments only when 'things' are arguments

### DIFF
--- a/lib/ash/resource/verifiers/verify_primary_read_action_has_no_arguments.ex
+++ b/lib/ash/resource/verifiers/verify_primary_read_action_has_no_arguments.ex
@@ -41,8 +41,7 @@ defmodule Ash.Resource.Verifiers.VerifyPrimaryReadActionHasNoArguments do
     This is often done by mistake, but can also be done intentionally.
 
     Primary read actions are used when loading relationships, checking policies and more.
-    It is okay to have optional arguments, but required arguments are almost never desired.
-
+    #{if things == "arguments", do: "It is okay to have optional arguments, but required arguments are almost never desired.\n", else: ""}
     If you intended to have #{things} on your primary read action, add `primary_read_warning?: false`
     to `use Ash.Resource`. For example:
 


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
