### PR TITLE
Per process actor and tenant

### DIFF
--- a/documentation/topics/advanced/multitenancy.md
+++ b/documentation/topics/advanced/multitenancy.md
@@ -154,3 +154,16 @@ end
 ```
 
 This allows you to pass an `%Organization{}` or an organization_id around, and have that `organization_id` properly used with attribute and context-based multitenancy.
+
+## Per-process tenants
+
+In web applications, the tenant is typically determined when authenticating a request,
+and each request runs in a separate process. You can set default tenant for current process by calling
+
+```elixir
+Process.put(:ash_tenant, tenant)
+```
+
+The tenant will be used by default for all queries and changesets, and can be overriden using options.
+
+

--- a/documentation/topics/security/actors-and-authorization.md
+++ b/documentation/topics/security/actors-and-authorization.md
@@ -45,6 +45,18 @@ MyDomain.create_post!(Post, authorize?: true)
 > |> Ash.read!(actor: current_user)
 > ```
 
+## Per-process actors
+
+In web applications, the actor is typically the current user that is determined when authenticating a request,
+and each request runs in a separate process. You can set default actor for current process by calling
+
+```elixir
+Process.put(:ash_actor, actor)
+```
+
+The actor will be used by default for all queries and changesets, and can be overriden using options.
+
+
 ## Default value of `authorize?`
 
 The default value of `authorize?` is determined by the `authorization` configuration of the relevant domain. By default, `authorize?` is set to `true` (and so can be ommitted in all of the examples above). If a resource has no authorizers, then all requests will be allowed.

--- a/test/authorizer/authorizer_test.exs
+++ b/test/authorizer/authorizer_test.exs
@@ -84,6 +84,25 @@ defmodule Ash.Test.Changeset.AuthorizerTest do
       assert post.title == "true"
     end
 
+    test "authorize :by_default authorizes if actor is set for process" do
+      Application.put_env(:ash, Domain,
+        authorization: [
+          authorize: :by_default
+        ]
+      )
+
+      start_supervised({Ash.Test.Authorizer, strict_check: :authorized})
+
+      Process.put(:ash_actor, :an_actor)
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:title_is_authorization, %{})
+        |> Ash.create!()
+
+      assert post.title == "true"
+    end
+
     test "require_actor? requires an actor for all requests" do
       Application.put_env(:ash, Domain,
         authorization: [

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -322,6 +322,20 @@ defmodule Ash.Test.Policy.SimpleTest do
     end
   end
 
+  test "relating_to_actor/1 works when creating, using per-process actor", %{user: user} do
+    Process.put(:ash_actor, user)
+
+    Tweet
+    |> Ash.Changeset.for_create(:create, %{user_id: user.id})
+    |> Ash.create!(authorize?: true)
+
+    assert_raise Ash.Error.Forbidden, fn ->
+      Tweet
+      |> Ash.Changeset.for_create(:create, %{user_id: Ash.UUID.generate()})
+      |> Ash.create!(authorize?: true)
+    end
+  end
+
   test "relating_to_actor/1 works when updating", %{user: user} do
     Tweet
     |> Ash.Changeset.for_create(:create, %{user_id: user.id})


### PR DESCRIPTION
In web applications, tenant and actor are typically  determined when authenticating a request, and each request runs in a separate process. This patch allows setting per-process default actor and tenant



# Contributor checklist

- [x] Documentation changes
- [x] Features include unit/acceptance tests
