### PR TITLE
feat: duration

### DIFF
--- a/lib/ash/query/function/date_add.ex
+++ b/lib/ash/query/function/date_add.ex
@@ -1,9 +1,12 @@
 defmodule Ash.Query.Function.DateAdd do
   @moduledoc """
-  Adds the given interval to the current time in UTC
+  Adds the given interval or Duration to the current time in UTC
+  Adds the given interval or Duration to the current time in UTC
 
   For example:
      activates_at < date_add(today(), 7, :day)
+     activates_at < date_add(today(), Duration.new!(day: 7))
+     activates_at < date_add(today(), Duration.new!(day: 7))
 
   Documentation + available intervals inspired by the corresponding ecto interval implementation
   """
@@ -12,7 +15,7 @@ defmodule Ash.Query.Function.DateAdd do
 
   @beginning_of_day Time.new!(0, 0, 0)
 
-  def args, do: [[:date, :integer, :duration_name]]
+  def args, do: [[:date, :integer, :duration_name], [:date, :duration]]
 
   def returns, do: [:date]
 
@@ -22,6 +25,11 @@ defmodule Ash.Query.Function.DateAdd do
          truncated <- DateTime.to_date(shifted) do
       {:known, truncated}
     end
+  end
+
+  def evaluate(%{arguments: [date, duration]}) when is_struct(duration, Duration) do
+    shifted = Date.shift(date, duration)
+    {:known, shifted}
   end
 
   def can_return_nil?(%{arguments: [date | _]}) do

--- a/lib/ash/query/function/datetime_add.ex
+++ b/lib/ash/query/function/datetime_add.ex
@@ -1,21 +1,27 @@
 defmodule Ash.Query.Function.DateTimeAdd do
   @moduledoc """
-  Adds the given interval to the current time in UTC
+  Adds the given interval or Duration to the current time in UTC
 
   For example:
      activates_at < datetime_add(now(), 7, :day)
+     activates_at < datetime_add(now(), Duration.new!(day:7))
 
   Documentation + available intervals inspired by the corresponding ecto interval implementation
   """
 
   use Ash.Query.Function, name: :datetime_add, eager_evaluate?: false
 
-  def args, do: [[:utc_datetime, :integer, :duration_name]]
+  def args, do: [[:utc_datetime, :integer, :duration_name], [:utc_datetime, :duration]]
 
   def returns, do: [:utc_datetime]
 
   def evaluate(%{arguments: [datetime, factor, interval]}) do
     shifted = Ash.Query.Function.Ago.datetime_add(datetime, factor, interval)
+    {:known, shifted}
+  end
+
+  def evaluate(%{arguments: [datetime, duration]}) when is_struct(duration, Duration) do
+    shifted = DateTime.shift(datetime, duration)
     {:known, shifted}
   end
 

--- a/lib/ash/query/function/from_now.ex
+++ b/lib/ash/query/function/from_now.ex
@@ -1,9 +1,10 @@
 defmodule Ash.Query.Function.FromNow do
   @moduledoc """
-  Adds the given interval from the current time in UTC.
+  Adds the given interval or Duration from the current time in UTC.
 
   For example:
      expires_at < from_now(7, :day)
+     expires_at < from_now(Duration.new!(day: 7))
 
   Documentation + available intervals inspired by the corresponding ecto interval implementation
   """
@@ -17,6 +18,12 @@ defmodule Ash.Query.Function.FromNow do
   def evaluate(%{arguments: [factor, interval]}) do
     now = DateTime.utc_now()
     shifted = Ash.Query.Function.Ago.datetime_add(now, factor, interval)
+    {:known, shifted}
+  end
+
+  def evaluate(%{arguments: [duration]}) when is_struct(duration, Duration) do
+    now = DateTime.utc_now()
+    shifted = Ash.Query.Function.Ago.datetime_add(now, duration)
     {:known, shifted}
   end
 

--- a/lib/ash/query/function/minus.ex
+++ b/lib/ash/query/function/minus.ex
@@ -1,12 +1,16 @@
 defmodule Ash.Query.Function.Minus do
   @moduledoc """
-  Multiplies the value by negative one
+  Negates the value
   """
   use Ash.Query.Function, name: :-
 
   def args, do: [[:any]]
 
   def returns, do: [:same]
+
+  def evaluate(%{arguments: [duration]}) when is_struct(duration, Duration) do
+    {:known, Duration.negate(duration)}
+  end
 
   def evaluate(%{arguments: [val]}) do
     {:ok, op} = Ash.Query.Operator.Basic.Times.new(val, -1)

--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -13,10 +13,11 @@ defmodule Ash.Query.Operator.Basic do
       no_nils: true,
       evaluate_types: :numbers,
       types: [
+        [:same, :any],
         [:duration, :integer],
         [:integer, :duration]
       ],
-      returns: [:duration, :duration]
+      returns: [:same, :duration, :duration]
     ],
     minus: [
       symbol: :-,
@@ -71,15 +72,6 @@ defmodule Ash.Query.Operator.Basic do
         @moduledoc false
 
         require Decimal
-        require Duration
-        require Date
-        require DateTime
-        require NaiveDateTime
-        require Time
-        require Date
-        require DateTime
-        require NaiveDateTime
-        require Time
 
         use Ash.Query.Operator,
           operator: unquote(opts[:symbol]),

--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -11,7 +11,12 @@ defmodule Ash.Query.Operator.Basic do
     times: [
       symbol: :*,
       no_nils: true,
-      evaluate_types: :numbers
+      evaluate_types: :numbers,
+      types: [
+        [:duration, :integer],
+        [:integer, :duration]
+      ],
+      returns: [:duration, :duration]
     ],
     minus: [
       symbol: :-,
@@ -66,6 +71,15 @@ defmodule Ash.Query.Operator.Basic do
         @moduledoc false
 
         require Decimal
+        require Duration
+        require Date
+        require DateTime
+        require NaiveDateTime
+        require Time
+        require Date
+        require DateTime
+        require NaiveDateTime
+        require Time
 
         use Ash.Query.Operator,
           operator: unquote(opts[:symbol]),
@@ -188,7 +202,7 @@ defmodule Ash.Query.Operator.Basic do
         end
 
         defp do_evaluate(op, left, right)
-             when Decimal.is_decimal(left) or Decimal.is_decimal(right) do
+             when Decimal.is_decimal(left) and Decimal.is_decimal(right) do
           case op do
             :+ -> {:known, Decimal.add(to_decimal(left), to_decimal(right))}
             :* -> {:known, Decimal.mult(to_decimal(left), to_decimal(right))}
@@ -197,12 +211,78 @@ defmodule Ash.Query.Operator.Basic do
           end
         end
 
-        defp do_evaluate(:-, %DateTime{} = left, %DateTime{} = right) do
-          {:known, DateTime.diff(left, right)}
+        defp do_evaluate(:-, %left_name{} = left, %right_name{} = right) do
+          case {left_name, right_name} do
+            {Duration, Duration} ->
+              {:known, Duration.subtract(left, right)}
+
+            {Date, Duration} ->
+              {:known, Date.shift(left, Duration.negate(right))}
+
+            {Date, _} ->
+              {:known, Date.diff(left, right)}
+
+            {DateTime, Duration} ->
+              {:known, DateTime.shift(left, Duration.negate(right))}
+
+            {DateTime, _} ->
+              {:known, DateTime.diff(left, right)}
+
+            {Time, Duration} ->
+              {:known, Time.shift(left, Duration.negate(right))}
+
+            {Time, _} ->
+              {:known, Time.diff(left, right)}
+
+            {NaiveDateTime, Duration} ->
+              {:known, NaiveDateTime.shift(left, Duration.negate(right))}
+
+            {NaiveDateTime, _} ->
+              {:known, NaiveDateTime.diff(left, right)}
+
+            _ ->
+              :unknown
+          end
         end
 
-        defp do_evaluate(:-, %Date{} = left, %Date{} = right) do
-          {:known, Date.diff(left, right)}
+        defp do_evaluate(:+, %left_name{} = left, %right_name{} = right) do
+          case {left_name, right_name} do
+            {Duration, Duration} -> {:known, Duration.add(left, right)}
+            {Date, Duration} -> {:known, Date.shift(left, right)}
+            {Duration, Date} -> {:known, Date.shift(right, left)}
+            {DateTime, Duration} -> {:known, DateTime.shift(left, right)}
+            {Duration, DateTime} -> {:known, DateTime.shift(right, left)}
+            {NaiveDateTime, Duration} -> {:known, NaiveDateTime.shift(left, right)}
+            {Duration, NaiveDateTime} -> {:known, NaiveDateTime.shift(right, left)}
+            {Time, Duration} -> {:known, Time.shift(left, right)}
+            {Duration, Time} -> {:known, Time.shift(right, left)}
+            _ -> :unknown
+          end
+        end
+
+        defp do_evaluate(:*, left, right)
+             when is_struct(left, Duration) or is_struct(right, Duration) do
+          cond do
+            is_struct(left, Duration) and is_integer(right) ->
+              {:known, Duration.multiply(left, right)}
+
+            is_integer(left) and is_struct(right, Duration) ->
+              {:known, Duration.multiply(right, left)}
+          end
+        end
+
+        defp do_evaluate(op, left, right) when is_struct(left, Duration) and is_struct(right, Duration) do
+          case op do
+            :+ -> {:known, Duration.add(left, right)}
+            :- -> {:known, Duration.subtract(left, right)}
+          end
+        end
+
+        defp do_evaluate(:*, left, right) when is_struct(left, Duration) or is_struct(right, Duration) do
+          cond do
+            is_struct(left, Duration) and is_integer(right) -> {:known, Duration.multiply(left, right)}
+            is_integer(left) and is_struct(right, Duration) -> {:known, Duration.multiply(right, left)}
+          end
         end
 
         if unquote(opts[:evaluate_types]) == :numbers do

--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -271,17 +271,23 @@ defmodule Ash.Query.Operator.Basic do
           end
         end
 
-        defp do_evaluate(op, left, right) when is_struct(left, Duration) and is_struct(right, Duration) do
+        defp do_evaluate(op, left, right)
+             when is_struct(left, Duration) and is_struct(right, Duration) do
           case op do
             :+ -> {:known, Duration.add(left, right)}
             :- -> {:known, Duration.subtract(left, right)}
+            _ -> :unknown
           end
         end
 
-        defp do_evaluate(:*, left, right) when is_struct(left, Duration) or is_struct(right, Duration) do
+        defp do_evaluate(:*, left, right)
+             when is_struct(left, Duration) or is_struct(right, Duration) do
           cond do
-            is_struct(left, Duration) and is_integer(right) -> {:known, Duration.multiply(left, right)}
-            is_integer(left) and is_struct(right, Duration) -> {:known, Duration.multiply(right, left)}
+            is_struct(left, Duration) and is_integer(right) ->
+              {:known, Duration.multiply(left, right)}
+
+            is_integer(left) and is_struct(right, Duration) ->
+              {:known, Duration.multiply(right, left)}
           end
         end
 

--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -1,0 +1,53 @@
+defmodule Ash.Type.Duration do
+  @moduledoc """
+  Represents a Duration
+
+  A builtin type that can be referenced via `:duration`
+  """
+  use Ash.Type
+
+  @impl true
+  def storage_type(_), do: :duration
+
+  @impl true
+  def generator(_constraints) do
+    # Waiting on blessed date/datetime generators in stream data
+    # https://github.com/whatyouhide/stream_data/pull/161/files
+    StreamData.constant(Duration.new!(minute: 30))
+  end
+
+  @impl true
+  def cast_input(nil, _), do: {:ok, nil}
+
+  def cast_input(value, _) do
+    Ecto.Type.cast(:duration, value)
+  end
+
+  @impl true
+  def matches_type?(%Duration{}, _), do: true
+  def matches_type?(_, _), do: false
+
+  @impl true
+  def cast_atomic(new_value, _constraints) do
+    {:atomic, new_value}
+  end
+
+  @impl true
+  def cast_stored(nil, _), do: {:ok, nil}
+
+  def cast_stored(value, constraints) when is_binary(value) do
+    cast_input(value, constraints)
+  end
+
+  def cast_stored(value, _) do
+    Ecto.Type.load(:duration, value)
+  end
+
+  @impl true
+
+  def dump_to_native(nil, _), do: {:ok, nil}
+
+  def dump_to_native(value, _) do
+    Ecto.Type.dump(:duration, value)
+  end
+end

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -55,6 +55,7 @@ defmodule Ash.Type do
     utc_datetime: Ash.Type.UtcDatetime,
     utc_datetime_usec: Ash.Type.UtcDatetimeUsec,
     datetime: Ash.Type.DateTime,
+    duration: Ash.Type.Duration,
     url_encoded_binary: Ash.Type.UrlEncodedBinary,
     union: Ash.Type.Union,
     module: Ash.Type.Module,

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -109,7 +109,7 @@ defmodule Ash.Test.ExprTest do
       now = DateTime.utc_now()
       tomorrow = DateTime.add(now, 1, :day)
       expr = expr(^tomorrow - ^now)
-      assert eval!(expr) == 86400
+      assert eval!(expr) == 86_400
     end
 
     test "date diff expression" do

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -109,7 +109,7 @@ defmodule Ash.Test.ExprTest do
       now = DateTime.utc_now()
       tomorrow = DateTime.add(now, 1, :day)
       expr = expr(^tomorrow - ^now)
-      assert eval!(expr) == 86_400
+      assert eval!(expr) == 86400
     end
 
     test "date diff expression" do

--- a/test/query/function/ago_test.exs
+++ b/test/query/function/ago_test.exs
@@ -9,6 +9,15 @@ defmodule Ash.Query.Function.AgoTest do
       assert {:known, %DateTime{} = datetime} = Ago.evaluate(%{arguments: [1, :year]})
       assert datetime.year == today.year - 1
     end
+
+    test "Years ago :duration" do
+      today = Date.utc_today()
+
+      assert {:known, %DateTime{} = datetime} =
+               Ago.evaluate(%{arguments: [Duration.new!(year: 1)]})
+
+      assert datetime.year == today.year - 1
+    end
   end
 
   describe "datetime_add helper" do
@@ -54,7 +63,21 @@ defmodule Ash.Query.Function.AgoTest do
 
     test "Adding -5 minutes is the same as adding -300 seconds" do
       now = DateTime.utc_now()
-      assert Ago.datetime_add(now, -5, :minute) == DateTime.add(now, -300, :second)
+
+      assert Ago.datetime_add(now, Duration.new!(hour: 3)) ==
+               Ago.datetime_add(now, Duration.new!(minute: 180))
+    end
+
+    test "Adding -5 minutes is the same as adding -300 seconds " do
+      now = DateTime.utc_now()
+      assert Ago.datetime_add(now, -5, :minute) == Ago.datetime_add(now, -300, :second)
+    end
+
+    test "Adding -5 minutes :duration is the same as adding -300 seconds :duration" do
+      now = DateTime.utc_now()
+
+      assert Ago.datetime_add(now, Duration.new!(minute: -5)) ==
+               Ago.datetime_add(now, Duration.new!(second: -300))
     end
   end
 end

--- a/test/query/function/date_add_test.exs
+++ b/test/query/function/date_add_test.exs
@@ -13,4 +13,15 @@ defmodule Ash.Query.Function.DateAddTest do
       assert date.year == today.year + 1
     end
   end
+
+  describe "date_add :duration query function" do
+    test "1 year from today" do
+      today = DateTime.utc_now() |> DateTime.to_date()
+
+      assert {:known, %Date{} = date} =
+               DateAdd.evaluate(%{arguments: [today, Duration.new!(year: 1)]})
+
+      assert date.year == today.year + 1
+    end
+  end
 end

--- a/test/query/function/datetime_add_test.exs
+++ b/test/query/function/datetime_add_test.exs
@@ -13,4 +13,15 @@ defmodule Ash.Query.Function.DateTimeAddTest do
       assert datetime.year == today.year + 1
     end
   end
+
+  describe "datetime_add :duration query function" do
+    test "1 year from today" do
+      today = DateTime.utc_now()
+
+      assert {:known, %DateTime{} = datetime} =
+               DateTimeAdd.evaluate(%{arguments: [today, Duration.new!(year: 1)]})
+
+      assert datetime.year == today.year + 1
+    end
+  end
 end

--- a/test/query/function/from_now_test.exs
+++ b/test/query/function/from_now_test.exs
@@ -1,0 +1,22 @@
+defmodule Ash.Query.Function.FromNowTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Query.Function.FromNow
+
+  describe "from now query function" do
+    test "Years from now" do
+      today = Date.utc_today()
+      assert {:known, %DateTime{} = datetime} = FromNow.evaluate(%{arguments: [1, :year]})
+      assert datetime.year == today.year + 1
+    end
+
+    test "Years from now :duration" do
+      today = Date.utc_today()
+
+      assert {:known, %DateTime{} = datetime} =
+               FromNow.evaluate(%{arguments: [Duration.new!(year: 1)]})
+
+      assert datetime.year == today.year + 1
+    end
+  end
+end

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -66,6 +66,7 @@ defmodule Ash.Test.Type.DurationTest do
       calculate :duration_a_plus_b, :duration, expr(duration_a + duration_b)
       calculate :duration_b_minus_a, :duration, expr(duration_b - duration_a)
       calculate :duration_b_times_three, :duration, expr(duration_b * 3)
+      calculate :duration_two_times_b, :duration, expr(2 * duration_b)
       calculate :duration_a_negated, :duration, expr(-duration_a)
       calculate :date_plus_duration_d, :date, expr(datetime + duration_d)
       calculate :date_minus_duration_d, :date, expr(datetime - duration_d)
@@ -198,6 +199,7 @@ defmodule Ash.Test.Type.DurationTest do
         :duration_a_plus_b,
         :duration_b_minus_a,
         :duration_b_times_three,
+        :duration_two_times_b,
         :duration_a_negated,
         :date_plus_duration_d,
         :date_minus_duration_d,
@@ -218,6 +220,7 @@ defmodule Ash.Test.Type.DurationTest do
     assert post.duration_a_plus_b == %Duration{hour: 1, minute: 30}
     assert post.duration_b_minus_a == %Duration{hour: -1, minute: 30}
     assert post.duration_b_times_three == %Duration{minute: 90}
+    assert post.duration_two_times_b == %Duration{minute: 60}
     assert post.duration_a_negated == %Duration{hour: -1}
     assert post.date_plus_duration_d == Date.shift(@today, @year1)
     assert post.date_minus_duration_d == Date.shift(@today, Duration.negate(@year1))

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -1,0 +1,261 @@
+defmodule Ash.Test.Type.DurationTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  import Ash.Expr
+  alias Ash.Query.Operator.Basic
+
+  import Ash.Expr
+  alias Ash.Query.Operator.Basic
+
+  @year1 Duration.new!(year: 1)
+  @month5 Duration.new!(month: 5)
+  @hour1 Duration.new!(hour: 1)
+  @minute30 Duration.new!(minute: 30)
+  @millisecond1 Duration.new!(microsecond: {1000, 6})
+
+  @today Date.utc_today()
+  @datetime_now DateTime.utc_now()
+  @naive_datetime_now NaiveDateTime.utc_now()
+  @time_now Time.utc_now()
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :duration_a, :duration do
+        public?(true)
+      end
+
+      attribute :duration_b, :duration, allow_nil?: false, public?: true
+
+      attribute :duration_c, :duration, allow_nil?: true, public?: true
+
+      attribute :duration_d, :duration, allow_nil?: true, public?: true
+
+      attribute :date, :date, allow_nil?: true, public?: true
+
+      attribute :datetime, :datetime, allow_nil?: true, public?: true
+
+      attribute :naive_datetime, :naive_datetime, allow_nil?: true, public?: true
+
+      attribute :time, :time, allow_nil?: true, public?: true
+
+      attribute :time_usec, :time_usec, allow_nil?: true, public?: true
+
+      attribute :utc_datetime, :utc_datetime, allow_nil?: true, public?: true
+
+      attribute :utc_datetime_usec, :utc_datetime_usec, allow_nil?: true, public?: true
+    end
+
+    calculations do
+      calculate :duration_a_plus_b, :duration, expr(duration_a + duration_b)
+      calculate :duration_b_minus_a, :duration, expr(duration_b - duration_a)
+      calculate :duration_b_times_three, :duration, expr(duration_b * 3)
+      calculate :duration_a_negated, :duration, expr(-duration_a)
+      calculate :date_plus_duration_d, :date, expr(datetime + duration_d)
+      calculate :date_minus_duration_d, :date, expr(datetime - duration_d)
+      calculate :datetime_plus_duration_a, :datetime, expr(datetime + duration_a)
+      calculate :datetime_minus_duration_b, :datetime, expr(datetime - duration_b)
+
+      calculate :naive_datetime_plus_duration_a,
+                :naive_datetime,
+                expr(naive_datetime + duration_a)
+
+      calculate :naive_datetime_minus_duration_b,
+                :naive_datetime,
+                expr(naive_datetime - duration_b)
+
+      calculate :time_plus_duration_a, :time, expr(time + duration_a)
+      calculate :time_minus_duration_b, :time, expr(time - duration_b)
+      calculate :time_usec_plus_duration_c, :time_usec, expr(time_usec + duration_c)
+      calculate :time_usec_minus_duration_c, :time_usec, expr(time_usec - duration_c)
+      calculate :utc_datetime_plus_duration_a, :utc_datetime, expr(utc_datetime + duration_a)
+      calculate :utc_datetime_minus_duration_b, :utc_datetime, expr(utc_datetime - duration_b)
+
+      calculate :utc_datetime_usec_plus_duration_c,
+                :utc_datetime_usec,
+                expr(utc_datetime_usec + duration_c)
+
+      calculate :utc_datetime_usec_minus_duration_c,
+                :utc_datetime_usec,
+                expr(utc_datetime_usec - duration_c)
+    end
+  end
+
+  test "it handles non-empty values" do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{
+        duration_a: @hour1,
+        duration_b: @minute30
+      })
+      |> Ash.create!()
+
+    assert post.duration_a == @hour1
+    assert post.duration_b == @minute30
+    assert post.duration_c == nil
+  end
+
+  describe "functions resulting in duration" do
+    test "minus function performs negation" do
+      assert Ash.Query.Function.Minus.evaluate(%{arguments: [@year1]}) ==
+               {:known, Duration.new!(year: -1)}
+    end
+  end
+
+  describe "operators resulting in duration" do
+    test "plus operator performs addition of two durations" do
+      assert Basic.Plus.evaluate(%{left: @year1, right: @month5}) ==
+               {:known, Duration.add(@year1, @month5)}
+    end
+
+    test "minus operator performs subtraction of two durations" do
+      assert Basic.Minus.evaluate(%{left: @year1, right: @month5}) ==
+               {:known, Duration.subtract(@year1, @month5)}
+    end
+
+    test "times operator performs duration times integer" do
+      assert Basic.Times.evaluate(%{left: @year1, right: 2}) ==
+               {:known, Duration.multiply(@year1, 2)}
+    end
+  end
+
+  describe "operators on other temporal types with duration" do
+    test "plus operator performs addition of duration to date" do
+      assert Basic.Plus.evaluate(%{left: @today, right: @year1}) ==
+               {:known, Date.shift(@today, @year1)}
+    end
+
+    test "minus operator performs subtraction of duration from date" do
+      assert Basic.Minus.evaluate(%{left: @today, right: @year1}) ==
+               {:known, Date.shift(@today, Duration.negate(@year1))}
+    end
+
+    test "plus operator performs addition of duration to datetime" do
+      assert Basic.Plus.evaluate(%{left: @datetime_now, right: @year1}) ==
+               {:known, DateTime.shift(@datetime_now, @year1)}
+    end
+
+    test "minus operator performs subtraction of duration from datetime" do
+      assert Basic.Minus.evaluate(%{left: @datetime_now, right: @year1}) ==
+               {:known, DateTime.shift(@datetime_now, Duration.negate(@year1))}
+    end
+
+    test "plus operator performs addition of duration to naive_datetime" do
+      assert Basic.Plus.evaluate(%{left: @naive_datetime_now, right: @year1}) ==
+               {:known, NaiveDateTime.shift(@naive_datetime_now, @year1)}
+    end
+
+    test "minus operator performs subtraction of duration from naive_datetime" do
+      assert Basic.Minus.evaluate(%{left: @naive_datetime_now, right: @year1}) ==
+               {:known, NaiveDateTime.shift(@naive_datetime_now, Duration.negate(@year1))}
+    end
+
+    test "plus operator performs addition of duration to time" do
+      assert Basic.Plus.evaluate(%{left: @time_now, right: @minute30}) ==
+               {:known, Time.shift(@time_now, @minute30)}
+    end
+
+    test "minus operator performs subtraction of duration from time" do
+      assert Basic.Minus.evaluate(%{left: @time_now, right: @minute30}) ==
+               {:known, Time.shift(@time_now, Duration.negate(@minute30))}
+    end
+  end
+
+  test "calculations" do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{
+        duration_a: @hour1,
+        duration_b: @minute30,
+        duration_c: @millisecond1,
+        duration_d: @year1,
+        date: @today,
+        datetime: @datetime_now,
+        naive_datetime: @naive_datetime_now,
+        time: @time_now,
+        time_usec: @time_now,
+        utc_datetime: @datetime_now,
+        utc_datetime_usec: @datetime_now
+      })
+      |> Ash.create!()
+      |> Ash.load!([
+        :duration_a_plus_b,
+        :duration_b_minus_a,
+        :duration_b_times_three,
+        :duration_a_negated,
+        :date_plus_duration_d,
+        :date_minus_duration_d,
+        :datetime_plus_duration_a,
+        :datetime_minus_duration_b,
+        :naive_datetime_plus_duration_a,
+        :naive_datetime_minus_duration_b,
+        :time_plus_duration_a,
+        :time_minus_duration_b,
+        :time_usec_plus_duration_c,
+        :time_usec_minus_duration_c,
+        :utc_datetime_plus_duration_a,
+        :utc_datetime_minus_duration_b,
+        :utc_datetime_usec_plus_duration_c,
+        :utc_datetime_usec_minus_duration_c
+      ])
+
+    assert post.duration_a_plus_b == %Duration{hour: 1, minute: 30}
+    assert post.duration_b_minus_a == %Duration{hour: -1, minute: 30}
+    assert post.duration_b_times_three == %Duration{minute: 90}
+    assert post.duration_a_negated == %Duration{hour: -1}
+    assert post.date_plus_duration_d == Date.shift(@today, @year1)
+    assert post.date_minus_duration_d == Date.shift(@today, Duration.negate(@year1))
+
+    assert post.datetime_plus_duration_a ==
+             DateTime.truncate(DateTime.shift(@datetime_now, @hour1), :second)
+
+    assert post.datetime_minus_duration_b ==
+             DateTime.truncate(DateTime.shift(@datetime_now, Duration.negate(@minute30)), :second)
+
+    assert post.naive_datetime_plus_duration_a ==
+             NaiveDateTime.truncate(NaiveDateTime.shift(@naive_datetime_now, @hour1), :second)
+
+    assert post.naive_datetime_minus_duration_b ==
+             NaiveDateTime.truncate(
+               NaiveDateTime.shift(@naive_datetime_now, Duration.negate(@minute30)),
+               :second
+             )
+
+    assert post.time_plus_duration_a == Time.truncate(Time.shift(@time_now, @hour1), :second)
+
+    assert post.time_minus_duration_b ==
+             Time.truncate(Time.shift(@time_now, Duration.negate(@minute30)), :second)
+
+    assert post.time_usec_plus_duration_c == Time.shift(@time_now, @millisecond1)
+
+    assert post.time_usec_minus_duration_c ==
+             Time.shift(@time_now, Duration.negate(@millisecond1))
+
+    assert post.utc_datetime_plus_duration_a ==
+             DateTime.truncate(DateTime.shift(@datetime_now, @hour1), :second)
+
+    assert post.utc_datetime_minus_duration_b ==
+             DateTime.truncate(DateTime.shift(@datetime_now, Duration.negate(@minute30)), :second)
+
+    assert post.utc_datetime_usec_plus_duration_c == DateTime.shift(@datetime_now, @millisecond1)
+
+    assert post.utc_datetime_usec_minus_duration_c ==
+             DateTime.shift(@datetime_now, Duration.negate(@millisecond1))
+  end
+end


### PR DESCRIPTION
Adds Ash.Type.Duration which is an Elixir Duration, shortname: :duration (also :duration in Ecto). The precision inherent in the interval is maintained. 

The idea is here is to allow Durations to be ash attributes persisted in the chosen DataLayer, noting that Ash has some existing support for durations by combining attributes of :duration_name and :integer type. 

Given that Elixir DateTime.shift, etc can be used with :duration and Comp.compare is implemented (using to_timeout such that durations are compared based on their total magnitude) I'm not sure whether Ash.Query.Function such as Ago, Date_Add, From_Now are needed.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ✔️] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
