### PR TITLE
fix: add clause in Ash.Type.String.match/1 to handle the OTP 28 regex tuples

### DIFF
--- a/lib/ash/type/string.ex
+++ b/lib/ash/type/string.ex
@@ -336,6 +336,10 @@ defmodule Ash.Type.String do
     {:ok, regex}
   end
 
+  def match({regex, flags}) when is_binary(regex) and is_binary(flags) do
+    {:ok, Regex.compile!(regex, flags)}
+  end
+
   def match(value) do
     {:error,
      "Must provide a string or a tuple of regex and flags (see warning), got: #{inspect(value)}"}

--- a/test/type/ci_string_test.exs
+++ b/test/type/ci_string_test.exs
@@ -42,6 +42,16 @@ defmodule Ash.Test.Type.CiString do
       attribute :string_f, :ci_string,
         constraints: [min_length: 3, max_length: 6, trim?: false],
         public?: true
+
+      attribute :string_g, :ci_string,
+        allow_nil?: true,
+        constraints: [match: ~r/^string_[a-z]+$/i],
+        public?: true
+
+      attribute :string_h, :ci_string,
+        allow_nil?: true,
+        constraints: [match: {~S"^string_[a-z]+$", "i"}],
+        public?: true
     end
   end
 
@@ -129,5 +139,49 @@ defmodule Ash.Test.Type.CiString do
              Post
              |> Ash.Query.filter(string_f == "FoObAr")
              |> Ash.read!()
+  end
+
+  test "match for :string_g succeeds on good regexes" do
+    Post
+    |> Ash.Changeset.for_create(:create, %{string_g: "string_a"})
+    |> Ash.create!()
+
+    Post
+    |> Ash.Changeset.for_create(:create, %{string_g: "string_b"})
+    |> Ash.create!()
+  end
+
+  test "match for :string_g rejects bad regexes" do
+    assert {:error, %Ash.Error.Invalid{}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{string_g: "string_1"})
+             |> Ash.create()
+
+    assert {:error, %Ash.Error.Invalid{}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{string_g: "string"})
+             |> Ash.create()
+  end
+
+  test "match for :string_h succeeds on good regexes" do
+    Post
+    |> Ash.Changeset.for_create(:create, %{string_h: "string_a"})
+    |> Ash.create!()
+
+    Post
+    |> Ash.Changeset.for_create(:create, %{string_h: "string_b"})
+    |> Ash.create!()
+  end
+
+  test "match for :string_h rejects bad regexes" do
+    assert {:error, %Ash.Error.Invalid{}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{string_h: "string_1"})
+             |> Ash.create()
+
+    assert {:error, %Ash.Error.Invalid{}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{string_h: "string"})
+             |> Ash.create()
   end
 end


### PR DESCRIPTION
fix: add clause in Ash.Type.String.match/1 to handle the OTP 28 regex tuples

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
