### PR TITLE
docs: fix several cases that should be Ash.Query.sort_input/2

### DIFF
--- a/documentation/how-to/write-queries.livemd
+++ b/documentation/how-to/write-queries.livemd
@@ -415,7 +415,7 @@ MyApp.Posts.Post
 # use `sort_input` to sort based on user input
 # it only allows accessing public fields
 MyApp.Posts.Post
-|> Ash.Query.sort("text,-count_of_comments")
+|> Ash.Query.sort_input("text,-count_of_comments")
 |> Ash.read!()
 ```
 

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -2954,13 +2954,13 @@ defmodule Ash.Query do
   Ash.Query.sort(query, name: :desc, title: :asc)
 
   # sort by name ascending
-  Ash.Query.sort(query, "name")
+  Ash.Query.sort_input(query, "name")
 
   # sort by name descending, and title ascending
-  Ash.Query.sort(query, "-name,title")
+  Ash.Query.sort_input(query, "-name,title")
 
   # sort by name descending with nils at the end
-  Ash.Query.sort(query, "--name")
+  Ash.Query.sort_input(query, "--name")
   ```
 
   ## Sort Strings


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

There were a few cases in the documentation where `Ash.Query.sort/2` was used where it should have been `Ash.Query.sort_input/2`.