### PR TITLE
fix: set_tenant on combination query

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -4257,6 +4257,7 @@ defmodule Ash.Query do
           end)
 
         base_query
+        |> Ash.Query.set_tenant(query.tenant)
         |> limit(combination.limit)
         |> offset(combination.offset)
         |> do_filter(combination.filter)


### PR DESCRIPTION
I encountered this issue in a project where a combination query referenced a relationship, and it was searching in the `public` schema. This changed fixed it.