### PR TITLE
fix: case is not allowed and cond is allowed in ash expressions

### DIFF
--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -276,3 +276,35 @@ Ash.Query.filter(User, full_name == "Hob Goblin")
 
 Ash.Query.filter(User, full_name(delimiter: "~") == "Hob~Goblin")
 ```
+
+
+
+## Case vs Cond Expressions
+
+When working with conditional expressions in Ash, you should use `cond` instead of `case` statements. Here's an example:
+
+```elixir
+# This works - using cond
+calculations do
+  calculate :user_order, :integer, expr(
+    cond do
+      role == :principal -> 1
+      role == :teacher -> 2
+      role == :student -> 3
+    end
+  )
+end
+
+# This doesn't work - using case
+calculations do
+  calculate :user_order, :integer, expr(
+    case role do
+      :principal -> 1
+      :teacher -> 2
+      :student -> 3
+    end
+  )
+end
+```
+
+The `cond` expression is the correct way to handle conditional logic in Ash expressions.

--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -747,7 +747,8 @@ defmodule Ash.Expr do
   end
 
   def do_expr({:case, _, _}, _escape?) do
-    raise ArgumentError, message: """
+    raise ArgumentError,
+      message: """
       `case` expressions are not supported in Ash expressions.
       Please use `cond` expressions instead. For example:
 
@@ -1314,7 +1315,9 @@ defmodule Ash.Expr do
                     case Enum.uniq_by(all_returns, &elem(&1, 0)) do
                       [single] ->
                         {arg_types,
-                         Enum.find(all_returns, single, fn {_, constraints} -> constraints != [] end)}
+                         Enum.find(all_returns, single, fn {_, constraints} ->
+                           constraints != []
+                         end)}
 
                       _ ->
                         {arg_types, nil}

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -16,7 +16,7 @@ defmodule Ash.Test.ExprTest do
         )
         |> Ash.Filter.hydrate_refs(%{})
 
-        determine_types(func, args)
+      determine_types(func, args)
     end
   end
 
@@ -41,6 +41,7 @@ defmodule Ash.Test.ExprTest do
         Code.eval_quoted(
           quote do
             import Ash.Expr
+
             expr(
               case :role do
                 :principal -> 1

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -16,7 +16,7 @@ defmodule Ash.Test.ExprTest do
         )
         |> Ash.Filter.hydrate_refs(%{})
 
-      determine_types(func, args)
+        determine_types(func, args)
     end
   end
 
@@ -32,6 +32,25 @@ defmodule Ash.Test.ExprTest do
     test "integers are coerced to strings" do
       expr = expr("foo" <> type(2024, :string))
       assert eval!(expr) == "foo2024"
+    end
+  end
+
+  describe "case expressions" do
+    test "raises error when using case expressions" do
+      assert_raise ArgumentError, ~r/`case` expressions are not supported/, fn ->
+        Code.eval_quoted(
+          quote do
+            import Ash.Expr
+            expr(
+              case :role do
+                :principal -> 1
+                :teacher -> 2
+                :student -> 3
+              end
+            )
+          end
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
- raises ArgumentError with example

case is not allowed in ash expressions. instead use  cond. 

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
