### PR TITLE
Set doc false for internal functions

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -770,6 +770,7 @@ defmodule Ash do
     ]
   ]
 
+  @doc false
   def calculate_opts, do: @calculate_opts
 
   @run_action_opts [


### PR DESCRIPTION
Fixes a minor documentation issue which exposes `calculate_opts` function here in https://hexdocs.pm/ash/Ash.html#functions