### PR TITLE
fix documentation for broadcast_type: :broadcast

### DIFF
--- a/documentation/dsls/DSL-Ash.Notifier.PubSub.md
+++ b/documentation/dsls/DSL-Ash.Notifier.PubSub.md
@@ -119,7 +119,7 @@ Configured with `broadcast_type`.
 
 - `:notification` just sends the notification
 - `:phoenix_broadcast` sends a `%Phoenix.Socket.Broadcast{}` (see above)
-- `:broadcast` sends `%{topic: (topic), event: (event), notification: (notification)}`
+- `:broadcast` sends `%{topic: (topic), event: (event), payload: (notification)}`
 
 
 ## pub_sub

--- a/lib/ash/notifier/pub_sub/pub_sub.ex
+++ b/lib/ash/notifier/pub_sub/pub_sub.ex
@@ -208,7 +208,7 @@ defmodule Ash.Notifier.PubSub do
 
   - `:notification` just sends the notification
   - `:phoenix_broadcast` sends a `%Phoenix.Socket.Broadcast{}` (see above)
-  - `:broadcast` sends `%{topic: (topic), event: (event), notification: (notification)}`
+  - `:broadcast` sends `%{topic: (topic), event: (event), payload: (notification)}`
   """
 
   use Spark.Dsl.Extension,


### PR DESCRIPTION
it sends,  %{topic: (topic), event: (event), payload: (notification)},
not  %{topic: (topic), event: (event), notification: (notification)}

# Contributor checklist

- [x] Documentation changes
