### PR TITLE
fix: maintain order of enum values

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -127,7 +127,7 @@ defmodule Ash.Type.Enum do
       @behaviour Ash.Type.Enum
 
       @values_map Ash.Type.Enum.build_values_map(opts[:values])
-      @values Map.keys(@values_map)
+      @values Ash.Type.Enum.build_values_list(opts[:values])
 
       atom_typespec =
         if Enum.any?(@values, &is_atom/1) do
@@ -154,9 +154,9 @@ defmodule Ash.Type.Enum do
 
       @type t() :: unquote(typespec)
 
-      @string_values @values |> Enum.map(&to_string/1)
+      @string_values Enum.map(@values, &to_string/1)
 
-      @any_not_downcase? Enum.any?(@string_values, fn value -> String.downcase(value) != value end)
+      @any_not_downcase? Enum.any?(@string_values, &(String.downcase(&1) != &1))
 
       @impl Ash.Type.Enum
       def values, do: @values
@@ -346,6 +346,16 @@ defmodule Ash.Type.Enum do
           description: nil,
           label: humanize(value_with_no_description)
         })
+    end)
+  end
+
+  @doc false
+  def build_values_list(values) do
+    values
+    |> verify_values!()
+    |> Enum.map(fn
+      {value, _} -> value
+      value -> value
     end)
   end
 

--- a/test/type/enum_test.exs
+++ b/test/type/enum_test.exs
@@ -137,7 +137,7 @@ defmodule Ash.Test.Type.EnumTest do
                    {:type, 0, :union,
                     [
                       {:type, 0, :union,
-                       [{:atom, 0, :another_one}, {:atom, 0, :with_details}, {:atom, 0, :foo}]},
+                       [{:atom, 0, :with_details}, {:atom, 0, :another_one}, {:atom, 0, :foo}]},
                       {:remote_type, 0, [{:atom, 0, String}, {:atom, 0, :t}, []]}
                     ]}, []}
               ]} = Code.Typespec.fetch_types(MixedEnum)


### PR DESCRIPTION
When using a custom `Ash.Type.Enum` type, make sure `values/0` returns the values in the same order as defined on the type.

I'm showing the values in a select input and noticed the order changed randomly. This seems to be caused by converting the values to a map (for which the order of keys is not predictable).

I decided to keep the map (instead of replacing it with a keyword list) to keep label/description lookups performant.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
