### PR TITLE
fix(Ash.Reactor): Don't import `Ash.Expr` in the bulk update DSL.

### DIFF
--- a/lib/ash/reactor/dsl/bulk_update.ex
+++ b/lib/ash/reactor/dsl/bulk_update.ex
@@ -144,7 +144,7 @@ defmodule Ash.Reactor.Dsl.BulkUpdate do
       target: __MODULE__,
       args: [:name, :resource, {:optional, :action}],
       identifier: :name,
-      imports: [Reactor.Dsl.Argument, Ash.Expr],
+      imports: [Reactor.Dsl.Argument],
       entities: [
         actor: [Ash.Reactor.Dsl.Actor.__entity__()],
         context: [Ash.Reactor.Dsl.Context.__entity__()],

--- a/lib/ash/reactor/steps/bulk_create_step.ex
+++ b/lib/ash/reactor/steps/bulk_create_step.ex
@@ -1,6 +1,6 @@
 defmodule Ash.Reactor.BulkCreateStep do
   @moduledoc """
-  The Reactor stop which is used to execute create actions in bulk.
+  The Reactor step which is used to execute create actions in bulk.
   """
 
   use Reactor.Step

--- a/lib/ash/reactor/steps/bulk_update_step.ex
+++ b/lib/ash/reactor/steps/bulk_update_step.ex
@@ -1,6 +1,6 @@
 defmodule Ash.Reactor.BulkUpdateStep do
   @moduledoc """
-  The Reactor stop which is used to execute create actions in bulk.
+  The Reactor step which is used to execute update actions in bulk.
   """
 
   use Reactor.Step


### PR DESCRIPTION
This was causing a name clash because `Ash.Expr` and the DSL are trying to define a function/macro called `actor/1`.

I've also added a test related to #2053 to verify that authorization works as expected.

