### PR TITLE
Fix crash when sorting by aggregates with non-attribute field

### DIFF
--- a/lib/ash/sort/sort.ex
+++ b/lib/ash/sort/sort.ex
@@ -365,7 +365,7 @@ defmodule Ash.Sort do
     attribute =
       if aggregate.field do
         related = Ash.Resource.Info.related(resource, aggregate.relationship_path)
-        Ash.Resource.Info.attribute(related, aggregate.field)
+        Ash.Resource.Info.field(related, aggregate.field)
       end
 
     attribute_type =


### PR DESCRIPTION
This fixes a bug where sorting by aggregates whose `field` is not an attribute (i.e. aggregate or a calculation) would cause a crash.

```
[error] ** (UndefinedFunctionError) function nil.embedded?/0 is undefined
    nil.embedded?()
    (ash 3.5.4) lib/ash/sort/sort.ex:428: Ash.Sort.do_type_sortable?/3
    (ash 3.5.4) lib/ash/sort/sort.ex:251: Ash.Sort.get_field/5
    (ash 3.5.4) lib/ash/sort/sort.ex:204: Ash.Sort.parse_sort/4
    (ash 3.5.4) lib/ash/sort/sort.ex:111: anonymous fn/4 in Ash.Sort.parse_input/3
    (elixir 1.18.3) lib/enum.ex:4968: Enumerable.List.reduce/3
    (elixir 1.18.3) lib/enum.ex:2600: Enum.reduce_while/3
    (ash 3.5.4) lib/ash/sort/sort.ex:110: Ash.Sort.parse_input/3
    (ash 3.5.4) lib/ash/query/query.ex:455: Ash.Query.sort_input/3
```

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
