### PR TITLE
improvement: Add Query.Function.now/1-2 for timezones

### DIFF
--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -89,6 +89,8 @@ For elixir-backed data layers, they will be a function or an MFA that will be ca
 ## DateTime Functions
 
 - `now/0` | Evaluates to the current time when the expression is evaluated
+- `now/1` | Evaluates to the current time for a specific timezone when the expression is evaluated.
+- `now/2` | Evaluates to the current time for a specific timezone and timezone database when the expression is evaluated.
 - `today/0` | Evaluates to the current date when the expression is evaluated
 - `ago/2` | i.e `deleted_at > ago(7, :day)`. The available time intervals are documented in `Ash.Type.DurationName`
 - `from_now/2` | Same as `ago` but adds instead of subtracting

--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -97,6 +97,17 @@ defmodule Ash do
                           """,
                           default: false
                         ],
+                        return_records?: [
+                          type: :boolean,
+                          doc: """
+                          If `true`, the the query will not be executed and not records will be returned.
+
+                          This can be used with `return_query?: true` to get the query without the records.
+
+                          Useful for using the code interface to get the query for aggregate functions like `Ash.exists?`
+                          """,
+                          default: true
+                        ],
                         skip_unknown_inputs: [
                           type: {:wrap_list, {:or, [:atom, :string]}},
                           doc:

--- a/lib/ash/query/function/now.ex
+++ b/lib/ash/query/function/now.ex
@@ -4,9 +4,14 @@ defmodule Ash.Query.Function.Now do
   """
   use Ash.Query.Function, name: :now, eager_evaluate?: false
 
-  def args, do: [[]]
+  def args, do: [[], [:time_zone], [:time_zone, :time_zone_database]]
 
-  def returns, do: [:utc_datetime_usec]
+  def returns, do: [:utc_datetime_usec, :datetime]
+
+  def evaluate(%{arguments: [timezone]}), do: {:known, DateTime.now!(timezone)}
+
+  def evaluate(%{arguments: [time_zone, time_zone_database]}),
+    do: {:known, DateTime.now!(time_zone, time_zone_database)}
 
   def evaluate(_), do: {:known, DateTime.utc_now()}
 

--- a/test/query/function/now_test.exs
+++ b/test/query/function/now_test.exs
@@ -1,0 +1,22 @@
+defmodule Ash.Query.Function.NowTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Query.Function.Now
+
+  describe "now query function" do
+    test "now/0" do
+      assert {:known, %DateTime{}} =
+               Now.evaluate(%{arguments: []})
+    end
+
+    test "now/1" do
+      assert {:known, %DateTime{}} =
+               Now.evaluate(%{arguments: ["Etc/UTC"]})
+    end
+
+    test "now/2" do
+      assert {:known, %DateTime{}} =
+               Now.evaluate(%{arguments: ["Etc/UTC", Calendar.get_time_zone_database()]})
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

- Update `Ash.Query.Function.Now` with `now/1-2` to allow passing in the timezone and timezone database to match `DateTime.now/1-2`
- `mix format` updated `ash.ex`
