### PR TITLE
Add field names to identities

### DIFF
--- a/documentation/topics/resources/identities.md
+++ b/documentation/topics/resources/identities.md
@@ -17,6 +17,9 @@ defmodule MyApp.MyResource do
 
     # If the `username` attribute must be unique for every record with a given `site` value
     identity :special_usernames, [:username, :site]
+
+    # If the `user_id` field should hold the errors for the uniqueness violation
+    identity :unique_email, [:email], field_names: [:user_id]
   end
 end
 ```

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -2236,7 +2236,7 @@ defmodule Ash.Changeset do
             {:ok, _} ->
               error =
                 Ash.Error.Changes.InvalidChanges.exception(
-                  fields: identity.keys,
+                  fields: identity.field_names || identity.keys,
                   message: identity.message || "has already been taken"
                 )
 

--- a/lib/ash/resource/identity.ex
+++ b/lib/ash/resource/identity.ex
@@ -13,6 +13,7 @@ defmodule Ash.Resource.Identity do
     :name,
     :keys,
     :description,
+    :field_names,
     :message,
     :eager_check?,
     :eager_check_with,
@@ -70,6 +71,10 @@ defmodule Ash.Resource.Identity do
     description: [
       type: :string,
       doc: "An optional description for the identity"
+    ],
+    field_names: [
+      type: {:wrap_list, :atom},
+      doc: "The field names to hold errors when unique identity is violated."
     ],
     message: [
       type: :string,

--- a/test/actions/identity_test.exs
+++ b/test/actions/identity_test.exs
@@ -17,6 +17,7 @@ defmodule Ash.Test.Actions.IdentityTest do
     identities do
       identity :unique_title, [:title] do
         eager_check_with(Domain)
+        field_names([:title, :slug])
       end
 
       identity :unique_url, [:url] do
@@ -56,7 +57,7 @@ defmodule Ash.Test.Actions.IdentityTest do
                valid?: false,
                errors: [
                  %Ash.Error.Changes.InvalidChanges{
-                   fields: [:title],
+                   fields: [:title, :slug],
                    message: "has already been taken"
                  }
                ]

--- a/test/resource/identities_test.exs
+++ b/test/resource/identities_test.exs
@@ -87,6 +87,26 @@ defmodule Ash.Test.Resource.IdentitiesTest do
              ] = Ash.Resource.Info.identities(Post)
     end
 
+    test "Identity field names are allowed" do
+      defposts do
+        actions do
+          default_accept :*
+
+          read :read do
+            primary? true
+          end
+        end
+
+        identities do
+          identity :foobar, [:name, :contents], field_names: [:contents]
+        end
+      end
+
+      assert [
+               %Ash.Resource.Identity{field_names: [:contents]}
+             ] = Ash.Resource.Info.identities(Post)
+    end
+
     test "enforce identity domain is inferred" do
       assert_raise Spark.Error.DslError,
                    ~r/Cannot infer eager_check_with, because the domain is not specified on this resource./,


### PR DESCRIPTION
This PR add `field_names` option to identities. It will work in tandem with https://github.com/ash-project/ash_postgres/pull/478

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
