### PR TITLE
Move misplaced sentence in the getting started guide

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -163,12 +163,11 @@ To ensure that your code stays formatted like the examples here, you can add `:a
 > ### Picosat installation issues? {: .info}
 >
 > If you have trouble compiling `picosat_elixir`, then replace `{:picosat_elixir, "~> 0.2"}` with `{:simple_sat, "~> 0.1"}` to use a simpler (but mildly slower) solver. You can always switch back to `picosat_elixir` later once you're done with the tutorial.
+> And run `mix deps.get`, to install the dependency.
 
 > #### Note {: .neutral}
 >
 > For more auto-formatting options, see the [Development Utilities guide](/documentation/topics/development/development-utilities.md).
-
-And run `mix deps.get`, to install the dependency.
 
 ### Building your first Ash Domain
 


### PR DESCRIPTION
I think it should be like this:

<img width="840" alt="Screenshot 2025-03-19 at 13 45 30" src="https://github.com/user-attachments/assets/f92f865c-7676-4d66-b791-e03ff5d4826b" />

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
