### PR TITLE
fix: Duration struct

### DIFF
--- a/lib/ash/duration.ex
+++ b/lib/ash/duration.ex
@@ -1,0 +1,15 @@
+defmodule Ash.Duration do
+  @moduledoc """
+  A duration struct for Ash.
+  """
+
+  defstruct [:year, :month, :hour, :minute, :microsecond]
+
+  @type t :: %__MODULE__{
+          year: integer(),
+          month: integer(),
+          hour: integer(),
+          minute: integer(),
+          microsecond: {integer(), integer()}
+        }
+end

--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -24,7 +24,7 @@ defmodule Ash.Type.Duration do
   end
 
   @impl true
-  def matches_type?(%Duration{}, _), do: true
+  def matches_type?(%Ash.Duration{}, _), do: true
   def matches_type?(_, _), do: false
 
   @impl true


### PR DESCRIPTION
I compiled main of `ash_postgres` and got:
```
error: Duration.__struct__/0 is undefined, cannot expand struct Duration. Make sure the struct name is correct. If the struct name exists and is correct but it still cannot be found, you likely have cyclic module usage in your code
  lib/ash/type/duration.ex:27: Ash.Type.Duration.matches_type?/2


== Compilation error in file lib/ash/type/duration.ex ==
** (CompileError) lib/ash/type/duration.ex: cannot compile module Ash.Type.Duration (errors have been logged)
    lib/ash/type/duration.ex:27: (module)
could not compile dependency :ash, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ash --force", update it with "mix deps.update ash" or clean it with "mix deps.clean ash"
```
I added duration basic struct which solved the compile issue. But now there's a lot of warnings:
```
warning: Duration.new!/1 is undefined (module Duration is not available or is yet to be defined)
  lib/ash/type/duration.ex:16: Ash.Type.Duration.generator/1

warning: Date.shift/2 is undefined or private
  lib/ash/query/function/date_add.ex:31: Ash.Query.Function.DateAdd.evaluate/1

warning: Duration.negate/1 is undefined (module Duration is not available or is yet to be defined)
  lib/ash/query/function/minus.ex:12: Ash.Query.Function.Minus.evaluate/1

warning: Duration.negate/1 is undefined (module Duration is not available or is yet to be defined)
  lib/ash/query/function/ago.ex:26: Ash.Query.Function.Ago.evaluate/1
```
What's puzzling to me is why does it work on `ash`, no warnings, test pass... 🤔 
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
