### PR TITLE
Update misspellings/typos on docs and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@ to a resource that you did not intend them to be able to see.
 
 * validate multitenancy earlier in bulk actions
 
-* initialize all types propertly at compile time
+* initialize all types properly at compile time
 
 ## [v3.4.69](https://github.com/ash-project/ash/compare/v3.4.68...v3.4.69) (2025-03-18)
 
@@ -383,7 +383,7 @@ to a resource that you did not intend them to be able to see.
 
 * don't prevent changing values to `nil` when original data is not available
 
-* propagate invalid refrence error when adding calc context to sort (#1827)
+* propagate invalid reference error when adding calc context to sort (#1827)
 
 * ensure that we don't try to compare not loaded or forbidden values
 
@@ -412,7 +412,7 @@ to a resource that you did not intend them to be able to see.
 
 * fix case where batch before/after action callbacks could be skipped
 
-* return NotFound error in proper cases on bulk intefaces
+* return NotFound error in proper cases on bulk interfaces
 
 * don't eagerly return records on bulk update/destroys
 
@@ -636,7 +636,7 @@ to a resource that you did not intend them to be able to see.
 
 * [`Ash.Changeset`] Use clearer error message for match validation atomic errors (#1721)
 
-* [`Ash.Type`] Add autogenerate_enabled? to Ash.Type for Ecto compatability (#1715)
+* [`Ash.Type`] Add autogenerate_enabled? to Ash.Type for Ecto compatibility (#1715)
 
 * [`Ash.Policy.Authorizer`] warn when domain policies would be ignored by resources
 
@@ -848,7 +848,7 @@ You should upgrade regardless, and adopt that new configuration.
 
 ### Improvements:
 
-- [`Ash.Reactor`]: Always add the notication middleware any time the extension is added. (#1657)
+- [`Ash.Reactor`]: Always add the notification middleware any time the extension is added. (#1657)
 
 ## [v3.4.46](https://github.com/ash-project/ash/compare/v3.4.45...v3.4.46) (2024-12-12)
 
@@ -1880,7 +1880,7 @@ field_policies :include
 
 - [bulk actions] ensure that errors in queries do not raise in atomic upgrades/single atomics
 
-- [Ash.Type.Integer] use correct contraint when validating min int (#1298)
+- [Ash.Type.Integer] use correct constraint when validating min int (#1298)
 
 - [Ash.Filter] don't refer to private attributes when parsing filter inputs that refer to relationships (#1280)
 
@@ -2116,7 +2116,7 @@ field_policies :include
 
 - [identities] support `nils_distinct?` on identities
 
-- [identties] support `where` option on `identities`
+- [identities] support `where` option on `identities`
 
 - [identities] allow calculations in identity keys
 
@@ -2265,7 +2265,7 @@ We are starting the changelog fresh. See `documentation/2.0-CHANGELOG.md` in Git
 For a guide on adjusting to these breaking changes, see the [upgrade guide](/documentation/topics/development/upgrading-to-3.0.md)
 
 - [Ash.Api] has been renamed to `Ash.Domain`, and references to the concept have been renamed as well, i.e in options and in the DSL
-- [Ash] we now call functions on this, isntead of the domain. i.e `Ash.create` and `Ash.read`. The generated functions are now marked as deprecated
+- [Ash] we now call functions on this, instead of the domain. i.e `Ash.create` and `Ash.read`. The generated functions are now marked as deprecated
 - [Ash] remove process context functionality. You can no longer store the actor/tenant in the context with `Ash.set_actor` and so on
 - [private?] deprecate `private?: false` in favor of the more explicit `public?: true`
 - [default_accept] default `default_accept` is now `[]`

--- a/documentation/2.0-CHANGELOG.md
+++ b/documentation/2.0-CHANGELOG.md
@@ -379,7 +379,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 - change names of code interface methods for calculations (#863)
 
-- properly mark manuall created input refs with `input?: true`
+- properly mark manually created input refs with `input?: true`
 
 - clean vars should handle map vars
 
@@ -1303,7 +1303,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes:
 
-- propertly handle configured list of tracers
+- properly handle configured list of tracers
 
 ## [v2.14.14](https://github.com/ash-project/ash/compare/v2.14.13...v2.14.14) (2023-09-12)
 
@@ -1547,7 +1547,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 - validate arg (#662)
 
-- validate argument unequality
+- validate argument inequality
 
 - validate argument in
 
@@ -1883,7 +1883,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 - `Ash.Query.accessing/2` to get a list of fields being accessed
 
-- builting `LoadAttribute` and `LoadRelationship` calculations
+- building `LoadAttribute` and `LoadRelationship` calculations
 
 - warn on invalid/impossible policies
 
@@ -3099,7 +3099,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes:
 
-- don't raise a backwards incompatible error message on certian changeset functions
+- don't raise a backwards incompatible error message on certain changeset functions
 
 - properly apply managed relationships on manual actions
 
@@ -3450,7 +3450,7 @@ the order allows direct reuse without any gymnastics
 
 - add some info to policy errors
 
-- experimental support for calcualtions accepting expression arguments
+- experimental support for calculations accepting expression arguments
 
 - various Ash.Flow improvements, including returning the new `Ash.Flow.Result`
 
@@ -4738,7 +4738,7 @@ the order allows direct reuse without any gymnastics
 
 ### Improvements:
 
-- use paramaterized types under the hood
+- use parameterized types under the hood
 
 ## [v1.47.12](https://github.com/ash-project/ash/compare/v1.47.11...v1.47.12) (2021-09-12)
 

--- a/documentation/dsls/DSL-Ash.Policy.Authorizer.md
+++ b/documentation/dsls/DSL-Ash.Policy.Authorizer.md
@@ -883,7 +883,7 @@ end
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`private_fields`](#field_policies-private_fields){: #field_policies-private_fields } | `:show \| :hide \| :include` | `:show` | How private fields should be handeled by field policies in internal functions. See the [Policies guide](documentation/topics/security/policies.md#field-policies) for more. |
+| [`private_fields`](#field_policies-private_fields){: #field_policies-private_fields } | `:show \| :hide \| :include` | `:show` | How private fields should be handled by field policies in internal functions. See the [Policies guide](documentation/topics/security/policies.md#field-policies) for more. |
 
 
 

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -1039,7 +1039,7 @@ end
 |------|------|---------|------|
 | [`manual`](#actions-create-manual){: #actions-create-manual } | `(any, any -> any) \| module` |  | Override the creation behavior. Accepts a module or module and opts, or a function that takes the changeset and context. See the [manual actions guide](/documentation/topics/manual-actions.md) for more. |
 | [`upsert?`](#actions-create-upsert?){: #actions-create-upsert? } | `boolean` | `false` | Forces all uses of this action to be treated as an upsert. |
-| [`upsert_identity`](#actions-create-upsert_identity){: #actions-create-upsert_identity } | `atom` |  | The identity to use for the upsert. Cannot be overriden by the caller. Ignored  if `upsert?` is not set to `true`. |
+| [`upsert_identity`](#actions-create-upsert_identity){: #actions-create-upsert_identity } | `atom` |  | The identity to use for the upsert. Cannot be overridden by the caller. Ignored  if `upsert?` is not set to `true`. |
 | [`upsert_fields`](#actions-create-upsert_fields){: #actions-create-upsert_fields } | `:replace_all \| {:replace, atom \| list(atom)} \| {:replace_all_except, atom \| list(atom)} \| atom \| list(atom)` |  | The fields to overwrite in the case of an upsert. If not provided, all fields except for fields set by defaults will be overwritten. |
 | [`upsert_condition`](#actions-create-upsert_condition){: #actions-create-upsert_condition } | `any` |  | An expression to check if the record should be updated when there's a conflict. |
 | [`return_skipped_upsert?`](#actions-create-return_skipped_upsert?){: #actions-create-return_skipped_upsert? } | `boolean` |  | Returns the record that would have been upserted against but was skipped due to a filter or no fields being changed. How this works depends on the data layer. Keep in mind that read policies *are not applied* to the read of the record in question. |
@@ -2389,7 +2389,7 @@ identity :full_name, [:first_name, :last_name]
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`where`](#identities-identity-where){: #identities-identity-where } | `any` |  | A filter that expresses only matching records are unique on the provided keys. Ignored on embedded resources. |
-| [`nils_distinct?`](#identities-identity-nils_distinct?){: #identities-identity-nils_distinct? } | `boolean` | `true` | Whether or not `nil` values are considered always distinct from eachother. `nil` values won't conflict with eachother unless you set this option to `false`. |
+| [`nils_distinct?`](#identities-identity-nils_distinct?){: #identities-identity-nils_distinct? } | `boolean` | `true` | Whether or not `nil` values are considered always distinct from each other. `nil` values won't conflict with each other unless you set this option to `false`. |
 | [`eager_check?`](#identities-identity-eager_check?){: #identities-identity-eager_check? } | `boolean` | `false` | Whether or not this identity is validated to be unique at validation time. |
 | [`eager_check_with`](#identities-identity-eager_check_with){: #identities-identity-eager_check_with } | `module` |  | Validates that the unique identity provided is unique at validation time, outside of any transactions, using the domain module provided. Will default to resource's domain. |
 | [`pre_check?`](#identities-identity-pre_check?){: #identities-identity-pre_check? } | `boolean` | `false` | Whether or not this identity is validated to be unique in a before_action hook. |

--- a/documentation/topics/actions/update-actions.md
+++ b/documentation/topics/actions/update-actions.md
@@ -94,7 +94,7 @@ atomic updates.
 
 ## Fully Atomic updates
 
-Atomic updates are a special case of update actions that can be done completely atomically. If your update action can't be done atomically, you will get an error unless you have set `require_atomic? false`. This is to encourage you to opt for atomic updates whereever reasonable. Not all actions can reasonably be made atomic, and not all non-atomic actions are problematic for concurrency. The goal is only to make sure that you are aware and have considered the implications.
+Atomic updates are a special case of update actions that can be done completely atomically. If your update action can't be done atomically, you will get an error unless you have set `require_atomic? false`. This is to encourage you to opt for atomic updates wherever reasonable. Not all actions can reasonably be made atomic, and not all non-atomic actions are problematic for concurrency. The goal is only to make sure that you are aware and have considered the implications.
 
 > ### What does atomic mean? {: .info}
 >

--- a/documentation/topics/development/upgrading-to-3.0.md
+++ b/documentation/topics/development/upgrading-to-3.0.md
@@ -294,7 +294,7 @@ For those who want to be more explicit, or after your upgrade has complete if yo
 
 > ### :\* private attributes can now be accepted {: .info}
 >
-> In 2.0, accepting a private attribute as a change required adding an argument with the same name, and using `change set_attribute(...)`. Now that we require explicit accept lists, you can place private attribtues in that list, which will allow them to be written to (but not read back).
+> In 2.0, accepting a private attribute as a change required adding an argument with the same name, and using `change set_attribute(...)`. Now that we require explicit accept lists, you can place private attributes in that list, which will allow them to be written to (but not read back).
 
 > ### :\* includes belongs_to attributes! {: .warning}
 >
@@ -423,7 +423,7 @@ If you are using api extensions (i.e `AshGraphql` and `AshJsonApi`), you will ne
 
 > ### Embedded resources too! {: .WARNING}
 >
-> The above includes embedded resources as well! Don't forget to make sure that all fields on your embedded resources are also marked as `public?: true` (if applicable). The goal here is to have a clear visual indicator of what in your application can be shown publically.
+> The above includes embedded resources as well! Don't forget to make sure that all fields on your embedded resources are also marked as `public?: true` (if applicable). The goal here is to have a clear visual indicator of what in your application can be shown publicly.
 
 ---
 
@@ -532,7 +532,7 @@ things like IDs in notification topics, that do not change, so for most this wil
 
 If you wish to send a notification for the old value and the new value, then an action cannot be done atomically. Bulk actions must update each record in turn, and atomic updates can't be leveraged.
 
-If you're comfortable with the performance implications, you can restore the previous behavior by addding `previous_values?: true` to your publications in your pub_sub notifier
+If you're comfortable with the performance implications, you can restore the previous behavior by adding `previous_values?: true` to your publications in your pub_sub notifier
 
 ```elixir
 publish :update, ["user:updated", :email], previous_values?: true

--- a/documentation/topics/resources/code-interfaces.md
+++ b/documentation/topics/resources/code-interfaces.md
@@ -18,7 +18,7 @@ You can define a code interface on individual resources as well, using the `code
 
 ```elixir
 code_interface do
-  # the action open can be omitted because it matches the functon name
+  # the action open can be omitted because it matches the function name
   define :open, args: [:subject]
 end
 ```

--- a/documentation/topics/security/actors-and-authorization.md
+++ b/documentation/topics/security/actors-and-authorization.md
@@ -47,7 +47,7 @@ MyDomain.create_post!(Post, authorize?: true)
 
 ## Default value of `authorize?`
 
-The default value of `authorize?` is determined by the `authorization` configuration of the relevant domain. By default, `authorize?` is set to `true` (and so can be ommitted in all of the examples above). If a resource has no authorizers, then all requests will be allowed.
+The default value of `authorize?` is determined by the `authorization` configuration of the relevant domain. By default, `authorize?` is set to `true` (and so can be omitted in all of the examples above). If a resource has no authorizers, then all requests will be allowed.
 
 ## Authorizers
 

--- a/documentation/topics/security/policies.md
+++ b/documentation/topics/security/policies.md
@@ -285,7 +285,7 @@ So lets make our `belongs_to` relationship looks like this.
 belongs_to :author, MyApp.Author do
   allow_nil? false
   allow_forbidden_field? true
-  athorize_read_with :error
+  authorize_read_with :error
 end
 ```
 
@@ -623,7 +623,7 @@ This prevents a common security vulnerability that would allow malicious actors 
 
 #### Field references in filters & sorts
 
-When a field is referenced in filters or sorts, the field reference is replaced with a conditional, that evalutes to the field value if the actor is authorized to view the field, or `nil` otherwise (causing all conditions to evaluate to `false`).
+When a field is referenced in filters or sorts, the field reference is replaced with a conditional, that evaluates to the field value if the actor is authorized to view the field, or `nil` otherwise (causing all conditions to evaluate to `false`).
 
 Lets say that users have a field policy that only allows viewing the email address if the user's id matches the actor's id, similar to the abvoe example.
 
@@ -653,7 +653,7 @@ This prevents the same security vulnerability as described above, which would al
 
 ### Policy Breakdowns
 
-Policy breakdowns can be fetched on demand for a given forbidden error (either an `Ash.Error.Forbidden` that contains one ore more `Ash.Error.Forbidden.Policy` errors, or an `Ash.Error.Forbidden.Policy` error itself), via `Ash.Error.Forbidden.Policy.report/2`.
+Policy breakdowns can be fetched on demand for a given forbidden error (either an `Ash.Error.Forbidden` that contains one or more `Ash.Error.Forbidden.Policy` errors, or an `Ash.Error.Forbidden.Policy` error itself), via `Ash.Error.Forbidden.Policy.report/2`.
 
 Additionally, you can request that they be provided in the error message for all raised forbidden errors (without the help text), by setting
 

--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -123,7 +123,7 @@ defmodule Ash do
                           type: {:one_of, [:filter, :error]},
                           default: :filter,
                           doc:
-                            "If set to `:error`, instead of applying authorization filters as a filter, any records not matching the authroization filter will cause an error to be returned."
+                            "If set to `:error`, instead of applying authorization filters as a filter, any records not matching the authorization filter will cause an error to be returned."
                         ]
                       ],
                       @global_opts,
@@ -257,7 +257,7 @@ defmodule Ash do
                        type: {:one_of, [:filter, :error]},
                        default: :filter,
                        doc:
-                         "If set to `:error`, instead of applying authorization filters as a filter, any records not matching the authroization filter will cause an error to be returned."
+                         "If set to `:error`, instead of applying authorization filters as a filter, any records not matching the authorization filter will cause an error to be returned."
                      ]
                    ]
                    |> Spark.Options.merge(@global_opts, "Global Options")
@@ -423,7 +423,7 @@ defmodule Ash do
 
       `{:notification, notification}` - if `return_notifications?` is set to `true`
       `{:ok, record}` - if `return_records?` is set to `true`
-      `{:error, error}` - an error that occurred. May be changeset or an invidual error.
+      `{:error, error}` - an error that occurred. May be changeset or an individual error.
       """
     ],
     return_nothing?: [

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -78,7 +78,7 @@ defmodule Ash.ActionInput do
     ],
     skip_unknown_inputs: [
       type: {:wrap_list, {:or, [:atom, :string]}},
-      doc: "A list of unknow inputs to skip. Use `:*` to skip all unknown inputs."
+      doc: "A list of unknown inputs to skip. Use `:*` to skip all unknown inputs."
     ],
     tracer: [
       type: :any,

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -198,7 +198,7 @@ defmodule Ash.Actions.Destroy.Bulk do
               # We need to figure out a way to capture errors raised by the stream when picking items off somehow
               # for now, we only go this route if there are potentially more records in the result set than
               # in the batch size, to solve this problem for atomic upgrades.
-              # we can likely make the stream throw something instead of raising somethign
+              # we can likely make the stream throw something instead of raising something
               # like `{:stream_error, ...}` if a specific option is passed in.
               # once we figure this out, we may be able to remove the branch above
               run(

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -154,7 +154,7 @@ defmodule Ash.Actions.Update.Bulk do
               # We need to figure out a way to capture errors raised by the stream when picking items off somehow
               # for now, we only go this route if there are potentially more records in the result set than
               # in the batch size, to solve this problem for atomic upgrades.
-              # we can likely make the stream throw something instead of raising somethign
+              # we can likely make the stream throw something instead of raising something
               # like `{:stream_error, ...}` if a specific option is passed in.
               # once we figure this out, we may be able to remove the branch above
               run(

--- a/lib/ash/error/query/no_such_field.ex
+++ b/lib/ash/error/query/no_such_field.ex
@@ -1,5 +1,5 @@
 defmodule Ash.Error.Query.NoSuchField do
-  @moduledoc "Used when a field(attrbute, calculation, aggregate or relationship) that doesn't exist is used in a query"
+  @moduledoc "Used when a field(attribute, calculation, aggregate or relationship) that doesn't exist is used in a query"
   use Ash.Error.Exception
 
   use Splode.Error, fields: [:resource, :field], class: :invalid

--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -4354,7 +4354,7 @@ defmodule Ash.Filter do
     else
       _ ->
         raise """
-        Attempted to read relationship path that does not exsist.
+        Attempted to read relationship path that does not exist.
 
         Resource: #{inspect(resource)}
         Path: #{inspect(list)}

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -56,7 +56,7 @@ defmodule Ash.Generator do
 
   ## About Generators
 
-  These generators are backed by `StreamData`, and are ready for use with proeprty testing via `ExUnitProperties`
+  These generators are backed by `StreamData`, and are ready for use with property testing via `ExUnitProperties`
 
   Many functions in this module support "overrides", which allow passing down either constant values
   or your own `StreamData` generators.
@@ -192,7 +192,7 @@ defmodule Ash.Generator do
   * `:authorize?` - Passed through to the changeset
   * `:context` - Passed through to the changeset
   * `:after_action` - A one argument function that takes the result and returns
-    a new result to run after the record is creatd.
+    a new result to run after the record is created.
 
   ## The `uses` option
 
@@ -337,7 +337,7 @@ defmodule Ash.Generator do
   * `:authorize?` - Passed through to the changeset
   * `:context` - Passed through to the changeset
   * `:after_action` - A one argument function that takes the result and returns
-    a new result to run after the record is creatd.
+    a new result to run after the record is created.
   """
   @spec seed_generator(
           Ash.Resource.record()

--- a/lib/ash/helpers.ex
+++ b/lib/ash/helpers.ex
@@ -281,7 +281,7 @@ defmodule Ash.Helpers do
   end
 
   @doc """
-  Returns {params, opts} from ambigous inputs.
+  Returns {params, opts} from ambiguous inputs.
   """
   def get_params_and_opts(params_or_opts, opts) do
     if opts == [] && Keyword.keyword?(params_or_opts) do

--- a/lib/ash/plug_helpers.ex
+++ b/lib/ash/plug_helpers.ex
@@ -177,7 +177,7 @@ if Code.ensure_loaded?(Plug.Conn) do
     @doc """
     Sets the context inside the Plug connection.
 
-    Context can be used to store abitrary data about the user, connection, or
+    Context can be used to store arbitrary data about the user, connection, or
     anything else you like that doesn't belong as part of the actor or tenant.
 
     The context is stored inside the [connection's private

--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -424,7 +424,7 @@ defmodule Ash.Policy.Authorizer do
         type: {:one_of, [:show, :hide, :include]},
         default: Application.compile_env(:ash, :policies)[:private_fields] || :show,
         doc: """
-        How private fields should be handeled by field policies in internal functions. See the [Policies guide](documentation/topics/security/policies.md#field-policies) for more.
+        How private fields should be handled by field policies in internal functions. See the [Policies guide](documentation/topics/security/policies.md#field-policies) for more.
         """
       ]
     ]

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -57,7 +57,7 @@ defmodule Ash.Query do
 
   ## Escape Hatches
 
-  Many of these tools are suprisingly deep and capable, covering everything you
+  Many of these tools are surprisingly deep and capable, covering everything you
   need to build your domain logic. With that said, these tools are *not*
   designed to encompass *every kind of query* that you could possibly want to
   write over your data. `Ash` is *not* an ORM or a database query tool, despite

--- a/lib/ash/resource/actions/create.ex
+++ b/lib/ash/resource/actions/create.ex
@@ -80,7 +80,7 @@ defmodule Ash.Resource.Actions.Create do
                 upsert_identity: [
                   type: :atom,
                   doc: """
-                  The identity to use for the upsert. Cannot be overriden by the caller. Ignored  if `upsert?` is not set to `true`.
+                  The identity to use for the upsert. Cannot be overridden by the caller. Ignored  if `upsert?` is not set to `true`.
                   """
                 ],
                 upsert_fields: [

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -1353,7 +1353,7 @@ defmodule Ash.Type do
   @doc """
   Modifies an expression to apply a type's casting logic to the value it produces.
 
-  This delegates to the underlying types implementaiton of `c:cast_atomic/2`.
+  This delegates to the underlying types implementation of `c:cast_atomic/2`.
   """
   @spec cast_atomic(t(), term, constraints()) ::
           {:atomic, Ash.Expr.t()}
@@ -1403,7 +1403,7 @@ defmodule Ash.Type do
   @doc """
   Applies a types constraints to an expression.
 
-  This delegates to the underlying types implementaiton of `c:apply_atomic_constraints/2`.
+  This delegates to the underlying types implementation of `c:apply_atomic_constraints/2`.
   """
   @spec apply_atomic_constraints(t(), term, constraints()) ::
           {:ok, Ash.Expr.t()} | {:error, Ash.Error.t()}

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -799,7 +799,7 @@ defmodule Ash.Test.Actions.CreateTest do
       assert :tag in changeset.defaults
     end
 
-    test "a default being set and then overriden will no longer be annotated as a default" do
+    test "a default being set and then overridden will no longer be annotated as a default" do
       changeset =
         Post
         |> Ash.Changeset.new()

--- a/test/uuid_v7_test.exs
+++ b/test/uuid_v7_test.exs
@@ -13,7 +13,7 @@ defmodule Ash.Test.UUIDv7Test do
       for _ <- 1..100 do
         uuid = Ash.UUIDv7.generate()
         # only guaranteed sorted if >= 1 nanosecond apart
-        # can't sleep for one nanoseond AFAIK, so sleep for 1 ms
+        # can't sleep for one nanosecond AFAIK, so sleep for 1 ms
         :timer.sleep(3)
         uuid
       end
@@ -26,7 +26,7 @@ defmodule Ash.Test.UUIDv7Test do
       for _ <- 1..100 do
         uuid = Ash.UUIDv7.bingenerate()
         # only guaranteed sorted if >= 1 nanosecond apart
-        # can't sleep for one nanoseond AFAIK, so sleep for 1 ms
+        # can't sleep for one nanosecond AFAIK, so sleep for 1 ms
         :timer.sleep(3)
         uuid
       end


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Hi! I'm using [codespell](https://github.com/codespell-project/codespell) for checking misspellings/typos in docs and/or comments found in this repo. I ignored words such as `dont` (`don't`), etc.