### PR TITLE
chore: remove repeat of the same type in Aggregate opts schema

### DIFF
--- a/documentation/dsls/DSL-Ash.Notifier.PubSub.md
+++ b/documentation/dsls/DSL-Ash.Notifier.PubSub.md
@@ -137,8 +137,8 @@ pub_sub do
   module MyEndpoint
   prefix "post"
 
-  publish :destroy, ["foo", :id]
-  publish :update, ["bar", :name], event: "name_change"
+  publish :destroy, ["destroyed", :id]
+  publish :update, ["updated", :name], event: "name_change"
   publish_all :create, "created"
 end
 

--- a/lib/ash/query/aggregate.ex
+++ b/lib/ash/query/aggregate.ex
@@ -71,7 +71,7 @@ defmodule Ash.Query.Aggregate do
         "A base query to use for the aggregate, or a keyword list to be passed to `Ash.Query.build/2`"
     ],
     field: [
-      type: {:or, [:atom, {:struct, Ash.Query.Calculation}, {:struct, Ash.Query.Calculation}]},
+      type: {:or, [:atom, {:struct, Ash.Query.Calculation}, {:struct, Ash.Query.Aggregate}]},
       doc: "The field to use for the aggregate. Not necessary for all aggregate types."
     ],
     expr: [


### PR DESCRIPTION
Just same thing repeated twice. Maybe there was something else in mind for the second item.
