### PR TITLE
Add failing test for ignored calculation arguments

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,7 @@ if Mix.env() == :test do
 
   config :ash, :custom_expressions, [Ash.Test.Expressions.JaroDistance]
 
-  config :ash, :keep_read_action_loads_when_loading?, false
+  config :ash, :keep_read_action_loads_when_loading?, true
   config :ash, :read_action_after_action_hooks_in_order?, true
   config :ash, :bulk_actions_default_to_errors?, true
 

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -311,7 +311,7 @@ defmodule Ash.Test.Actions.LoadTest do
     end
 
     preparations do
-      prepare build(load: [:category_length])
+      prepare build(load: [:category_length, :sum])
     end
 
     attributes do
@@ -348,6 +348,12 @@ defmodule Ash.Test.Actions.LoadTest do
 
     calculations do
       calculate :category_length, :string, expr(string_length(category))
+
+      calculate :sum, :integer do
+        argument :a, :integer, default: 1
+        argument :b, :integer, default: 2
+        calculation expr(^arg(:a) + ^arg(:b))
+      end
     end
 
     relationships do
@@ -2003,6 +2009,19 @@ defmodule Ash.Test.Actions.LoadTest do
       |> Ash.create!()
 
     assert %Ash.NotLoaded{} = Ash.load!(post, :author).category_length
+  end
+
+  test "calculation arguments should be respected" do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{
+        title: "author post",
+        contents: "post content"
+      })
+      |> Ash.create!()
+
+    post = Ash.load!(post, sum: [a: 3, b: 4])
+    assert 7 == post.sum
   end
 
   test "you can load data on create with no default read action" do


### PR DESCRIPTION
The issue has been present since commit `5665ec59` when `keep_read_action_loads_when_loading?` is true.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
