### PR TITLE
Fix Ash.run_action/2 with opts

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -819,7 +819,7 @@ defmodule Ash do
       """
     ],
     authorize?: [
-      type: :boolean,
+      type: {:in, [true, false, nil]},
       doc: """
       Whether or not the request should be authorized.
       """

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -49,6 +49,12 @@ defmodule Ash.Test.AshTest do
 
         change set_attribute(:state, arg(:state))
       end
+
+      action :action do
+        run fn _input, _context ->
+          :ok
+        end
+      end
     end
 
     calculations do
@@ -387,6 +393,16 @@ defmodule Ash.Test.AshTest do
         |> Ash.Scope.to_opts()
 
       assert {:ok, true} = Ash.calculate(user, :awaken?, opts)
+    end
+  end
+
+  describe "run_action/2" do
+    test "with opts" do
+      input = Ash.ActionInput.for_action(User, :action, %{})
+
+      opts = %Ash.Resource.Change.Context{} |> Ash.Scope.to_opts()
+
+      assert :ok = Ash.run_action(input, opts)
     end
   end
 


### PR DESCRIPTION
This PR is similar to #2083 and fixes the following error:

`{:error, %Spark.Options.ValidationError{message: "invalid value for :authorize? option: expected boolean, got: nil", value: nil, key: :authorize?, __exception__: true, keys_path: []}}`

One thing I’m curious about: I’ve noticed that there are two different ways of representing “boolean or nil” in Spark:

- `{:in, [true, false, nil]}`
- `{:or, [:boolean, {:literal, nil}]}`

While the latter seems a bit more explicit in terms of meaning, I’m wondering which style is preferred.
Either way, I think it might be good to standardize the usage throughout the codebase, and I’d like to include that change in this PR as well.

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
