### PR TITLE
fix: properly handle keyword variant in `Ash.Query.add_error/3`

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -244,6 +244,7 @@ defmodule Ash.Query do
   alias Ash.Actions.Sort
 
   alias Ash.Error.Invalid.TimeoutNotSupported
+  alias Ash.Error.Load.NoSuchRelationship
 
   alias Ash.Error.Query.{
     AggregatesNotSupported,
@@ -258,7 +259,6 @@ defmodule Ash.Query do
     Required
   }
 
-  alias Ash.Error.Load.{InvalidQuery, NoSuchRelationship}
   alias Ash.Query.{Aggregate, Calculation}
 
   require Ash.Tracer
@@ -3385,9 +3385,7 @@ defmodule Ash.Query do
         )
       else
         InvalidQuery.exception(
-          fields: keyword[:fields] || [],
           message: keyword[:message],
-          value: keyword[:value],
           vars: keyword
         )
       end
@@ -3406,7 +3404,7 @@ defmodule Ash.Query do
       %__MODULE__{resource: query_resource} = destination_query
       when query_resource != relationship_resource ->
         [
-          InvalidQuery.exception(
+          Ash.Error.Load.InvalidQuery.exception(
             resource: resource,
             relationship: key,
             query: destination_query,
@@ -3419,7 +3417,7 @@ defmodule Ash.Query do
              (destination_query.limit ||
                 (destination_query.offset && destination_query.offset != 0)) do
           [
-            InvalidQuery.exception(
+            Ash.Error.Load.InvalidQuery.exception(
               resource: resource,
               relationship: key,
               query: destination_query,


### PR DESCRIPTION
Was getting complains when tried to use `Ash.Query.add_error(query, message: "Bad query")`.

Two things:

1) There were two aliases for `InvalidQuery` in the file - one for `Ash.Error.Query.InvalidQuery` and `Ash.Error.Load.InvalidQuery` with later taking a precedence. (I would have assumed that there should be a Credo rule for that.)

2) `Ash.Error.Query.InvalidQuery` does not accept `fields` or `value` - it has only `field` and `message`. And since `field` is guaranteed to be nil (because of the condition it is in) there is no need to pass it in.