### PR TITLE
tests: test propagation of context to calculation in policy expression

### DIFF
--- a/test/policy/complex_test.exs
+++ b/test/policy/complex_test.exs
@@ -279,4 +279,8 @@ defmodule Ash.Test.Policy.ComplexTest do
 
     assert_received {:runtime_check_executed, [_]}
   end
+
+  test "calculations get context and actor", %{me: me, post_by_me: post} do
+    assert %{text: "[deleted]"} = Post.erase!(post, actor: me, context: %{post_id: post.id})
+  end
 end

--- a/test/support/policy_complex/resources/post.ex
+++ b/test/support/policy_complex/resources/post.ex
@@ -21,6 +21,10 @@ defmodule Ash.Test.Support.PolicyComplex.Post do
     policy action_type(:create) do
       authorize_if always()
     end
+
+    policy action(:erase) do
+      authorize_if expr(has_context)
+    end
   end
 
   ets do
@@ -49,6 +53,10 @@ defmodule Ash.Test.Support.PolicyComplex.Post do
       accept [:text]
       change relate_actor(:author)
     end
+
+    update :erase do
+      change set_attribute(:text, "[deleted]")
+    end
   end
 
   aggregates do
@@ -76,10 +84,13 @@ defmodule Ash.Test.Support.PolicyComplex.Post do
     calculate :count_of_comments_calc, :integer, expr(count_of_comments) do
       public?(true)
     end
+
+    calculate :has_context, :boolean, expr(id == ^context(:post_id) and author_id == ^actor(:id))
   end
 
   code_interface do
     define :create, args: [:text]
+    define :erase
   end
 
   relationships do


### PR DESCRIPTION
Have an issue with usage of a calculation in a policy expression. The calculation is an expression one and references actor through `^actor(:id)`. The problem that I see is that actor/context does not propagate to calculation expression.

Two reasons (solving either of them should fix the issue, but I don't know what would be appropriate):
a) Calculation context is not filled.
b) `Ash.Expr.fill_template` does not go into `Ash.Query.Ref`.

To demonstrate using the test example, this works:
```elixir
policy action(:erase) do
  authorize_if expr(id == ^context(:post_id) and author_id == ^actor(:id))
end
```

But this does not:
```elixir
policy action(:erase) do
  authorize_if expr(has_context)
end

calculate :has_context, :boolean, expr(id == ^context(:post_id) and author_id == ^actor(:id))
```