### PR TITLE
Calculation doc: mention the context argument

### DIFF
--- a/lib/ash/resource/calculation/calculation.ex
+++ b/lib/ash/resource/calculation/calculation.ex
@@ -49,7 +49,7 @@ defmodule Ash.Resource.Calculation do
          ]},
       required: true,
       doc: """
-      The `module`, `{module, opts}` or `expr(...)` to use for the calculation. Also accepts a function that takes *a list of records* and produces a result for each record.
+      The `module`, `{module, opts}` or `expr(...)` to use for the calculation. Also accepts a function that takes *a list of records* and the context, and produces a result for each record.
       """
     ],
     description: [


### PR DESCRIPTION
I got bitten by this, and had to check the doc for calculations to figure that the second argument is the context. So I though I'd fix it :)

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
