### PR TITLE
Fix typo in closing `"`

### DIFF
--- a/documentation/topics/development/error-handling.md
+++ b/documentation/topics/development/error-handling.md
@@ -74,7 +74,7 @@ create :upsert_article_by_slug do
   upsert_condition expr(user_id == ^actor(:id))
   error_handler fn 
     _changeset, %Ash.Error.Changes.StaleRecord{} ->
-      Ash.Error.Changes.InvalidChanges.exception(field: :slug, message: "has already been taken")"
+      Ash.Error.Changes.InvalidChanges.exception(field: :slug, message: "has already been taken")
 
     _ changeset, other ->
       # leave other errors untouched


### PR DESCRIPTION
Fixes a simple typo in closing `"` in the docs.
# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
