### PR TITLE
Failing test: update unloads already loaded relationships

### DIFF
--- a/test/actions/update_test.exs
+++ b/test/actions/update_test.exs
@@ -594,6 +594,29 @@ defmodule Ash.Test.Actions.UpdateTest do
   end
 
   describe "load" do
+    test "should not unload already loaded relationships when load option is not provided" do
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "Name"})
+        |> Ash.create!()
+
+      Post
+      |> Ash.Changeset.for_create(:create, %{title: "Post 1"})
+      |> Ash.Changeset.manage_relationship(:author, author, type: :append_and_remove)
+      |> Ash.create!()
+
+      author = author |> Ash.load!(:posts)
+
+      assert [%Post{}] = author.posts
+
+      author =
+        author
+        |> Ash.Changeset.for_update(:update, %{name: "Updated Name"})
+        |> Ash.update!()
+
+      assert [%Post{}] = author.posts
+    end
+
     test "allows loading has_many relationship on the changeset" do
       author =
         Author


### PR DESCRIPTION
I've found that calling `Ash.update` causes already-loaded relationships to be replaced with `%Ash.NotLoaded{}`. I'm wondering if this is the intended behavior.

I noticed this because previously the loaded relationships were preserved after an update, but after a recent update, they are being set to `%Ash.NotLoaded{}`, which led to a raise in our code.

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
