### PR TITLE
feat(enum): Ash.Type.Enum - Add optional description and label value …

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -119,14 +119,14 @@ defmodule Ash.Type.Enum do
   @callback match(term) :: {:ok, atom} | :error
 
   defmacro __using__(opts) do
-    quote location: :keep, generated: true, bind_quoted: [opts: opts, behaviour: __MODULE__] do
+    quote location: :keep, generated: true, bind_quoted: [opts: opts] do
       use Ash.Type
 
       require Ash.Expr
 
-      @behaviour behaviour
+      @behaviour Ash.Type.Enum
 
-      @values_map behaviour.build_values_map(opts[:values])
+      @values_map Ash.Type.Enum.build_values_map(opts[:values])
       @values Map.keys(@values_map)
 
       atom_typespec =
@@ -158,24 +158,24 @@ defmodule Ash.Type.Enum do
 
       @any_not_downcase? Enum.any?(@string_values, fn value -> String.downcase(value) != value end)
 
-      @impl behaviour
+      @impl Ash.Type.Enum
       def values, do: @values
 
-      @impl behaviour
+      @impl Ash.Type.Enum
       def label(value) when value in @values do
         value
         |> details()
         |> Map.get(:label)
       end
 
-      @impl behaviour
+      @impl Ash.Type.Enum
       def description(value) when value in @values do
         value
         |> details()
         |> Map.get(:description)
       end
 
-      @impl behaviour
+      @impl Ash.Type.Enum
       def details(value) when value in @values do
         Map.get(@values_map, value)
       end
@@ -277,7 +277,7 @@ defmodule Ash.Type.Enum do
         end
       end
 
-      @impl behaviour
+      @impl Ash.Type.Enum
       @spec match?(term) :: boolean
       def match?(term) do
         case match(term) do
@@ -286,7 +286,7 @@ defmodule Ash.Type.Enum do
         end
       end
 
-      @impl behaviour
+      @impl Ash.Type.Enum
       @spec match(term) :: {:ok, atom} | :error
       def match(value) when value in @values, do: {:ok, value}
       def match(value) when value in @string_values, do: {:ok, String.to_existing_atom(value)}

--- a/test/support/enum.ex
+++ b/test/support/enum.ex
@@ -16,7 +16,8 @@ defmodule DescriptiveEnum do
       {:bar, "Obviously a bar"},
       {:baz, "Undoubtedly a baz"},
       :a_thing_with_no_description,
-      {:another_thing_with_no_description, nil}
+      {:another_thing_with_no_description, nil},
+      with_details: [description: "Look I have a description", label: "I have a label"]
     ]
 end
 
@@ -29,5 +30,14 @@ end
 defmodule MixedEnum do
   @moduledoc false
 
-  use Ash.Type.Enum, values: [:foo, "bar", "baz"]
+  use Ash.Type.Enum,
+    values: [
+      :foo,
+      "bar",
+      "baz",
+      {"Foo", "Awesome Description"},
+      {"StringWithDetails", [description: "Look I have a description", label: "Awesome Label"]},
+      {:another_one, "Another Awesome Description"},
+      with_details: [description: "Look I have a description", label: "I have a label"]
+    ]
 end

--- a/test/type/enum_test.exs
+++ b/test/type/enum_test.exs
@@ -78,12 +78,24 @@ defmodule Ash.Test.Type.EnumTest do
              :bar,
              :baz,
              :a_thing_with_no_description,
-             :another_thing_with_no_description
+             :another_thing_with_no_description,
+             :with_details
            ]
 
     assert DescriptiveEnum.description(:foo) == "Clearly a foo"
     assert DescriptiveEnum.description(:a_thing_with_no_description) == nil
     assert DescriptiveEnum.description(:another_thing_with_no_description) == nil
+    assert DescriptiveEnum.description(:with_details) == "Look I have a description"
+  end
+
+  test "it handles labels and generates them when no label is provided" do
+    assert DescriptiveEnum.label(:foo) == "Foo"
+    assert DescriptiveEnum.label(:a_thing_with_no_description) == "A thing with no description"
+
+    assert DescriptiveEnum.label(:another_thing_with_no_description) ==
+             "Another thing with no description"
+
+    assert DescriptiveEnum.label(:with_details) == "I have a label"
   end
 
   describe "types are correctly generated" do
@@ -102,6 +114,7 @@ defmodule Ash.Test.Type.EnumTest do
                   {:t,
                    {:type, 0, :union,
                     [
+                      {:atom, 0, :with_details},
                       {:atom, 0, :another_thing_with_no_description},
                       _,
                       _,
@@ -123,7 +136,8 @@ defmodule Ash.Test.Type.EnumTest do
                   {:t,
                    {:type, 0, :union,
                     [
-                      {:atom, 0, :foo},
+                      {:type, 0, :union,
+                       [{:atom, 0, :another_one}, {:atom, 0, :with_details}, {:atom, 0, :foo}]},
                       {:remote_type, 0, [{:atom, 0, String}, {:atom, 0, :t}, []]}
                     ]}, []}
               ]} = Code.Typespec.fetch_types(MixedEnum)


### PR DESCRIPTION
- Add keyword list for enum values to add `description` and/or `label`
- Add `label/1` to return the label for a given value
- Add `details/1` to return the label and description map
- Add validation to raise when unsupported options are provided for a value
- Change `description_map` to `values_map`.  When `{:key, description}` is provided per existing functionality, the description is put into the `values_map` with the `description` key.
- Change `description/1` to get the value from the `details_map` using the `description` key
- Update documentation to show the new functions and ways to add `description` and `label`
- Add `value_to_label/1` function that generates a label from the `:atom` key or uses the `:string` key as the label when a label is not provided.

closes #1724

This addition is completely backwards compatible, and all existing tests pass. Ash users who already have enums with descriptions won't be affected.

Example

```elixir
defmodule MyApp.MyEnum do
  use Ash.Type.Enum, values: [
    open: "An open ticket",
    closed: [description: "A closed ticket", label: "Closed"],
    escalated: [label: "Uh oh!"]
  ]
end

```

The next step is to add a PR to `ash_phoenix` to leverage the `label` to provide nice select options in forms.

I attempted to switch away from the `validate_values` function and leverage constraints, but I didn't have much luck. I'm open to guidance on how to do it, as I think it would be nice to do it instead of the manual validation function.

Let me know if you have any questions or feedback.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
