### PR TITLE
Harden CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,13 @@ updates:
         dependency-type: production
       dev-dependencies:
         dependency-type: development
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # Group all GitHub Actions updates together to have less PRs
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -57,6 +57,8 @@ on:
 env:
   PG_VERSION: ${{inputs.postgres-version}}
   ASH_CI_BUILD: true
+permissions:
+  contents: read
 jobs:
   # Some kind of 403 permissions bug here
   report_mix_deps:
@@ -65,8 +67,8 @@ jobs:
     # Only run this job when we're on the main branch, not for PRs
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
-      - uses: erlef/mix-dependency-submission@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: erlef/mix-dependency-submission@dd81a2f0238bd242a4674703ba7b99c0b284b2f1 # v1.1.3
     permissions:
       # Give the default GITHUB_TOKEN write permission to call the dependencies API
       contents: write
@@ -74,7 +76,7 @@ jobs:
     name: audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Update Elixir version in .tool-versions
         if: inputs.elixir-version != 'default'
         run: |
@@ -99,15 +101,15 @@ jobs:
           else
             echo "erlang ${{ inputs.erlang-version }}" > .tool-versions
           fi
-      - uses: team-alembic/staple-actions/actions/mix-hex-audit@main
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-hex-audit@59199173e18eee6748b65d01626ef82d51c6e963 # main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           task: deps.audit
   build-test:
     name: MIX_ENV=test mix.compile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Update Elixir version in .tool-versions
         if: inputs.elixir-version != 'default'
         run: |
@@ -132,8 +134,8 @@ jobs:
           else
             echo "erlang ${{ inputs.erlang-version }}" > .tool-versions
           fi
-      - uses: team-alembic/staple-actions/actions/install-elixir@main
-      - uses: team-alembic/staple-actions/actions/mix-compile@main
+      - uses: team-alembic/staple-actions/actions/install-elixir@59199173e18eee6748b65d01626ef82d51c6e963 # main
+      - uses: team-alembic/staple-actions/actions/mix-compile@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
   build-docs:
@@ -144,12 +146,12 @@ jobs:
       - build-test
       - spark-cheat-sheets
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-docs@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-docs@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: dev
           use-cache: false
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: doc/
   deploy-docs:
@@ -168,7 +170,7 @@ jobs:
     steps:
       - name: Deploy to GitHub pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   formatter:
     name: mix format --check-formatted
@@ -176,8 +178,8 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-format@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-format@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
 
@@ -187,8 +189,8 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.spark-formatter}}
         with:
           mix-env: test
@@ -200,13 +202,13 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.spark-cheat-sheets}}
         with:
           mix-env: test
           task: spark.cheat_sheets --dry-run --yes
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.spark-cheat-sheets}}
         with:
           mix-env: test
@@ -217,8 +219,8 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.sobelow}}
         with:
           mix-env: test
@@ -228,8 +230,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-credo@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-credo@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.spark-formatter}}
         with:
           mix-env: test
@@ -240,8 +242,8 @@ jobs:
       - build-test
     if: ${{inputs.codegen}}
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash.codegen --check
@@ -251,8 +253,8 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: deps.unlock --check-unused
@@ -267,19 +269,19 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         if: github.event.pull_request.user.login == 'dependabot[bot]'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
         if: github.event.pull_request.user.login == 'dependabot[bot]'
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           task: igniter.upgrade --git-ci --yes
         if: github.event.pull_request.user.login == 'dependabot[bot]'
       - name: Commit Changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         with:
           commit_message: "[dependabot skip] Apply Igniter Upgrades"
@@ -304,53 +306,53 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.postgres && inputs.ash_postgres}}
         with:
           mix-env: test
           task: ash_postgres.generate_migrations --check
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash_postgres.create
         if: ${{inputs.postgres && inputs.ash_postgres}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ecto.create
         if: ${{inputs.postgres && inputs.ecto_postgres}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash_postgres.migrate
         if: ${{inputs.postgres && inputs.ash_postgres}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash_postgres.migrate --tenants
         if: ${{inputs.postgres && inputs.ash_postgres}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ecto.migrate
         if: ${{inputs.postgres && inputs.ecto_postgres}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash_sqlite.generate_migrations --check
         if: ${{inputs.sqlite}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash_sqlite.create
         if: ${{inputs.sqlite}}
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
           task: ash_sqlite.migrate
         if: ${{inputs.sqlite}}
-      - uses: team-alembic/staple-actions/actions/mix-test@main
+      - uses: team-alembic/staple-actions/actions/mix-test@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: test
         env:
@@ -364,8 +366,8 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-dialyzer@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-dialyzer@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: dev
 
@@ -375,8 +377,8 @@ jobs:
     needs:
       - build-test
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-compile@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-compile@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: dev
   build-release:
@@ -445,7 +447,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Extract crate information
         shell: bash
@@ -456,7 +458,7 @@ jobs:
         shell: bash
         run: |
           rustup target add ${{ matrix.job.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           prefix-key: v0-precomp
           shared-key: ${{ matrix.job.target }}-${{ matrix.nif }}
@@ -464,7 +466,7 @@ jobs:
             native/igniter_js
       - name: Build the project
         id: build-crate
-        uses: philss/rustler-precompiled-action@v1.1.4
+        uses: philss/rustler-precompiled-action@853ac56183f29a080304df3ff8a194b5bbdc24cc # v1.1.4
         with:
           project-name: igniter_js
           project-version: ${{ env.PROJECT_VERSION }}
@@ -476,13 +478,13 @@ jobs:
           cargo-args: ${{ matrix.job.cargo-args }}
 
       - name: Artifact upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.build-crate.outputs.file-name }}
           path: ${{ steps.build-crate.outputs.file-path }}
 
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           files: |
             ${{ steps.build-crate.outputs.file-path }}
@@ -505,12 +507,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Release
     steps:
-      - uses: actions/checkout@v3
-      - uses: team-alembic/staple-actions/actions/mix-task@main
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: team-alembic/staple-actions/actions/mix-task@59199173e18eee6748b65d01626ef82d51c6e963 # main
         if: ${{inputs.rustler-precompiled-module}}
         with:
           task: rustler_precompiled.download ${{inputs.rustler-precompiled-module}} --only-local --all --print
-      - uses: team-alembic/staple-actions/actions/mix-hex-publish@main
+      - uses: team-alembic/staple-actions/actions/mix-hex-publish@59199173e18eee6748b65d01626ef82d51c6e963 # main
         with:
           mix-env: dev
           hex-api-key: ${{secrets.HEX_API_KEY}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,20 @@ on:
   pull_request:
     branches: [main, "3.0"]
   workflow_dispatch:
-
+permissions:
+  contents: read
 jobs:
   ash-ci:
     strategy:
       matrix:
         sat_solver: ["SimpleSat", "Picosat"]
-    uses: ash-project/ash/.github/workflows/ash-ci.yml@main
+    uses: ./.github/workflows/ash-ci.yml
     secrets:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     with:
       sat-solver: ${{ matrix.sat_solver }}
       igniter-upgrade: ${{matrix.sat_solver == 'Picosat'}}

--- a/.github/workflows/test-subprojects.yml
+++ b/.github/workflows/test-subprojects.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - "v*"
     branches: [main, "3.0"]
+permissions:
+  contents: read
 jobs:
   test-subprojects:
     runs-on: ubuntu-latest
@@ -60,27 +62,32 @@ jobs:
       # data layers should be tested against main of `ash_sql`
       ASH_SQL_VERSION: main
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
       - run: sudo apt-get install --yes erlang-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           repository: ${{matrix.project.org}}/${{matrix.project.name}}
           path: ${{matrix.project.name}}
           ref: ${{matrix.project.ref}}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           repository: ash-project/ash
           path: ash
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@8aa8a857c6be0daae6e97272bb299d5b942675a4 # v1.19.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache-deps
         with:
           path: ${{matrix.project.name}}/deps
           key: ${{matrix.project.name}}-otp-${{matrix.otp}}-elixir-${{matrix.elixir}}-deps-2-${{ hashFiles('config/**/*.exs') }}-${{ hashFiles(format('{0}{1}', github.workspace, '/ash/mix.lock')) }}
           restore-keys: ${{matrix.project.name}}-otp-${{matrix.otp}}-elixir-${{matrix.elixir}}-deps-2-${{ hashFiles('config/**/*.exs') }}-
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache-build
         with:
           path: ${{matrix.project.name}}/_build


### PR DESCRIPTION
# What’s changed

* **Actions pinned to commit SHAs** – Every third-party Action reference now points to an immutable Git commit instead of a moving tag.
* **Least-privilege permissions** – The workflow’s top-level token is limited to `contents:read`; individual jobs elevate only to the scopes they actually need (e.g., `contents:write`).
* **Dependabot** – Update GitHub Actions; weekly grouped update.

# Why it matters

Pinning Actions guards against supply-chain attacks and unexpected upstream changes, giving us deterministic, auditable builds. Restricting the default token to read-only follows GitHub’s least-privilege guidance, reducing the blast radius if a job is ever compromised while still allowing specific jobs to perform their required tasks.

# How did I implement this?

I used this tool to generate the changes: https://app.stepsecurity.io/secure-workflow

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
