### PR TITLE
Fix filtering with aggregates refers calculation error

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -2132,7 +2132,7 @@ defmodule Ash.Filter do
             field
         end
 
-      field_ref = field_to_ref(aggregate.resource, field_ref)
+      field_ref = field_to_ref(related, field_ref)
 
       query_rel_paths ++ do_relationship_paths(field_ref, include_exists?, with_refs?, true)
     else


### PR DESCRIPTION
This PR resolves #1953.

I found that `Ash.Query.Calculation.from_resource_calculation/3` can succeed even when the calculation does not belong to the given resource.

https://github.com/nallwhy/ash/blob/8d9b53d4e726bdcc7cab69978b2ad50c7a87467c/lib/ash/query/calculation.ex#L199

To prevent similar bugs in the future, it might be worth reconsidering the current behavior where calculations are allowed to pass without verification.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
