### PR TITLE
Fix Ash.calculate/2 with opts

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -753,8 +753,14 @@ defmodule Ash do
       The tenant, supplied to calculation context.
       """
     ],
+    context: [
+      type: :map,
+      doc: """
+      Context to set on the calculation input.
+      """
+    ],
     authorize?: [
-      type: :boolean,
+      type: {:in, [true, false, nil]},
       default: true,
       doc: """
       Whether or not the request is being authorized, provided to calculation context.

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -31,7 +31,7 @@ defmodule Ash.Test.AshTest do
 
     actions do
       default_accept [:name, :state]
-      defaults [:create, :update]
+      defaults [:read, :create, :update]
 
       create :create_awake do
         accept [:name]
@@ -49,6 +49,10 @@ defmodule Ash.Test.AshTest do
 
         change set_attribute(:state, arg(:state))
       end
+    end
+
+    calculations do
+      calculate :awaken?, :boolean, expr(state == :awake), public?: true
     end
   end
 
@@ -371,6 +375,16 @@ defmodule Ash.Test.AshTest do
 
       assert %User{name: "Alice", state: :awake} =
                Ash.update!(user, %{state: :awake}, action: :update_state)
+    end
+  end
+
+  describe "calculate/2" do
+    test "with opts" do
+      user = Ash.create!(User, %{name: "Alice"})
+
+      opts = %Ash.Resource.Calculation.Context{} |> Ash.Scope.to_opts()
+
+      assert {:ok, false} = Ash.calculate(user, :awaken?, opts)
     end
   end
 


### PR DESCRIPTION
This PR fixes following errors.

`{:error, %Spark.Options.ValidationError{message: "unknown options [:context], valid options are: [:args, :refs, :actor, :scope, :tenant, :authorize?, :tracer, :record, :data_layer?, :reuse_values?, :domain]", value: %{}, key: :context, __exception__: true, keys_path: []}}`

`{:error, %Spark.Options.ValidationError{message: "invalid value for :authorize? option: expected boolean, got: nil", value: nil, key: :authorize?, __exception__: true, keys_path: []}}`

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
