### PR TITLE
fix: properly handle bulk soft destroy

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1677,6 +1677,11 @@ defmodule Ash.Actions.Update.Bulk do
                  action,
                  Keyword.put(opts, :atomic_upgrade?, false)
                ) do
+            :ok ->
+              Process.put({:any_success?, ref}, true)
+
+              []
+
             {:ok, result} ->
               Process.put({:any_success?, ref}, true)
 

--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -8,7 +8,8 @@ defmodule Ash.Actions.Update do
   import Ash.Expr
 
   @spec run(Ash.Domain.t(), Ash.Resource.record(), Ash.Resource.Actions.action(), Keyword.t()) ::
-          {:ok, Ash.Resource.record(), list(Ash.Notifier.Notification.t())}
+          :ok
+          | {:ok, Ash.Resource.record(), list(Ash.Notifier.Notification.t())}
           | {:ok, Ash.Resource.record()}
           | {:error, Ash.Changeset.t()}
           | {:error, term}


### PR DESCRIPTION
`Ash.Actions.Update.run` [can return `:ok`](https://github.com/ash-project/ash/blob/0761bbbaaab11e22ab33f7ee7a919473f7ebb33c/lib/ash/actions/update/update.ex#L391) in case of a soft destroy. So such return variant needs to be handled in processing of bulk update.

(Typespec for `run` does not list simple `:ok` as a potential result right now. Didn't know if I should have added it in this PR.)