### PR TITLE
Remove duplicate args

### DIFF
--- a/lib/ash/query/function/string_join.ex
+++ b/lib/ash/query/function/string_join.ex
@@ -19,11 +19,10 @@ defmodule Ash.Query.Function.StringJoin do
       [{:array, :string}, :string],
       [{:array, :string}, :ci_string],
       [{:array, :ci_string}],
-      [{:array, :ci_string}, :ci_string],
       [{:array, :ci_string}, :ci_string]
     ]
 
-  def returns, do: [:string, :string, :ci_string, :ci_string, :ci_string, :ci_string]
+  def returns, do: [:string, :string, :ci_string, :ci_string, :ci_string]
 
   def evaluate(%{arguments: [values, joiner]}) do
     join(values, joiner)


### PR DESCRIPTION
Removes the duplicate arg `[{:array, :ci_string}, :ci_string]`

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
