### PR TITLE
fix: properly handle change with `where` validations in bulk

### DIFF
--- a/documentation/dsls/DSL-Ash.Reactor.md
+++ b/documentation/dsls/DSL-Ash.Reactor.md
@@ -481,7 +481,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-ash_step-argument-description){: #reactor-ash_step-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-ash_step-argument-description){: #reactor-ash_step-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-ash_step-argument-transform){: #reactor-ash_step-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -1470,7 +1470,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-change-argument-description){: #reactor-change-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-change-argument-description){: #reactor-change-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-change-argument-transform){: #reactor-change-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 

--- a/lib/ash/actions/helpers.ex
+++ b/lib/ash/actions/helpers.ex
@@ -37,7 +37,7 @@ defmodule Ash.Actions.Helpers do
 
               applicable = changes[change_index]
 
-              if applicable == :all || index in applicable do
+              if applicable == :all || (applicable && index in applicable) do
                 change_opts =
                   Ash.Actions.Helpers.templated_opts(
                     change_opts,

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -2606,7 +2606,7 @@ defmodule Ash.Changeset do
     changes
     |> Enum.reduce(changeset, fn {location, change_or_validation}, changeset ->
       try do
-        context = %{ context | tenant: changeset.tenant }
+        context = %{context | tenant: changeset.tenant}
 
         run_change_or_validation(
           change_or_validation,

--- a/lib/ash/policy/check.ex
+++ b/lib/ash/policy/check.ex
@@ -39,7 +39,7 @@ defmodule Ash.Policy.Check do
   """
   @callback auto_filter(actor(), authorizer(), options()) :: Keyword.t() | Ash.Expr.t()
   @doc """
-  An optional callback, hat allows the check to work with policies set to `access_type :runtime`
+  An optional callback, that allows the check to work with policies set to `access_type :runtime`
 
   Takes a list of records, and returns the subset of authorized records.
   """

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -481,7 +481,7 @@ defmodule Ash.Test.Actions.LoadTest do
     attributes do
       uuid_primary_key(:id)
       attribute(:rating, :integer, public?: true)
-      # calling it `made_at` is part of a regression 
+      # calling it `made_at` is part of a regression
       # test that this attribute has no `timestamps` (specifically that
       # `inserted_at` reference would not resolve for this resource
       # while on `Post` it does).


### PR DESCRIPTION
Was getting error about `nil` not implementing enumerable protocol. It was because `changes` map won't contain changes that did not pass their conditional `where` validations.

Also included a formatting fix, a credo fix, a typo fix and a cheat sheets fix.