### PR TITLE
fix: typo in Ash.Error.Framework module

### DIFF
--- a/lib/ash/error/framework.ex
+++ b/lib/ash/error/framework.ex
@@ -62,7 +62,7 @@ defmodule Ash.Error.Framework do
         end)
 
       container_doc(
-        "%Ash.Error.framework{",
+        "%Ash.Error.Framework{",
         items,
         "}",
         opts,


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
