### PR TITLE
chore: Raise an `ArgumentError` when generating a changeset using a non-existent action

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -763,17 +763,22 @@ defmodule Ash.Generator do
   """
   @spec action_input(
           Ash.Resource.t() | Ash.Resource.record(),
-          action :: atom,
+          action_name :: atom,
           generators :: overrides()
         ) :: map()
-  def action_input(resource_or_record, action, generators \\ %{}) do
+  def action_input(resource_or_record, action_name, generators \\ %{}) do
     resource =
       case resource_or_record do
         %resource{} -> resource
         resource -> resource
       end
 
-    action = Ash.Resource.Info.action(resource, action)
+    action = Ash.Resource.Info.action(resource, action_name)
+
+    if !action do
+      raise ArgumentError,
+            "Invalid action #{inspect(resource)}.#{action_name}"
+    end
 
     arguments = Enum.reject(action.arguments, &find_manage_change(&1, action))
 

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -504,6 +504,14 @@ defmodule Ash.Test.GeneratorTest do
                Ash.Generator.changeset_generator(Author, :create, overrides: @meta_generator)
                |> Ash.Generator.generate()
     end
+
+    test "it raises an error for an invalid action name" do
+      assert_raise ArgumentError,
+                   "Invalid action Ash.Test.GeneratorTest.Author.jeremy_bearimy",
+                   fn ->
+                     Ash.Generator.changeset_generator(Author, :jeremy_bearimy)
+                   end
+    end
   end
 
   describe "seed" do


### PR DESCRIPTION
Without this change, the next line raises an error:

```
** (KeyError) key :arguments not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
```

Putting this in a PR for a quick once-over, in case there's an established pattern for doing this that I just missed.

# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
