### PR TITLE
docs: Fix a bad copy-paste mixing up `changeset_generator/3` and `seed_generator/2` documentation

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -123,10 +123,10 @@ defmodule Ash.Generator do
   end
 
   @doc """
-  A generator of seedable records, to be passed to `generate/1` or `generate_many/1`
+  A generator of changesets which call their specific actions when passed to `generate/1` or `generate_many/2`.
 
-  See `changeset_generator/3` for the equivalent construct for cases when you want to call resource
-  actions as opposed to seed directly to the data layer.
+  See `seed_generator/2` for the equivalent construct for cases when you want to seed directly to the data layer as opposed to calling resource
+  actions.
 
   ## Examples
 


### PR DESCRIPTION
Simple fix to documentation after [conferring with @zachdaniel](https://discord.com/channels/711271361523351632/1364820978160500797) on Discord.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
