### PR TITLE
fix: update Validations.ActionIs to accept atom or list(atom)

### DIFF
--- a/documentation/topics/resources/validations.md
+++ b/documentation/topics/resources/validations.md
@@ -129,7 +129,7 @@ The validations section allows you to add validations across multiple actions of
 validations do
   validate present([:foo, :bar]), on: :update
   validate present([:foo, :bar, :baz], at_least: 2), on: :create
-  validate present([:foo, :bar, :baz], at_least: 2), where: [action_is(:action1, :action2)]
+  validate present([:foo, :bar, :baz], at_least: 2), where: [action_is([:action1, :action2])]
   validate absent([:foo, :bar, :baz], exactly: 1), on: [:update, :destroy]
   validate {MyCustomValidation, [foo: :bar]}, on: :create
 end

--- a/lib/ash/resource/validation/action_is.ex
+++ b/lib/ash/resource/validation/action_is.ex
@@ -2,16 +2,46 @@ defmodule Ash.Resource.Validation.ActionIs do
   @moduledoc "Validates that the action is the specified action."
   use Ash.Resource.Validation
 
+  @opt_schema [
+    action: [
+      type: {:wrap_list, :atom},
+      doc: "The action or actions to compare against",
+      required: true
+    ]
+  ]
+
+  opt_schema = @opt_schema
+
+  defmodule Opts do
+    @moduledoc false
+    use Spark.Options.Validator, schema: opt_schema
+  end
+
+  @impl true
+  def init(opts) do
+    case Opts.validate(opts) do
+      {:ok, opts} ->
+        {:ok, Opts.to_options(opts)}
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
   @impl true
   def validate(changeset, opts, _context) do
-    if changeset.action.name == opts[:action] do
+    if changeset.action.name in List.wrap(opts[:action]) do
       :ok
     else
       # We use "unknown" here because it doesn't make sense to surface
       # this error to clients potentially (and this should really only be used as a condition anyway)
-      [message: message, vars: vars] = describe(opts)
+      description = describe(opts)
 
-      {:error, Ash.Error.Unknown.UnknownError.exception(error: message, vars: vars)}
+      {:error,
+       Ash.Error.Unknown.UnknownError.exception(
+         error: description[:message],
+         vars: description[:vars]
+       )}
     end
   end
 
@@ -22,6 +52,12 @@ defmodule Ash.Resource.Validation.ActionIs do
 
   @impl true
   def describe(opts) do
-    [message: "must be %{action}", vars: %{action: opts[:action]}]
+    case opts[:action] do
+      actions when is_list(actions) ->
+        [message: "action must be one of %{action}", vars: %{action: Enum.join(actions, ", ")}]
+
+      _ ->
+        [message: "must be %{action}", vars: %{action: opts[:action]}]
+    end
   end
 end

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -79,13 +79,15 @@ defmodule Ash.Resource.Validation.Builtins do
   end
 
   @doc """
-  Validates that the action is a specific action. Primarily meant for use in `where`.
+  Validates that the action name matches the provided action name or names. Primarily meant for use in `where`.
 
   ## Examples
 
       validate present(:foo), where: [action_is(:bar)]
+
+      validate present(:foo), where: action_is([:bar, :baz])
   """
-  @spec action_is(action :: atom) :: Validation.ref()
+  @spec action_is(action :: atom | list(atom)) :: Validation.ref()
   def action_is(action) do
     {Validation.ActionIs, action: action}
   end

--- a/test/resource/validation/action_is_test.exs
+++ b/test/resource/validation/action_is_test.exs
@@ -1,0 +1,79 @@
+defmodule Ash.Test.Resource.Validation.ActionIsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Resource.Validation.ActionIs
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule Post do
+    use Ash.Resource, domain: Domain
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :status, :string, public?: true
+    end
+  end
+
+  test "passes when action is equal to the one provided action" do
+    changeset =
+      Ash.Changeset.for_create(Post, :create)
+
+    assert_validation_success(changeset, action: :create)
+  end
+
+  test "fails when action is equal to the one provided action" do
+    changeset =
+      Ash.Changeset.for_update(%Post{}, :update)
+
+    assert_validation_error(changeset, [action: :create], "must be create")
+  end
+
+  test "passes when action is in list of provided actions" do
+    changesets = [
+      Ash.Changeset.for_create(Post, :create, %{status: "new"}),
+      Ash.Changeset.for_update(%Post{}, :update, %{status: "new"})
+    ]
+
+    for changeset <- changesets do
+      assert_validation_success(changeset, action: [:create, :update])
+    end
+  end
+
+  test "fails when action is not in list of provided actions" do
+    changeset = Ash.Changeset.for_destroy(%Post{}, :destroy)
+
+    assert_validation_error(
+      changeset,
+      [action: [:create, :update]],
+      "action must be one of create, update"
+    )
+  end
+
+  defp assert_validation_success(changeset, opts) do
+    assert :ok = ActionIs.validate(changeset, opts, %{})
+  end
+
+  defp assert_validation_error(changeset, opts, expected_message) do
+    assert {:error, %Ash.Error.Unknown.UnknownError{error: message, vars: vars}} =
+             ActionIs.validate(changeset, opts, %{})
+
+    assert expected_message == translate_message(message, vars)
+  end
+
+  defp translate_message(message, vars) do
+    Enum.reduce(vars, message, fn {key, value}, acc ->
+      if String.contains?(acc, "%{#{key}}") do
+        String.replace(acc, "%{#{key}}", to_string(value))
+      else
+        acc
+      end
+    end)
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Changes
- Update `Resource.Validations.ActionIs` to accept `atom | list(atom)` as described in the documentation
- Add `Resource.Validations.ActionIsTest` to verify that it handles both `atom` and `list(atom)`
- Add opts_schema to help with documentation - `action` is a `{:wrap_list, :atom}`
- Keep same exception message for backwards compatibility in case anyone is matching on it