### PR TITLE
fix: only return the changeset

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -3169,7 +3169,7 @@ defmodule Ash.Actions.Update.Bulk do
                   )
 
                 changeset ->
-                  {:cont, changeset}
+                  changeset
               end
             end)
 
@@ -3258,7 +3258,7 @@ defmodule Ash.Actions.Update.Bulk do
                   )
 
                 changeset ->
-                  {:cont, changeset}
+                  changeset
               end
             end)
 


### PR DESCRIPTION
Having the :cont there lead to it breaking [here](https://github.com/ash-project/ash/blob/fafa5b4f9f8378c021668d53cf4e3a98d40f0a16/lib/ash/actions/update/bulk.ex#L3013-L3014)
