### PR TITLE
fix(calculations): correct path construction order for nested relationship rewrites

### DIFF
--- a/lib/ash/actions/read/calculations.ex
+++ b/lib/ash/actions/read/calculations.ex
@@ -861,15 +861,16 @@ defmodule Ash.Actions.Read.Calculations do
           query
           |> get_all_rewrites(calculation, path)
           |> Enum.map(fn {{path, data, calc_name, calc_load}, source} ->
-            {{path ++ [{:rel, name}], data, calc_name, calc_load}, source}
+            {{[{:rel, name} | path], data, calc_name, calc_load}, source}
           end)
         end
 
       {name, query} ->
-        query
-        |> get_all_rewrites(calculation, path)
+        nested_rewrites = query |> get_all_rewrites(calculation, path)
+
+        nested_rewrites
         |> Enum.map(fn {{path, data, calc_name, calc_load}, source} ->
-          {{path ++ [{:rel, name}], data, calc_name, calc_load}, source}
+          {{[{:rel, name} | path], data, calc_name, calc_load}, source}
         end)
     end)
     |> Enum.concat(load_relationship_rewrites(ash_query, calculation, path))
@@ -898,7 +899,7 @@ defmodule Ash.Actions.Read.Calculations do
                     path
                   )
                   |> Enum.map(fn {{path, data, calc_name, calc_load}, source} ->
-                    {{path ++ [{:rel, name}], data, calc_name, calc_load}, source}
+                    {{[{:rel, name} | path], data, calc_name, calc_load}, source}
                   end)
               ]
 
@@ -925,7 +926,7 @@ defmodule Ash.Actions.Read.Calculations do
         path
       )
       |> Enum.map(fn {{path, data, calc_name, calc_load}, source} ->
-        {{path ++ [{:rel, calculation.opts[:relationship]}], data, calc_name, calc_load}, source}
+        {{[{:rel, calculation.opts[:relationship]} | path], data, calc_name, calc_load}, source}
       end)
     end)
   end


### PR DESCRIPTION
When loading multiple calculations that depend on nested relationships with no_attributes?: true, the rewrite system was constructing relationship traversal paths in reverse order, causing KeyError when trying to access relationships that don't exist on the current record.

The issue occurred in get_rewrites/4 where relationship names were being appended to paths instead of prepended, creating paths like [{:rel, :grandparent}, {:rel, :parent}] instead of the correct [{:rel, :parent}, {:rel, :grandparent}].

This caused the system to try accessing :grandparent directly on Child records instead of traversing Child → Parent → Grandparent.

Fixed by changing path construction from append to prepend:
- `path ++ [{:rel, name}]` → `[{:rel, name} | path]`

This ensures rewrite paths match actual relationship traversal order.

Closes #2127
