### PR TITLE
4.0: Return a single record from `Ash.read` when the action has `get?: true`

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -2191,7 +2191,7 @@ defmodule Ash do
   defp do_read_one(query, action, opts) do
     query
     |> Ash.Actions.Read.unpaginated_read(action, opts)
-    |> Ash.Helpers.unwrap_one()
+    |> Ash.Helpers.unwrap_one_if(!action.get?)
     |> case do
       {:ok, nil} ->
         if opts[:not_found_error?] do

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -20,8 +20,9 @@ defmodule Ash.Actions.Read do
   end
 
   @spec run(Ash.Query.t(), Ash.Resource.Actions.action(), Keyword.t()) ::
-          {:ok, Ash.Page.page() | list(Ash.Resource.record())}
-          | {:ok, Ash.Page.page() | list(Ash.Resource.record()), Ash.Query.t()}
+          {:ok, Ash.Page.page() | Ash.Resource.record() | list(Ash.Resource.record())}
+          | {:ok, Ash.Page.page() | Ash.Resource.record() | list(Ash.Resource.record()),
+             Ash.Query.t()}
           | {:error, term}
   def run(query, action, opts \\ [])
 
@@ -373,6 +374,7 @@ defmodule Ash.Actions.Read do
           query,
           opts
         )
+        |> unwrap_if_get(query.action)
         |> add_query(query, opts)
       else
         {:error, %Ash.Query{errors: errors} = query} ->
@@ -1836,6 +1838,17 @@ defmodule Ash.Actions.Read do
       {:ok, result, query}
     else
       {:ok, result}
+    end
+  end
+
+  defp unwrap_if_get(result, action) do
+    if action && action.get? do
+      case result do
+        [] -> nil
+        [record | _] -> record
+      end
+    else
+      result
     end
   end
 

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -2246,6 +2246,9 @@ defmodule Ash.Changeset do
             {:ok, nil} ->
               changeset
 
+            {:ok, []} ->
+              changeset
+
             {:ok, _} ->
               error =
                 Ash.Error.Changes.InvalidChanges.exception(

--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -298,6 +298,14 @@ defmodule Ash.Helpers do
     end
   end
 
+  def unwrap_one_if(result, condition) do
+    if condition do
+      unwrap_one(result)
+    else
+      result
+    end
+  end
+
   def unwrap_one({:error, error}) do
     {:error, error}
   end
@@ -337,6 +345,10 @@ defmodule Ash.Helpers do
       )
 
     {:error, error}
+  end
+
+  def unwrap_one(struct) when is_struct(struct) do
+    {:ok, struct}
   end
 
   def resource_from_data!(data, query, opts) do

--- a/test/actions/read_test.exs
+++ b/test/actions/read_test.exs
@@ -81,10 +81,12 @@ defmodule Ash.Test.Actions.ReadTest do
       end
 
       read :get_by_id do
+        get?(true)
         get_by(:id)
       end
 
       read :get_by_id_and_uuid do
+        get?(true)
         get_by([:id, :uuid])
       end
     end
@@ -399,6 +401,25 @@ defmodule Ash.Test.Actions.ReadTest do
                Post
                |> Ash.Query.limit(1)
                |> Ash.Query.offset(1)
+               |> Ash.read()
+    end
+
+    test "with get?: true actions, it returns the record instead of a list" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "test", contents: "yeet"})
+        |> Ash.create!()
+
+      assert {:ok, %Post{}} =
+               Post
+               |> Ash.Query.for_read(:get_by_id, %{id: post.id})
+               |> Ash.read()
+    end
+
+    test "with get?: true actions, it returns nil for missing records" do
+      assert {:ok, nil} =
+               Post
+               |> Ash.Query.for_read(:get_by_id, %{id: Ash.UUID.generate()})
                |> Ash.read()
     end
   end


### PR DESCRIPTION
Closes https://github.com/ash-project/ash/issues/1628

> Make get?: true read actions cause Ash.read to return a single record, just like pagination causes it to return a page.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [x] Update dependencies
