### PR TITLE
update usage rules

### DIFF
--- a/usage-rules.md
+++ b/usage-rules.md
@@ -444,8 +444,6 @@ Relationships describe connections between resources and are a core component of
 - Configure foreign key constraints in your data layer if they have them (see `references` in AshPostgres)
 - Always choose the appropriate relationship type based on your domain model
 
-### Types of Relationships
-
 #### Relationship Types
 
 ```elixir


### PR DESCRIPTION
I added examples for using code interfaces in places where we used the manual query-building approach. 

Afterwards, I let Claude compile the usage rules to remove duplication. I think opting for smaller usage rules is an advantage; we don't want to overload context windows. The rules files can become quite large if multiple ash packages are used, for example. 