### PR TITLE
Fix typo in get started docs

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -56,8 +56,8 @@ See the options below for more.
 
 First, to use `mix igniter.new`, the archive must be installed.
 
-```bash
-# install igniter.enw
+```elixir
+# install igniter.new
 mix archive.install hex igniter_new
 
 # create a new application with Ash in it

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -56,7 +56,7 @@ See the options below for more.
 
 First, to use `mix igniter.new`, the archive must be installed.
 
-```elixir
+```bash
 # install igniter.new
 mix archive.install hex igniter_new
 
@@ -68,7 +68,7 @@ mix igniter.new helpdesk --install ash && cd helpdesk
 
 If you already know that you want to use Phoenix and Ash together, you can use
 
-```elixir
+```bash
 # install the archive
 mix archive.install hex phx_new
 mix archive.install hex igniter_new
@@ -81,7 +81,7 @@ mix igniter.new helpdesk --install ash,ash_phoenix --with phx.new && cd helpdesk
 
 You can use igniter to add Ash to your existing project as well.
 
-```elixir
+```bash
 mix archive.install hex igniter_new
 mix igniter.install ash
 ```


### PR DESCRIPTION
+ change code type from bash to elixir for consistent highlighting (with `bash` the comment was rendered the same way as the command itself)

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
