### PR TITLE
fix: add one more verifier for code_interface if args are missing

### DIFF
--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1621,7 +1621,8 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Verifiers.VerifyNotifiers,
     Ash.Resource.Verifiers.VerifyPrimaryKeyPresent,
     Ash.Resource.Verifiers.VerifyGenericActionReactorInputs,
-    Ash.Resource.Verifiers.ValidateArgumentsToCodeInterface
+    Ash.Resource.Verifiers.ValidateArgumentsToCodeInterface,
+    Ash.Resource.Verifiers.VerifyCodeInterfaceArgumentCompleteness
   ]
 
   @moduledoc false

--- a/lib/ash/resource/verifiers/verify_code_interface_argument_completeness.ex
+++ b/lib/ash/resource/verifiers/verify_code_interface_argument_completeness.ex
@@ -1,0 +1,95 @@
+defmodule Ash.Resource.Verifiers.VerifyCodeInterfaceArgumentCompleteness do
+  @moduledoc """
+  Verifies that code interfaces declare all required action arguments in their args list.
+  
+  This prevents runtime Protocol.UndefinedError when users call interface functions
+  with positional arguments that should map to action arguments.
+  """
+  use Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl) do
+    dsl
+    |> Ash.Resource.Info.interfaces()
+    |> Enum.each(&verify_interface!(dsl, &1))
+    
+    :ok
+  end
+
+  defp verify_interface!(dsl, interface) do
+    action = Ash.Resource.Info.action(dsl, interface.action || interface.name)
+    module = Spark.Dsl.Verifier.get_persisted(dsl, :module)
+    
+    if action do
+      required_arguments = get_required_arguments(action)
+      interface_args = normalize_interface_args(interface.args || [])
+      
+      # Account for custom inputs that transform to action arguments
+      custom_input_targets = get_custom_input_targets(interface)
+      
+      # Account for explicitly excluded inputs
+      excluded_inputs = interface.exclude_inputs || []
+      
+      # Arguments that are satisfied by custom inputs or excluded don't need to be in args
+      satisfied_args = Enum.uniq(custom_input_targets ++ excluded_inputs)
+      
+      missing_args = (required_arguments -- interface_args) -- satisfied_args
+      
+      if missing_args != [] do
+        raise_missing_args_error(module, interface, action, missing_args)
+      end
+    end
+  end
+
+  defp get_required_arguments(action) do
+    action.arguments
+    |> Enum.filter(fn arg ->
+      # Required if: not allow_nil? and no default value
+      !arg.allow_nil? && is_nil(arg.default)
+    end)
+    |> Enum.map(& &1.name)
+  end
+
+  defp normalize_interface_args(args) do
+    Enum.map(args, fn
+      {:optional, arg} -> arg
+      arg -> arg
+    end)
+  end
+
+  defp get_custom_input_targets(interface) do
+    interface.custom_inputs
+    |> Enum.filter(& &1.transform)
+    |> Enum.map(& &1.transform.to)
+  end
+
+  defp raise_missing_args_error(module, interface, action, missing_args) do
+    action_name = action.name
+    interface_name = interface.name
+    
+    suggestion = """
+    code_interface do
+      define :#{interface_name}, args: #{inspect(missing_args)}
+    end
+    """
+    
+    raise Spark.Error.DslError,
+      module: module,
+      message: """
+      Code interface `#{interface_name}` is missing required arguments for action `#{action_name}`.
+      
+      The action `#{action_name}` has required arguments: #{inspect(missing_args)}
+      But the code interface doesn't declare them in the `args:` option.
+      
+      This will cause runtime errors when calling the interface function.
+      
+      Fix by updating your code interface:
+      
+      #{suggestion}
+      
+      Alternatively, if these arguments should be optional, add default values
+      or set `allow_nil? true` in the action arguments.
+      """,
+      path: [:code_interface, interface_name]
+  end
+end

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -117,7 +117,7 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
     end
 
     code_interface do
-      define :destroy_with_policy
+      define :destroy_with_policy, args: [:authorize?]
     end
 
     validations do

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -348,7 +348,7 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
     end
 
     code_interface do
-      define :update_with_policy_without_requiring_actor
+      define :update_with_policy_without_requiring_actor, args: [:authorize?]
     end
 
     policies do

--- a/test/resource/verify_code_interface_argument_completeness_test.exs
+++ b/test/resource/verify_code_interface_argument_completeness_test.exs
@@ -1,0 +1,267 @@
+defmodule Ash.Resource.Verifiers.VerifyCodeInterfaceArgumentCompletenessTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  
+  describe "verify_code_interface_argument_completeness" do
+    test "raises error when required arguments are missing from interface" do
+      assert_raise(
+        Spark.Error.DslError,
+        ~r/Code interface `test_action` is missing required arguments for action `test_action`/,
+        fn ->
+          defmodule TestResource do
+            use Ash.Resource, domain: Ash.Test.Domain
+            
+            actions do
+              action :test_action, :atom do
+                argument :required_arg, :string, allow_nil?: false
+              end
+            end
+            
+            code_interface do
+              define :test_action  # Missing args: [:required_arg]
+            end
+          end
+        end
+      )
+    end
+    
+    test "passes when all required arguments are declared" do
+      # Should not raise
+      defmodule TestResource2 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        actions do
+          action :test_action, :atom do
+            argument :required_arg, :string, allow_nil?: false
+          end
+        end
+        
+        code_interface do
+          define :test_action, args: [:required_arg]
+        end
+      end
+    end
+    
+    test "passes when argument has allow_nil? true" do
+      # Should not raise because argument allows nil
+      defmodule TestResource3 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        actions do
+          action :test_action, :atom do
+            argument :optional_arg, :string, allow_nil?: true
+          end
+        end
+        
+        code_interface do
+          define :test_action  # No args needed since argument allows nil
+        end
+      end
+    end
+    
+    test "passes when argument has a default value" do
+      # Should not raise because argument has a default
+      defmodule TestResource4 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        actions do
+          action :test_action, :atom do
+            argument :arg_with_default, :string, default: "default_value"
+          end
+        end
+        
+        code_interface do
+          define :test_action  # No args needed since argument has default
+        end
+      end
+    end
+    
+    test "raises error with multiple missing required arguments" do
+      assert_raise(
+        Spark.Error.DslError,
+        ~r/The action `complex_action` has required arguments: \[:arg1, :arg2\]/,
+        fn ->
+          defmodule TestResource5 do
+            use Ash.Resource, domain: Ash.Test.Domain
+            
+            actions do
+              action :complex_action, :atom do
+                argument :arg1, :string, allow_nil?: false
+                argument :arg2, :integer, allow_nil?: false
+                argument :optional_arg, :boolean, allow_nil?: true
+              end
+            end
+            
+            code_interface do
+              define :complex_action  # Missing args: [:arg1, :arg2]
+            end
+          end
+        end
+      )
+    end
+    
+    test "passes when using {:optional, arg} syntax" do
+      # Should not raise
+      defmodule TestResource6 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        actions do
+          action :test_action, :atom do
+            argument :required_arg, :string, allow_nil?: false
+          end
+        end
+        
+        code_interface do
+          define :test_action, args: [{:optional, :required_arg}]
+        end
+      end
+    end
+    
+    test "works with create actions" do
+      assert_raise(
+        Spark.Error.DslError,
+        ~r/Code interface `create_user` is missing required arguments/,
+        fn ->
+          defmodule TestResource7 do
+            use Ash.Resource, domain: Ash.Test.Domain
+            
+            attributes do
+              uuid_primary_key :id
+              attribute :name, :string, public?: true
+            end
+            
+            actions do
+              create :create_user do
+                argument :password, :string, allow_nil?: false
+                argument :password_confirmation, :string, allow_nil?: false
+              end
+            end
+            
+            code_interface do
+              define :create_user  # Missing args: [:password, :password_confirmation]
+            end
+          end
+        end
+      )
+    end
+    
+    test "works with read actions" do
+      assert_raise(
+        Spark.Error.DslError,
+        ~r/Code interface `search` is missing required arguments/,
+        fn ->
+          defmodule TestResource8 do
+            use Ash.Resource, domain: Ash.Test.Domain
+            
+            attributes do
+              uuid_primary_key :id
+              attribute :title, :string, public?: true
+            end
+            
+            actions do
+              read :search do
+                argument :query, :string, allow_nil?: false
+              end
+            end
+            
+            code_interface do
+              define :search  # Missing args: [:query]
+            end
+          end
+        end
+      )
+    end
+    
+    test "passes when interface name differs from action name" do
+      # Should not raise
+      defmodule TestResource9 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        actions do
+          action :internal_action, :atom do
+            argument :required_arg, :string, allow_nil?: false
+          end
+        end
+        
+        code_interface do
+          define :public_name, action: :internal_action, args: [:required_arg]
+        end
+      end
+    end
+    
+    test "includes helpful error message with fix suggestion" do
+      error = assert_raise(
+        Spark.Error.DslError,
+        fn ->
+          defmodule TestResource10 do
+            use Ash.Resource, domain: Ash.Test.Domain
+            
+            actions do
+              action :analyze_sentiment, :atom do
+                argument :text, :string, allow_nil?: false
+              end
+            end
+            
+            code_interface do
+              define :analyze_sentiment  # Missing args: [:text]
+            end
+          end
+        end
+      )
+      
+      assert error.message =~ "Fix by updating your code interface:"
+      assert error.message =~ "define :analyze_sentiment, args: [:text]"
+      assert error.message =~ "Alternatively, if these arguments should be optional"
+    end
+    
+    test "passes when custom input transforms to required argument" do
+      # Should not raise because custom input transforms :map to :id
+      defmodule TestResource11 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        attributes do
+          uuid_primary_key :id
+        end
+        
+        actions do
+          update :update_user do
+            argument :user_id, :string, allow_nil?: false
+          end
+        end
+        
+        code_interface do
+          define :update_by_map do
+            action :update_user
+            args [:map]
+            
+            custom_input :map, :map do
+              transform to: :user_id, using: &Map.fetch!(&1, :user_id)
+            end
+          end
+        end
+      end
+    end
+    
+    test "passes when argument is excluded" do
+      # Should not raise because argument is explicitly excluded
+      defmodule TestResource12 do
+        use Ash.Resource, domain: Ash.Test.Domain
+        
+        attributes do
+          uuid_primary_key :id
+        end
+        
+        actions do
+          update :update_user do
+            argument :user_id, :string, allow_nil?: false
+          end
+        end
+        
+        code_interface do
+          define :update_user, exclude_inputs: [:user_id]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
if args are missing from code_interface `define` but it is defined in the action, then the error is raised. 


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
