### PR TITLE
fix: make Ash.Query.sort/3 accept string param.

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -3173,6 +3173,12 @@ defmodule Ash.Query do
       ["foo", "-bar", "++baz", "--buz"]
 
 
+  > ### Sorting on user input? {: .neutral}
+  >
+  > If some of your sort parameters originate from user input, you should
+  > use the `Ash.Query.sort_input/3`-function instead.
+
+
   ## Calculations
 
   Calculation inputs can be provided by providing a map. To provide both inputs and an order,
@@ -3234,6 +3240,9 @@ defmodule Ash.Query do
           |> Enum.reduce(query, fn
             {sort, direction}, query ->
               %{query | sort: query.sort ++ [{sort, direction}]}
+
+            sort, query when is_binary(sort) ->
+              %{query | sort: query.sort ++ String.split(sort, ",", trim: true)}
 
             sort, query ->
               %{query | sort: query.sort ++ [{sort, :asc}]}

--- a/test/query/sort_test.exs
+++ b/test/query/sort_test.exs
@@ -1,0 +1,130 @@
+defmodule Ash.Test.Query.SortTest do
+  use ExUnit.Case, async: true
+
+  defmodule Post do
+    use Ash.Resource, domain: Ash.Test.Query.SortTest.Domain
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string
+      attribute :published_at, :utc_datetime
+      attribute :author_id, :uuid
+    end
+
+    actions do
+      defaults [:read, :create]
+    end
+  end
+
+  defmodule Comment do
+    use Ash.Resource, domain: Ash.Test.Query.DefaultSortTest.Domain
+
+    attributes do
+      uuid_primary_key :id
+      attribute :body, :string
+      attribute :created_at, :utc_datetime
+    end
+
+    relationships do
+      belongs_to :post, Post
+    end
+
+    actions do
+      defaults [:read, :create]
+    end
+  end
+
+  defmodule Domain do
+    use Ash.Domain
+
+    resources do
+      resource Post
+      resource Comment
+    end
+  end
+
+  alias Ash.Test.Query.SortTest.{Comment, Post}
+
+  describe "sort/2" do
+    test "applies :asc when nothing else is specified" do
+      query =
+        Post
+        |> Ash.Query.new()
+        |> Ash.Query.sort(:published_at)
+
+      assert query.sort == [{:published_at, :asc}]
+    end
+
+    test "works with string param" do
+      query =
+        Post
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.sort("published_at")
+
+      assert query.sort == [{:published_at, :asc}]
+    end
+
+    test "works with string param with negative prefix" do
+      query =
+        Post
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.sort("-published_at")
+
+      assert query.sort == [{:published_at, :desc}]
+    end
+
+    test "works with string param with double negative prefix" do
+      query =
+        Post
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.sort("--published_at")
+
+      assert query.sort == [{:published_at, :desc_nils_last}]
+    end
+
+    test "works with string param with positive prefix" do
+      query =
+        Post
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.sort("+published_at")
+
+      assert query.sort == [{:published_at, :asc}]
+    end
+
+    test "works with string param with double positive prefix" do
+      query =
+        Post
+        |> Ash.Query.new()
+        |> Ash.Query.sort("++published_at")
+
+      assert query.sort == [{:published_at, :asc_nils_first}]
+    end
+
+    test "handles string prefix with multiple fields" do
+      query =
+        Post
+        |> Ash.Query.new()
+        |> Ash.Query.sort("title,++published_at,-author_id")
+
+      assert query.sort == [{:title, :asc}, {:published_at, :asc_nils_first}, {:author_id, :desc}]
+    end
+
+    test "handles string prefix with dot notation" do
+      query =
+        Comment
+        |> Ash.Query.new()
+        |> Ash.Query.sort("--post.title,++post.published_at,post.author_id")
+
+      assert {%Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression},
+              :desc_nils_last} =
+               Enum.at(query.sort, 0)
+
+      assert {%Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression},
+              :asc_nils_first} =
+               Enum.at(query.sort, 1)
+
+      assert {%Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression}, :asc} =
+               Enum.at(query.sort, 2)
+    end
+  end
+end


### PR DESCRIPTION
Also adds some regression tests, and a heads-up in the docs that sort_input/3 should be used for user input.

Regarding the last test in `sort_test.exs`: I don't know of a better way to assert on the resulting calculation expressions, if there is a better way, just point me in the right direction and I'll update it 😅 

# Contributor checklist

- [x ] Bug fixes include regression tests
- [ ] Chores
- [x ] Documentation changes
- [x ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
