### PR TITLE
[docs] Update destroy actions docs to reference correct function name

### DIFF
--- a/documentation/topics/actions/destroy-actions.md
+++ b/documentation/topics/actions/destroy-actions.md
@@ -31,13 +31,12 @@ The basic formula for calling a destroy action looks like this:
 
 ```elixir
 record
-|> Ash.Query.for_destroy(:action_name, %{argument: :value}, ...opts)
+|> Ash.Changeset.for_destroy(:action_name, %{argument: :value}, ...opts)
 |> Ash.destroy!()
 ```
 
 See below for variations on action calling, and see the [code interface guide](/documentation/topics/code-interfaces.md) guide for how to
 define idiomatic and convenient functions that call your actions.
-
 
 ## Returning the destroyed record
 


### PR DESCRIPTION
Was looking at how to call a destroy action and noticed that the docs were referencing `Ash.Query.for_destroy` function, which I think was meant to be `Ash.Changeset.for_destroy`.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
