### PR TITLE
docs: fix pipe shorthand error

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -416,10 +416,11 @@ ticket = (
   |> Ash.create!()
 )
 
-ticket =
+ticket = (
   ticket
   |> Ash.Changeset.for_update(:close)
   |> Ash.update!()
+)
 
 #Helpdesk.Support.Ticket<
   ...


### PR DESCRIPTION
Pipe shorthand is not allowed immediately after a match expression in IEx.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
