### PR TITLE
fix: return records from bulk soft destroy if requested

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1675,7 +1675,10 @@ defmodule Ash.Actions.Update.Bulk do
                  domain,
                  changeset,
                  action,
-                 Keyword.put(opts, :atomic_upgrade?, false)
+                 Keyword.merge(opts,
+                   atomic_upgrade?: false,
+                   return_destroyed?: opts[:return_records?]
+                 )
                ) do
             :ok ->
               Process.put({:any_success?, ref}, true)


### PR DESCRIPTION
Bulk destroy [sets](https://github.com/ash-project/ash/blob/d2fd8e4d29323c23b52358aa315b56e05e506f6f/lib/ash/actions/destroy/bulk.ex#L1374) `opts[:return_destroyed?]` to `opts[:return_records?]` before calling destroy action. But if the destroy is soft then it will be handled by bulk update and it [does not set](https://github.com/ash-project/ash/blob/d2fd8e4d29323c23b52358aa315b56e05e506f6f/lib/ash/actions/update/bulk.ex#L1678) such thing right now.

Encountered the problem when by simply adding AshArchival the result of graphql mutation became nil instead of a record.