### PR TITLE
feat: add support for custom postgres image in CI workflow

### DIFF
--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -35,6 +35,8 @@ on:
       postgres-version:
         type: string
         default: "14"
+      postgres-image:
+        type: string
       sqlite:
         type: boolean
         default: false
@@ -399,7 +401,7 @@ jobs:
       - build-test
     services:
       postgres:
-        image: postgres:${{inputs.postgres-version}}
+        image: ${{ inputs.postgres-image || format('postgres:{0}', inputs.postgres-version) }}
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
           TZ: "UTC"


### PR DESCRIPTION
## Summary
- Add `postgres-image` input parameter to allow specifying custom PostgreSQL Docker images
- Maintain backward compatibility by falling back to default `postgres:version` format when custom image is not provided

## Use Cases
This enables testing with:
- PostGIS images (`postgis/postgis:15-3.3`)
- pgvector images (`pgvector/pgvector:pg15`)
- Alpine variants (`postgres:15-alpine`) 
- Custom PostgreSQL builds
- Specific vendor distributions