### PR TITLE
Failing test: Update unloads relationships on no-op update with tenant

### DIFF
--- a/test/filter/multitenancy_test.exs
+++ b/test/filter/multitenancy_test.exs
@@ -19,7 +19,7 @@ defmodule Ash.Test.MultitenancyTest do
 
     actions do
       default_accept :*
-      defaults [:read]
+      defaults [:read, update: :*]
 
       create :create do
         argument :multitenant_related, {:array, :map}
@@ -82,6 +82,22 @@ defmodule Ash.Test.MultitenancyTest do
     MultiTenant
     |> Ash.get!(1000, tenant: 1)
     |> Ash.destroy!(tenant: 1)
+  end
+
+  test "should preserve loaded relationships when performing no-op update" do
+    multi_tenant =
+      MultiTenant
+      |> Ash.Changeset.for_create(:create, %{id: 1000, owner: 1})
+      |> Ash.create!(load: [:multitenant_related], tenant: 1)
+
+    assert [] = multi_tenant.multitenant_related
+
+    multi_tenant =
+      multi_tenant
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.update!(tenant: 1)
+
+    assert [] = multi_tenant.multitenant_related
   end
 
   defmodule NonMultiTenant do


### PR DESCRIPTION
Calling Ash.update/2 with an empty attribute list and a tenant option causes previously loaded relationships to be unloaded unexpectedly.

The issue appears to stem from the following line:
https://github.com/ash-project/ash/blob/87340736e9d64bdeb6ead817c6b09db97d4df2d8/lib/ash/actions/update/update.ex#L553

At this point, changeset.data seems to be discarded and re-fetched via a new query, resulting in all previously loaded data being unloaded.

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
