### PR TITLE
fix: prevent MustBeAtomic error on singular embedded attributes

### DIFF
--- a/lib/ash/embeddable_type.ex
+++ b/lib/ash/embeddable_type.ex
@@ -720,7 +720,8 @@ defmodule Ash.EmbeddableType do
           {:not_atomic,
            "Embedded attributes do not support atomic updates with expressions, only literal values."}
         else
-          with true <- !list? || (list? and Enum.empty?(Ash.Resource.Info.primary_key(__MODULE__))),
+          with true <-
+                 !list? || (list? and Enum.empty?(Ash.Resource.Info.primary_key(__MODULE__))),
                :ok <- update_action_allows_atomics(constraints) do
             :ok
           else


### PR DESCRIPTION
# Problem

There are 3 documented conditions for atomic updates to work on embedded resources:

> Reason: Embedded attributes do not support atomic updates unless they have no primary key, or `constraints[:on_update]` is set to `:replace`, or the update action accepts all public attributes and has no changes.

But when an embedded attribute is not an array, the atomic action check was failing it, even when `on_update: :replace` is set. 

# Fix

This was discussed on [ElixirForum](https://elixirforum.com/t/atomic-updates-across-embedded-and-normal-attributes-failing-since-3-5-10/70936) where Zach suggested this fix. I'm only PR'ing it to try and be helpful. 

I couldn't find an appropriate test to modify. There is existing coverage of a `Profile` resource `embedded_resource_test.exs`, but this is currently set to not require atomic updates. If I require atomic updates and set `on_update: :replace`, the existing assertions around validations are broken. I didn't want to create an entire duplicate Profile test to cover this small case.

@zachdaniel Do you think it's appropriate to add a second Profile setup to cover this scenario? I'm happy to amend this PR if you'd like me to. 

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
