### PR TITLE
only print topic if present

### DIFF
--- a/lib/ash/notifier/pub_sub/pub_sub.ex
+++ b/lib/ash/notifier/pub_sub/pub_sub.ex
@@ -489,9 +489,31 @@ defmodule Ash.Notifier.PubSub do
 
   defp publishable_value?(nil, _notification), do: false
 
+  defp publishable_value?(
+         %Ash.NotLoaded{field: field},
+         %{topic: topic, resource: resource} = notification
+       ) do
+    Logger.warning(
+      "Not publishing notification `#{inspect(topic)}` for #{inspect(resource)} because `#{field}` is not loaded"
+    )
+
+    false
+  end
+
   defp publishable_value?(%Ash.NotLoaded{field: field}, notification) do
     Logger.warning(
-      "Not publishing notification `#{inspect(notification.topic)}` for #{inspect(notification.resource)} because `#{field}` is not loaded"
+      "Not publishing notification for #{inspect(notification.resource)} because `#{field}` is not loaded"
+    )
+
+    false
+  end
+
+  defp publishable_value?(
+         %Ash.ForbiddenField{field: field},
+         %{topic: topic, resource: resource} = notification
+       ) do
+    Logger.warning(
+      "Not publishing notification `#{inspect(topic)}` for #{inspect(resource)} because `#{field}` is an `%Ash.ForbiddenField{}`"
     )
 
     false
@@ -499,7 +521,7 @@ defmodule Ash.Notifier.PubSub do
 
   defp publishable_value?(%Ash.ForbiddenField{field: field}, notification) do
     Logger.warning(
-      "Not publishing notification `#{inspect(notification.topic)}` for #{inspect(notification.resource)} because `#{field}` is an `%Ash.ForbiddenField{}`"
+      "Not publishing notification for #{inspect(notification.resource)} because `#{field}` is an `%Ash.ForbiddenField{}`"
     )
 
     false


### PR DESCRIPTION
Not sure if it fixes a bug that might be present, but it does fix a symptom. Kept seeing this error:

```elixir
* ** (KeyError) key :topic not found in: %Ash.Notifier.Notification{
  resource: MyApp.Accounts.User,
  domain: MyApp.Accounts,
  action: %Ash.Resource.Actions.Update{
    name: :update,
    primary?: true,
    description: nil,
    error_handler: nil,
    accept: [:email, :role, :first_name, :last_name, :company_id, :depot_id],
    require_attributes: [],
    allow_nil_input: [],
    skip_unknown_inputs: [],
    manual: nil,
    manual?: false,
    require_atomic?: false,
    atomic_upgrade?: false,
    atomic_upgrade_with: nil,
    action_select: nil,
    notifiers: [],
    atomics: [],
    delay_global_validations?: false,
    skip_global_validations?: false,
    arguments: [],
    changes: [],
    reject: [],
    metadata: [],
    transaction?: true,
    touches_resources: [],
    type: :update
  },
  data: #MyApp.Accounts.User<
    routes: #Ash.NotLoaded<:relationship, field: :routes>,
    depot: #Ash.NotLoaded<:relationship, field: :depot>,
    company: #Ash.NotLoaded<:relationship, field: :company>,
    paper_trail_versions: #Ash.NotLoaded<:relationship, field: :paper_trail_versions>,
    __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
    id: "838e5a22-9b2c-466c-b0fe-8634c2a17d9b",
    email: #Ash.CiString<"user@test.com">,
    role: #Ash.NotLoaded<:attribute, field: :role>,
    first_name: #Ash.NotLoaded<:attribute, field: :first_name>,
    last_name: #Ash.NotLoaded<:attribute, field: :last_name>,
    company_id: #Ash.NotLoaded<:attribute, field: :company_id>,
    depot_id: #Ash.NotLoaded<:attribute, field: :depot_id>,
    archived_at: #Ash.NotLoaded<:attribute, field: :archived_at>,
    aggregates: %{},
    calculations: %{},
    ...
  >,
  changeset: #Ash.Changeset<
    domain: MyApp.Accounts,
    action_type: :update,
    action: :update,
    tenant: "601f308d-556a-40a3-9eda-05bbd1cee1b9",
    attributes: %{
      company_id: "38fa90

    (ash 3.5.7) lib/ash/notifier/pub_sub/pub_sub.ex:494: Ash.Notifier.PubSub.publishable_value?/2
    (ash 3.5.7) lib/ash/notifier/pub_sub/pub_sub.ex:445: Ash.Notifier.PubSub.all_combinations_of_values/5
    (ash 3.5.7) lib/ash/notifier/pub_sub/pub_sub.ex:338: Ash.Notifier.PubSub.fill_template/4
    (ash 3.5.7) lib/ash/notifier/pub_sub/pub_sub.ex:257: Ash.Notifier.PubSub.publish_notification/2
    (elixir 1.17.3) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ash 3.5.7) lib/ash/notifier/notifier.ex:45: anonymous fn/3 in Ash.Notifier.notify/1
    (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash 3.5.7) lib/ash/notifier/notifier.ex:37: Ash.Notifier.notify/1
    (ash 3.5.7) lib/ash/actions/update/bulk.ex:269: Ash.Actions.Update.Bulk.run/6
    (ash_graphql 1.7.8) lib/graphql/resolver.ex:1590: AshGraphql.Graphql.Resolver.mutate/2
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:234: Absinthe.Phase.Document.Execution.Resolution.reduce_resolution/1
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:189: Absinthe.Phase.Document.Execution.Resolution.do_resolve_field/3
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:174: Absinthe.Phase.Document.Execution.Resolution.do_resolve_fields/6
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:145: Absinthe.Phase.Document.Execution.Resolution.resolve_fields/4
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:88: Absinthe.Phase.Document.Execution.Resolution.walk_result/5
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:67: Absinthe.Phase.Document.Execution.Resolution.perform_resolution/3
    (absinthe 1.7.9) lib/absinthe/phase/document/execution/resolution.ex:24: Absinthe.Phase.Document.Execution.Resolution.resolve_current/3
    (absinthe 1.7.9) lib/absinthe/pipeline.ex:408: Absinthe.Pipeline.run_phase/3
    (absinthe_plug 1.5.8) lib/absinthe/plug.ex:536: Absinthe.Plug.run_query/4
```

Noticed that the stacktrace appears to be entirely Ash itself, so there might be a bug.
This triggers when making a (likely wrong) call via GraphQL