### PR TITLE
Fix: Allow update action types in Ash.Generator.generate

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -166,7 +166,7 @@ defmodule Ash.Generator do
           action_input(
             MyApp.Blog.Post,
             :create,
-            title: sequence(:title, &"Post #{&1}")
+            title: sequence(:title, &"Post \#{&1}")
           )
       ],
       defaults: fn inputs ->

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -157,25 +157,25 @@ defmodule Ash.Generator do
   this pattern could be expanded, yielding a resource with a new child resource:
 
   ```elixir
-  def attachment_for(post, opts \\ []) do
+  def post_for(author, opts \\ []) do
     changeset_generator(
-      post,
-      :add_attachments,
+      author,
+      :new_post,
       uses: [
-        attachment_input:
+        post_input:
           action_input(
-            MyApp.Blog.Attachment,
+            MyApp.Blog.Post,
             :create,
-            name: sequence(:attachment_name, &"My Attachment \#{&1}")
+            title: sequence(:title, &"Post #{&1}")
           )
       ],
       defaults: fn inputs ->
-        [attachments: [inputs[:attachment_inputs]]]
+        [posts: [inputs.post_input]]
       end,
       overrides: opts
     )
   end
-  ``
+  ```
 
   See the `Ash.Generator` moduledocs for more information.
 


### PR DESCRIPTION
Hello!



### Changes:
1. New function clause for `Ash.Generator.generate\1` to call `Ash.update!\1` on changesets of action type `:update`.
2. Added test for generator example using :update action on a parent resource.
3. Documentation example for this use-case.

# Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies