### PR TITLE
Fix erroneous policy group example

### DIFF
--- a/documentation/topics/security/policies.md
+++ b/documentation/topics/security/policies.md
@@ -163,7 +163,7 @@ policies do
     end
 
     policy action_type(:create) do
-      authorize_if always()
+      authorize_if relating_to_actor(:owner)
     end
   end
 end

--- a/documentation/topics/security/policies.md
+++ b/documentation/topics/security/policies.md
@@ -158,8 +158,12 @@ policies do
       authorize_if expr(owner_id == ^actor(:id))
     end
 
-    policy action_type([:create, :update, :destroy]) do
+    policy action_type([:update, :destroy]) do
       authorize_if expr(owner_id == ^actor(:id))
+    end
+
+    policy action_type(:create) do
+      authorize_if always()
     end
   end
 end


### PR DESCRIPTION
This fixes an error-throwing example in the policy docs (see [here](https://elixirforum.com/t/ensure-actor-can-only-create-resource-for-themselves/69988?u=sodapopcan)).

I can also add a note (either code comment above the `create` example or admonition block below) about not being able to use field references in create policies but I'm not sure this is the right place.