### PR TITLE
docs: Generic action implementation

### DIFF
--- a/lib/ash/resource/actions/action/action.ex
+++ b/lib/ash/resource/actions/action/action.ex
@@ -75,7 +75,10 @@ defmodule Ash.Resource.Actions.Action do
                        {:spark_function_behaviour, Ash.Resource.Actions.Implementation,
                         {Ash.Resource.Action.ImplementationFunction, 2}},
                        {:spark, Reactor}
-                     ]}
+                     ]},
+                  doc: """
+                  Module may be an `Ash.Resource.Actions.Implementation` or `Reactor`.
+                  """
                 ]
               ]
               |> Spark.Options.merge(

--- a/lib/ash/resource/actions/action/implementation.ex
+++ b/lib/ash/resource/actions/action/implementation.ex
@@ -1,6 +1,18 @@
 defmodule Ash.Resource.Actions.Implementation do
   @moduledoc """
-  An implementation of a generic action.
+  An implementation of a [generic action](generic-actions.md).
+
+
+  ### Example
+  ```
+  defmodule YourModule do
+    use Ash.Resource.Actions.Implementation
+
+    def run(input, opts, context) do
+      {:ok, "Hello"}
+    end
+  end
+  ```
   """
 
   defmodule Context do


### PR DESCRIPTION
Had some difficulty determining the implementation of the module that a generic action's `run` function takes so updating the docs to hopefully help someone else out

Could add a generator, taking inspiration from https://github.com/ash-project/ash/pull/1940, but unsure how useful that would be

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
