### PR TITLE
fix: make sure after_action is called in generate_many

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -782,13 +782,7 @@ defmodule Ash.Generator do
         result.records || []
 
       batch ->
-        Enum.map(batch, fn record ->
-          if record.__meta__.state == :built do
-            Ash.Seed.seed!(record)
-          else
-            record
-          end
-        end)
+        Enum.map(batch, &generate/1)
     end)
   end
 


### PR DESCRIPTION
# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
