### PR TITLE
fix: apply strict load in `Ash.get` properly

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -1563,7 +1563,6 @@ defmodule Ash do
       |> Ash.Query.new(domain: domain)
       |> Ash.Query.set_tenant(opts[:tenant])
       |> Ash.Query.filter(^filter)
-      |> Ash.Query.load(opts[:load] || [])
       |> Ash.Query.set_context(opts[:context] || %{})
       |> Ash.Query.lock(opts[:lock])
 


### PR DESCRIPTION
`load` option [will be applied](https://github.com/ash-project/ash/blob/d5f4c2a31ec04537107390e6ff2a404ba9191a28/lib/ash/actions/read/read.ex#L45) in `unpaginated_read` (it is in `read_opts`) and there it will take into account presence of `strict?` option.

Had a problem where `load: [relationship: [:field]]` was loading other attributes than `field` on `relationship`.