### PR TITLE
feat(Ash.Reactor): Add `get` step.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -47,6 +47,7 @@ spark_locals_without_parens = [
   belongs_to: 2,
   belongs_to: 3,
   broadcast_type: 1,
+  by: 1,
   bypass: 0,
   bypass: 1,
   bypass: 2,

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -729,8 +729,7 @@ defmodule Ash.CodeInterface do
                     |> case do
                       nil when not_found_error? ->
                         raise Ash.Error.to_error_class(
-                                Ash.Error.Query.NotFound.exception(
-                                resource: query.resource)
+                                Ash.Error.Query.NotFound.exception(resource: query.resource)
                               )
 
                       result ->

--- a/lib/ash/reactor/builders/get.ex
+++ b/lib/ash/reactor/builders/get.ex
@@ -1,0 +1,42 @@
+defimpl Reactor.Dsl.Build, for: Ash.Reactor.Dsl.Get do
+  alias Ash.Reactor.GetStep
+  alias Reactor.Builder
+  import Ash.Reactor.BuilderUtils
+
+  @doc false
+  @impl true
+  def build(get, reactor) do
+    with {:ok, reactor, arguments} <- build_input_arguments(reactor, get) do
+      arguments =
+        arguments
+        |> maybe_append(get.actor)
+        |> maybe_append(get.tenant)
+        |> maybe_append(get.load)
+        |> maybe_append(get.context)
+        |> Enum.concat(get.wait_for)
+
+      action_options =
+        get
+        |> Map.take([:action, :authorize?, :by, :domain, :fail_on_not_found?, :resource])
+        |> Enum.to_list()
+
+      step_options =
+        get
+        |> Map.take([:async?, :guards])
+        |> Map.put(:ref, :step_name)
+        |> Enum.to_list()
+
+      Builder.add_step(
+        reactor,
+        get.name,
+        {GetStep, action_options},
+        arguments,
+        step_options
+      )
+    end
+  end
+
+  @doc false
+  @impl true
+  def verify(_create, _dsl_state), do: :ok
+end

--- a/lib/ash/reactor/dsl/get.ex
+++ b/lib/ash/reactor/dsl/get.ex
@@ -1,0 +1,98 @@
+defmodule Ash.Reactor.Dsl.Get do
+  @moduledoc """
+  The `get` entity for the `Ash.Reactor` reactor extension.
+  """
+
+  defstruct __identifier__: nil,
+            action_step?: true,
+            action: nil,
+            actor: [],
+            async?: true,
+            authorize?: nil,
+            by: [],
+            context: nil,
+            description: nil,
+            domain: nil,
+            guards: [],
+            fail_on_not_found?: nil,
+            inputs: [],
+            load: nil,
+            name: nil,
+            resource: nil,
+            tenant: [],
+            transform: nil,
+            type: :read,
+            wait_for: []
+
+  @type t :: %__MODULE__{
+          __identifier__: any,
+          action_step?: true,
+          action: atom,
+          actor: nil | Ash.Reactor.Dsl.Actor.t(),
+          async?: boolean,
+          authorize?: boolean | nil,
+          by: [atom],
+          context: nil | Ash.Reactor.Dsl.Context.t(),
+          description: String.t() | nil,
+          domain: Ash.Domain.t(),
+          guards: [Reactor.Guard.Build.t()],
+          fail_on_not_found?: boolean,
+          inputs: [Ash.Reactor.Dsl.Inputs.t()],
+          load: nil | Ash.Reactor.Dsl.ActionLoad.t(),
+          name: atom,
+          resource: module,
+          tenant: nil | Ash.Reactor.Dsl.Tenant.t(),
+          type: :create,
+          wait_for: [Reactor.Dsl.WaitFor.t()]
+        }
+
+  @doc false
+  def __entity__,
+    do: %Spark.Dsl.Entity{
+      name: :get,
+      describe:
+        "Declares a step that will call a read action on a resource returning a single record.",
+      examples: [
+        """
+        get :post, MyApp.Post, :read do
+          by [:id]
+          inputs %{id: input(:post_id)}
+        end
+        """
+      ],
+      no_depend_modules: [:domain, :resource],
+      target: __MODULE__,
+      args: [:name, :resource, {:optional, :action}],
+      identifier: :name,
+      imports: [Reactor.Dsl.Argument],
+      entities: [
+        actor: [Ash.Reactor.Dsl.Actor.__entity__()],
+        context: [Ash.Reactor.Dsl.Context.__entity__()],
+        guards: [Reactor.Dsl.Guard.__entity__(), Reactor.Dsl.Where.__entity__()],
+        inputs: [Ash.Reactor.Dsl.Inputs.__entity__()],
+        load: [Ash.Reactor.Dsl.ActionLoad.__entity__()],
+        tenant: [Ash.Reactor.Dsl.Tenant.__entity__()],
+        wait_for: [Reactor.Dsl.WaitFor.__entity__()]
+      ],
+      singleton_entity_keys: [:actor, :context, :load, :tenant],
+      recursive_as: :steps,
+      schema:
+        [
+          by: [
+            type: {:wrap_list, :atom},
+            required: true,
+            doc: "The fields to filter by"
+          ],
+          fail_on_not_found?: [
+            type: :boolean,
+            required: false,
+            default: false,
+            doc: "When set to true the step will fail if the resource is not found."
+          ]
+        ]
+        |> Spark.Options.merge(
+          Ash.Reactor.Dsl.Action.__shared_action_option_schema__(false),
+          "Shared action options"
+        )
+    }
+end

--- a/lib/ash/reactor/reactor.ex
+++ b/lib/ash/reactor/reactor.ex
@@ -25,6 +25,7 @@ defmodule Ash.Reactor do
           | Ash.Reactor.Dsl.BulkUpdate.t()
           | Ash.Reactor.Dsl.Create.t()
           | Ash.Reactor.Dsl.Destroy.t()
+          | Ash.Reactor.Dsl.Get.t()
           | Ash.Reactor.Dsl.Load.t()
           | Ash.Reactor.Dsl.Read.t()
           | Ash.Reactor.Dsl.ReadOne.t()
@@ -42,6 +43,7 @@ defmodule Ash.Reactor do
         Ash.Reactor.Dsl.Change,
         Ash.Reactor.Dsl.Create,
         Ash.Reactor.Dsl.Destroy,
+        Ash.Reactor.Dsl.Get,
         Ash.Reactor.Dsl.Load,
         Ash.Reactor.Dsl.ReadOne,
         Ash.Reactor.Dsl.Read,

--- a/lib/ash/reactor/steps/get_step.ex
+++ b/lib/ash/reactor/steps/get_step.ex
@@ -1,0 +1,40 @@
+defmodule Ash.Reactor.GetStep do
+  @moduledoc """
+  The Reactor step which is used to execute get actions.
+  """
+  use Reactor.Step
+  import Ash.Reactor.StepUtils
+
+  alias Ash.Query
+  require Query
+
+  def run(arguments, context, options) do
+    query_options =
+      options
+      |> maybe_set_kw(:tracer, context[:tracer])
+      |> maybe_set_kw(:authorize?, context[:authorize?])
+      |> maybe_set_kw(:actor, context[:actor])
+      |> maybe_set_kw(:tenant, context[:tenant])
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:actor, arguments[:actor])
+      |> maybe_set_kw(:tenant, arguments[:tenant])
+
+    action_options =
+      [domain: options[:domain]]
+      |> maybe_set_kw(:authorize?, options[:authorize?])
+      |> maybe_set_kw(:load, arguments[:load])
+      |> maybe_set_kw(:not_found_error?, options[:fail_on_not_found?])
+      |> maybe_set_kw(:context, arguments[:context])
+
+    filter_keys = Keyword.fetch!(options, :by)
+
+    {filters, input} =
+      arguments[:input]
+      |> Map.split(filter_keys)
+
+    options[:resource]
+    |> Query.for_read(options[:action], input, query_options)
+    |> Query.filter_input(filters)
+    |> Ash.read_one(action_options)
+  end
+end

--- a/test/reactor/get_test.exs
+++ b/test/reactor/get_test.exs
@@ -1,0 +1,58 @@
+defmodule Ash.Test.ReactorGetTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias __MODULE__, as: Self
+  alias Ash.Test.Domain
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Domain
+
+    ets do
+      private? true
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, create: :*]
+    end
+
+    code_interface do
+      define :create
+    end
+  end
+
+  defmodule SimpleGetReactor do
+    @moduledoc false
+    use Reactor, extensions: [Ash.Reactor]
+
+    input(:post_id)
+
+    get :post, Self.Post, :read do
+      by([:id])
+      inputs(%{id: input(:post_id)})
+    end
+
+    return :post
+  end
+
+  test "it automatically filters the records by the supplied keys" do
+    posts =
+      ~w[Marty Doc Einstein]
+      |> Enum.map(&Post.create!(%{title: &1}))
+
+    post_id =
+      posts
+      |> Enum.random()
+      |> Map.fetch!(:id)
+
+    assert {:ok, %{id: ^post_id}} =
+             Reactor.run(SimpleGetReactor, %{post_id: post_id}, %{}, async?: false)
+  end
+end


### PR DESCRIPTION
Provides a specific step type which filters by the keys in the `by` option.  Behaves much the same as the Ash `get` code interface.

Closes #1886.
