### PR TITLE
Pass tenant option when seeding resource given by the generator

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -334,9 +334,12 @@ defmodule Ash.Generator do
         |> StreamData.fixed_map()
       end)
       |> StreamData.map(fn keys ->
-        Ash.Resource.set_metadata(struct(keys.__will_be_struct__, keys), %{
-          private: %{generator_after_action: opts[:after_action]}
-        })
+        Ash.Resource.set_metadata(
+          struct(keys.__will_be_struct__, keys),
+          opts
+          |> Keyword.take([:tenant])
+          |> Enum.into(%{private: %{generator_after_action: opts[:after_action]}})
+        )
       end)
     else
       if is_function(record) do
@@ -351,9 +354,12 @@ defmodule Ash.Generator do
       |> to_generators()
       |> StreamData.fixed_map()
       |> StreamData.map(fn keys ->
-        Ash.Resource.set_metadata(struct(resource, keys), %{
-          private: %{generator_after_action: opts[:after_action]}
-        })
+        Ash.Resource.set_metadata(
+          struct(resource, keys),
+          opts
+          |> Keyword.take([:tenant])
+          |> Enum.into(%{private: %{generator_after_action: opts[:after_action]}})
+        )
       end)
     end
   end

--- a/lib/ash/seed.ex
+++ b/lib/ash/seed.ex
@@ -32,6 +32,8 @@ defmodule Ash.Seed do
       |> Enum.concat(Ash.Resource.Info.relationships(resource))
       |> Enum.map(& &1.name)
 
+    opts = Map.take(input.__metadata__, [:tenant]) |> Enum.into([])
+
     input =
       input
       |> Map.take(keys)
@@ -49,7 +51,7 @@ defmodule Ash.Seed do
           Map.put(acc, key, value)
       end)
 
-    seed!(resource, input)
+    seed!(resource, input, opts)
   end
 
   def seed!(records) when is_list(records) do


### PR DESCRIPTION
Otherwise, it will ignore this option and try to insert into "global" table (e.g., when using PostgreSQL as a backend).

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
