### PR TITLE
Add failing test: calculation arguments should be respected for nested loads

### DIFF
--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -2011,16 +2011,24 @@ defmodule Ash.Test.Actions.LoadTest do
     assert %Ash.NotLoaded{} = Ash.load!(post, :author).category_length
   end
 
-  test "calculation arguments should be respected" do
-    post =
-      Post
-      |> Ash.Changeset.for_create(:create, %{
-        title: "author post",
-        contents: "post content"
-      })
-      |> Ash.create!()
+  test "calculation arguments should be respected for root loads" do
+    post = Post |> Ash.Changeset.for_create(:create, %{}) |> Ash.create!()
 
-    post = Ash.load!(post, sum: [a: 3, b: 4])
+    post = post |> Ash.load!(sum: [])
+    assert 3 == post.sum
+
+    post = post |> Ash.load!(sum: [a: 3, b: 4])
+    assert 7 == post.sum
+  end
+
+  test "calculation arguments should be respected for nested loads" do
+    author = Author |> Ash.Changeset.for_create(:create, %{}) |> Ash.create!()
+    Post |> Ash.Changeset.for_create(:create, %{author_id: author.id}) |> Ash.create!()
+
+    %{posts: [post]} = author |> Ash.load!(posts: [sum: []])
+    assert 3 = post.sum
+
+    %{posts: [post]} = author |> Ash.load!(posts: [sum: [a: 3, b: 4]])
     assert 7 == post.sum
   end
 


### PR DESCRIPTION
This test reproduces an issue where arguments are correctly applied when calling
`post |> Ash.load!(sum: [a: 3, b: 4])`,
but not applied when loading from a parent record like:
`author |> Ash.load!(posts: [sum: [a: 3, b: 4]])`.

You can reproduce the issue by running:
`mix test test/actions/load_test.exs:2024`

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
