### PR TITLE
feat: don't allow integer_primary_key in ETS data layer

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -42,7 +42,10 @@ defmodule Ash.DataLayer.Ets do
 
   use Spark.Dsl.Extension,
     sections: [@ets],
-    verifiers: [Ash.DataLayer.Verifiers.RequirePreCheckWith]
+    verifiers: [
+      Ash.DataLayer.Verifiers.RequirePreCheckWith,
+      Ash.DataLayer.Verifiers.IntegerPrimaryKeyNotUsed
+    ]
 
   alias Ash.Actions.Sort
 

--- a/lib/ash/data_layer/verifiers/integer_primary_key_not_used.ex
+++ b/lib/ash/data_layer/verifiers/integer_primary_key_not_used.ex
@@ -1,0 +1,35 @@
+defmodule Ash.DataLayer.Verifiers.IntegerPrimaryKeyNotUsed do
+  @moduledoc """
+  Ensures that integer primary key is not used, or raises.
+  """
+  use Spark.Dsl.Verifier
+
+  alias Spark.Dsl.Verifier
+
+  require Logger
+
+  @impl true
+  def verify(dsl) do
+    dsl
+    |> Verifier.get_entities([:attributes])
+    |> Enum.filter(fn attribute ->
+      attribute.primary_key? && attribute.type == Ash.Type.Integer
+    end)
+    |> case do
+      [] ->
+        :ok
+
+      attributes ->
+        {:error,
+         Spark.Error.DslError.exception(
+           message: """
+           The data layer does not support integer primary key.
+
+           Attributes: #{Enum.map_join(attributes, ", ", & &1.name)}
+
+           Consider using uuid_primary_key instead of integer_primary_key
+           """
+         )}
+    end
+  end
+end

--- a/test/ash/data_layer/ets_test.exs
+++ b/test/ash/data_layer/ets_test.exs
@@ -62,6 +62,21 @@ defmodule Ash.DataLayer.EtsTest do
     end
   end
 
+  test "won't compile with integer primary key" do
+    assert_raise Spark.Error.DslError, ~r/does not support integer primary key/, fn ->
+      defmodule Example do
+        use Ash.Resource,
+          domain: Domain,
+          data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          integer_primary_key :id
+          attribute :name, :string, public?: true
+        end
+      end
+    end
+  end
+
   test "resource_to_query" do
     assert %Query{resource: EtsTestUser} = EtsDataLayer.resource_to_query(EtsTestUser, nil)
   end


### PR DESCRIPTION
Don't allow `integer_primary_key` in ETS data layer

Closes https://github.com/ash-project/ash/issues/1500

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
