### PR TITLE
fix: Tuple loader and serializer

### DIFF
--- a/lib/ash/type/tuple.ex
+++ b/lib/ash/type/tuple.ex
@@ -141,7 +141,7 @@ defmodule Ash.Type.Tuple do
       end
     end)
     |> case do
-      {:ok, value} -> value |> Enum.reverse() |> List.to_tuple()
+      {:ok, value} -> {:ok, value |> Enum.reverse() |> List.to_tuple()}
       {:error, error} -> {:error, error}
     end
   end
@@ -155,8 +155,8 @@ defmodule Ash.Type.Tuple do
     list = Tuple.to_list(value)
 
     if length(list) == length(constraints[:fields]) do
-      value
-      |> Enum.zip_with(constraints[:fields])
+      list
+      |> Enum.zip(constraints[:fields])
       |> Map.new(fn {tuple_val, {key, _config}} ->
         {key, tuple_val}
       end)


### PR DESCRIPTION
The Tuple type had three bugs:

* In dump_to_native the original tuple `value` was used instead of the tuple converted to a list. This caused Elixir to complain that Tuple doesn't have Enumerable implemented when attempting to zip it.
* In dump_to_native Enum.zip_with was used, expecting constraints[:fields] to be a function. This patch changes that to Enum.zip so it properly zips up the tuple-to-list with the :fields constraints.
* In cast_stored we were returning the tuple, instead of {:ok, tuple} causing downstream to fail since it expected an {:ok, value} structure.

I'm not sure where to add tests for this, would love some guidance there :)

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
