### PR TITLE
improvement: add `Ash.Scope` for converting a scope to options

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -67,7 +67,7 @@ defmodule Ash do
     scope: [
       type: :any,
       doc:
-        "A value that implements the `Ash.Scope` protocol. Will overwrite any actor, tenant or context provided. See `Ash.Context` for more."
+        "A value that implements the `Ash.Scope` protocol, for passing around actor/tenant/context in a single value. See `Ash.Scope` for more."
     ]
   ]
 

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -72,6 +72,11 @@ defmodule Ash.ActionInput do
       type: :any,
       doc: "The tenant to use for the action."
     ],
+    scope: [
+      type: :any,
+      doc:
+        "A value that implements the `Ash.Scope` protocol, for passing around actor/tenant/context in a single value. See `Ash.Scope` for more."
+    ],
     actor: [
       type: :any,
       doc: "The actor performing the action"

--- a/lib/ash/actions/read/calculations.ex
+++ b/lib/ash/actions/read/calculations.ex
@@ -17,6 +17,13 @@ defmodule Ash.Actions.Read.Calculations do
         resource -> {resource, opts[:record]}
       end
 
+    {_, opts} =
+      Ash.Actions.Helpers.set_context_and_get_opts(
+        opts[:domain] || Ash.Resource.Info.domain(resource),
+        Ash.Query.new(resource),
+        opts
+      )
+
     with {:calc,
           %{
             arguments: calc_arguments,

--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -78,7 +78,11 @@ defmodule Ash.Can do
 
         opts
         |> Ash.Actions.Helpers.set_when_ok(:tenant, tenant)
-        |> Ash.Actions.Helpers.set_when_ok(:context, context, &Ash.Helpers.deep_merge_maps(&1, &2))
+        |> Ash.Actions.Helpers.set_when_ok(
+          :context,
+          context,
+          &Ash.Helpers.deep_merge_maps(&1, &2)
+        )
 
         case actor do
           {:ok, actor} ->

--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -60,15 +60,36 @@ defmodule Ash.Can do
 
   Note: `is_maybe` is set to `true`, if not set.
   """
-  @spec can(subject(), Ash.Domain.t(), Ash.Resource.record(), Keyword.t()) ::
+  @spec can(subject(), Ash.Domain.t(), Ash.actor() | Ash.Scope.t(), Keyword.t()) ::
           {:ok, boolean() | :maybe}
           | {:ok, boolean(), term()}
           | {:ok, boolean(), Ash.Changeset.t(), Ash.Query.t()}
           | {:error, Ash.Error.t()}
-  def can(action_or_query_or_changeset, domain, actor, opts \\ []) do
+  def can(action_or_query_or_changeset, domain, actor_or_scope, opts \\ []) do
     opts = Keyword.put_new(opts, :maybe_is, :maybe)
     opts = Keyword.put_new(opts, :run_queries?, true)
     opts = Keyword.put_new(opts, :filter_with, :filter)
+
+    {actor, opts} =
+      if Ash.Scope.impl_for(actor_or_scope) do
+        actor = Ash.Scope.get_actor(actor_or_scope)
+        tenant = Ash.Scope.get_tenant(actor_or_scope)
+        context = Ash.Scope.get_context(actor_or_scope)
+
+        opts
+        |> Ash.Actions.Helpers.set_when_ok(:tenant, tenant)
+        |> Ash.Actions.Helpers.set_when_ok(:context, context, &Ash.Helpers.deep_merge_maps(&1, &2))
+
+        case actor do
+          {:ok, actor} ->
+            {actor, opts}
+
+          :error ->
+            {nil, opts}
+        end
+      else
+        {actor_or_scope, opts}
+      end
 
     {resource, action_or_query_or_changeset, input, opts} =
       case resource_subject_input(action_or_query_or_changeset, domain, actor, opts) do

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1500,6 +1500,11 @@ defmodule Ash.Changeset do
       type: :map,
       doc: "Context to set on the query, changeset, or input"
     ],
+    scope: [
+      type: :any,
+      doc:
+        "A value that implements the `Ash.Scope` protocol, for passing around actor/tenant/context in a single value. See `Ash.Scope` for more."
+    ],
     private_arguments: [
       type: :map,
       doc: "Private argument values to set before validations and changes.",

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -698,7 +698,7 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {input_opts, opts} =
-                    Keyword.split(opts, [:input, :actor, :tenant, :authorize?, :tracer])
+                    Keyword.split(opts, [:input, :actor, :tenant, :authorize?, :tracer, :scope])
 
                   {input, input_opts} = Keyword.pop(input_opts, :input)
 
@@ -734,7 +734,15 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {query_opts, opts} =
-                    Keyword.split(opts, [:query, :actor, :tenant, :authorize?, :tracer, :context])
+                    Keyword.split(opts, [
+                      :query,
+                      :actor,
+                      :tenant,
+                      :authorize?,
+                      :tracer,
+                      :context,
+                      :scope
+                    ])
 
                   {query, query_opts} = Keyword.pop(query_opts, :query)
 
@@ -850,6 +858,7 @@ defmodule Ash.CodeInterface do
                     Keyword.split(opts, [
                       :actor,
                       :tenant,
+                      :scope,
                       :authorize?,
                       :tracer,
                       :context,
@@ -960,6 +969,7 @@ defmodule Ash.CodeInterface do
                       Keyword.split(opts, [
                         :actor,
                         :tenant,
+                        :scope,
                         :authorize?,
                         :tracer,
                         :context,
@@ -1020,6 +1030,7 @@ defmodule Ash.CodeInterface do
                         :actor,
                         :tenant,
                         :authorize?,
+                        :scope,
                         :tracer,
                         :context,
                         :skip_unknown_inputs
@@ -1226,6 +1237,7 @@ defmodule Ash.CodeInterface do
                       Keyword.split(opts, [
                         :actor,
                         :tenant,
+                        :scope,
                         :authorize?,
                         :tracer,
                         :context,
@@ -1285,6 +1297,7 @@ defmodule Ash.CodeInterface do
                       Keyword.split(opts, [
                         :actor,
                         :tenant,
+                        :scope,
                         :authorize?,
                         :tracer,
                         :context,
@@ -1648,6 +1661,7 @@ defmodule Ash.CodeInterface do
             Keyword.take(interface_options.schema(), [
               :actor,
               :tenant,
+              :scope,
               :authorize?,
               :tracer,
               :changeset,

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -716,6 +716,11 @@ defmodule Ash.Query do
       doc:
         "set the actor, which can be used in any `Ash.Resource.Change`s configured on the action. (in the `context` argument)"
     ],
+    scope: [
+      type: :any,
+      doc:
+        "A value that implements the `Ash.Scope` protocol, for passing around actor/tenant/context in a single value. See `Ash.Scope` for more."
+    ],
     authorize?: [
       type: :boolean,
       doc:

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -3515,9 +3515,9 @@ defmodule Ash.Query do
         |> offset(combination.offset)
         |> do_filter(combination.filter)
         |> sort(combination.sort)
-        |> select(combination.select || MapSet.to_list(
-            Ash.Resource.Info.selected_by_default_attribute_names(query.resource)
-          )
+        |> select(
+          combination.select ||
+            MapSet.to_list(Ash.Resource.Info.selected_by_default_attribute_names(query.resource))
         )
         |> Ash.Query.set_context(query.context)
         |> Ash.Query.set_context(%{data_layer: %{combination_query?: true}})

--- a/lib/ash/scope.ex
+++ b/lib/ash/scope.ex
@@ -1,0 +1,85 @@
+defprotocol Ash.Scope do
+  @moduledoc """
+  Determines how the `actor`, `tenant` and `context` are extracted from a data structure.
+
+  This is inspired by the same feature in `Phoenix`, however the `actor`, `tenant` and `context`
+  options will always remain available, as they are standardized representations of things that
+  actions can use to do their work. This exists as a convenience, especially for those who are
+  using an application with a version of Phoenix that has a concept of scopes.
+
+  ## Example
+
+  You would implement `Ash.Scope` for a module like so:
+
+  ```elixir
+  defmodule MyApp.Scope do
+    defstruct [:current_user, :current_tenant, :locale]
+
+    defimpl Ash.Scope do
+      def get_actor(%{current_user: current_user}), do: {:ok, current_user}
+      def get_tenant(%{current_tenant: current_tenant}), do: {:ok, current_tenant}
+      def get_context(%{locale: locale}), do: {:ok, %{locale: locale}}
+    end
+  end
+  ```
+
+  You could then use this in various places by passing the `scope` option.
+
+  For example:
+
+  ```elixir
+  scope = %MyApp.Scope{...}
+  # with code interfaces
+  MyApp.Blog.create_post!("new post", scope: scope)
+
+  # with changesets and queries
+  MyApp.Blog
+  |> Ash.Changeset.for_create(:create, %{title: "new post"}, scope: scope)
+  |> Ash.create!()
+
+  # with the context structs that we provide
+
+  def change(changeset, _, context) do
+    Ash.Changeset.after_action(changeset, fn changeset, result ->
+      MyApp.Domain.do_something_else(..., scope: context)
+      # if not using as a scope, the alternative is this
+      # in the future this will be deprecated
+      MyApp.Domain.do_somethign_else(..., Ash.Context.to_opts(context))
+    end)
+  end
+  ```
+
+  Extensions should not use this option, only end users.
+  """
+
+  @type t :: term()
+
+  @doc "Extracts the actor from the scope"
+  @spec get_actor(term()) :: {:ok, term} | :error
+  def get_actor(scope)
+
+  @doc "Extracts the tenant from the scope"
+  @spec get_tenant(term()) :: {:ok, term} | :error
+  def get_tenant(scope)
+
+  @doc "Extracts the context from the scope"
+  @spec get_context(term()) :: {:ok, term} | :error
+  def get_context(scope)
+end
+
+defimpl Ash.Scope,
+  for: [
+    Ash.Resource.Actions.Implementation.Context,
+    Ash.Resource.Calculation.Context,
+    Ash.Resource.Change.Context,
+    Ash.Resource.ManualCreate.Context,
+    Ash.Resource.ManualDestroy.Context,
+    Ash.Resource.ManualUpdate.Context,
+    Ash.Resource.ManualRelationship.Context,
+    Ash.Resource.Preparation.Context,
+    Ash.Resource.Validation.Context
+  ] do
+  def get_actor(%{actor: actor}), do: {:ok, actor}
+  def get_tenant(%{tenant: tenant}), do: {:ok, tenant}
+  def get_context(%{context: context}), do: {:ok, context || %{}}
+end

--- a/lib/ash/scope.ex
+++ b/lib/ash/scope.ex
@@ -7,6 +7,17 @@ defprotocol Ash.Scope do
   actions can use to do their work. This exists as a convenience, especially for those who are
   using an application with a version of Phoenix that has a concept of scopes.
 
+  ## Passing scope and options
+
+  For the `actor` and `tenant` extracted from scopes, if you also pass those values via options, i.e:
+
+  `scope: %MyApp.Scope{current_user: user1}, actor: user2`
+
+  if both values are non-nil and are not equal, we raise an error.
+  Otherwise, we choose the one that is not nil (or nil if both are nil).
+
+  For `context`, the values are deep merged.
+
   ## Example
 
   You would implement `Ash.Scope` for a module like so:

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -93,7 +93,11 @@ defmodule Ash.Test.CodeInterfaceTest do
         end
       end
 
-      define :hello_actor, default_options: [actor: %{name: "William Shatner"}]
+      define :hello_actor_with_default,
+        default_options: [actor: %{name: "William Shatner"}],
+        action: :hello_actor
+
+      define :hello_actor
       define :create_with_map, args: [:map]
       define :update_with_map, args: [:map]
 
@@ -168,8 +172,8 @@ defmodule Ash.Test.CodeInterfaceTest do
       end
 
       action :hello_actor, :string do
-        run(fn input, _ ->
-          {:ok, "Hello, #{input.context.private.actor.name}."}
+        run(fn input, context ->
+          {:ok, "Hello, #{context.actor.name}."}
         end)
       end
     end
@@ -599,8 +603,10 @@ defmodule Ash.Test.CodeInterfaceTest do
   end
 
   test "default options" do
-    assert "Hello, Leonard Nimoy." = User.hello_actor!(actor: %{name: "Leonard Nimoy"})
-    assert "Hello, William Shatner." = User.hello_actor!()
+    assert "Hello, Leonard Nimoy." =
+             User.hello_actor_with_default!(actor: %{name: "Leonard Nimoy"})
+
+    assert "Hello, William Shatner." = User.hello_actor_with_default!()
   end
 
   defmodule Scope do
@@ -616,6 +622,11 @@ defmodule Ash.Test.CodeInterfaceTest do
   test "uses scope options" do
     scope = %Scope{actor: %{name: "Jelly Belly"}}
     assert "Hello, Jelly Belly." = User.hello_actor!(scope: scope)
-    assert "Hello, William Shatner." = User.hello_actor!()
+
+    assert_raise ArgumentError, ~r/Got an actor via the/, fn ->
+      User.hello_actor!(scope: scope, actor: %{foobar: true})
+    end
+
+    assert "Hello, William Shatner." = User.hello_actor_with_default!()
   end
 end

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -602,4 +602,20 @@ defmodule Ash.Test.CodeInterfaceTest do
     assert "Hello, Leonard Nimoy." = User.hello_actor!(actor: %{name: "Leonard Nimoy"})
     assert "Hello, William Shatner." = User.hello_actor!()
   end
+
+  defmodule Scope do
+    defstruct [:actor, :tenant, :context]
+
+    defimpl Ash.Scope do
+      def get_actor(%{actor: actor}), do: {:ok, actor}
+      def get_tenant(%{tenant: tenant}), do: {:ok, tenant}
+      def get_context(%{context: context}), do: {:ok, context}
+    end
+  end
+
+  test "uses scope options" do
+    scope = %Scope{actor: %{name: "Jelly Belly"}}
+    assert "Hello, Jelly Belly." = User.hello_actor!(scope: scope)
+    assert "Hello, William Shatner." = User.hello_actor!()
+  end
 end


### PR DESCRIPTION
This would likely need to be incrementally adopted in various places, and the first place would be in `AshAuthentication`. We would likely make it an option in the `ash_authentication_live_session`, to take a `scope`, and expect that scope to define a function like `from_conn/1`. (or something like that)

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
