### PR TITLE
fix(code_interface): add notify?: true for bulk creates

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -926,6 +926,7 @@ defmodule Ash.CodeInterface do
                         bulk_opts =
                           opts
                           |> Keyword.delete(:bulk_options)
+                          |> Keyword.put(:notify?, true)
                           |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
                           |> Enum.concat(changeset_opts)
 
@@ -952,6 +953,7 @@ defmodule Ash.CodeInterface do
                         bulk_opts =
                           opts
                           |> Keyword.delete(:bulk_options)
+                          |> Keyword.put(:notify?, true)
                           |> Keyword.merge(Keyword.get(opts, :bulk_options, []))
                           |> Enum.concat(changeset_opts)
 


### PR DESCRIPTION
## Changes

- Code Interface: Add `Keyword.put(:notify?, true)` to `bulk_options` for bulk creates so notifications are sent by default like `:update` and `:destroy` actions

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
