### PR TITLE
testing: `force_change_attribute` behaviour when value is `nil` based on `v3.4.23`

### DIFF
--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -1357,4 +1357,28 @@ defmodule Ash.Test.Changeset.ChangesetTest do
 
     assert :published == updated_resource.publication_status
   end
+
+  describe "force_change_attribute" do
+    test "it changes the attribute to a value" do
+      post = Ash.Changeset.for_create(Post, :create) |> Ash.create!()
+
+      changeset =
+        post
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.Changeset.force_change_attribute(:title, "foo")
+
+      assert changeset.attributes == %{title: "foo"}
+    end
+
+    test "it sets the attribute to `nil`" do
+      post = Ash.Changeset.for_create(Post, :create) |> Ash.create!()
+
+      changeset =
+        post
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.Changeset.force_change_attribute(:title, nil)
+
+      assert changeset.attributes == %{title: nil}
+    end
+  end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Context

Related to the topic in Discord (https://discord.com/channels/711271361523351632/1383382022289883216)

A test that demonstrates that the behaviour of `force_change_attribute` changed.

What I did and what I observed:

- I branched out of `v3.4.23` (`git checkout v3.4.23;` `git checkout -b testing/attributes-to-nil-3.4.23`)
- I created the tests that set an attribute. One with a `string` value, one with `nil`. The tests pass.
- If you run the same tests on `main`/`v3.5.20`, the second test fails because no change was detected; `attributes: %{}`.

**Note**: this PR **does not** claim that `force_change_attribute` should behave as the tests expect it to behave!

I only want to demonstrate a change in the behaviour that I observed in our code base and we somewhat relied on this behaviour.

If it is not expected for `force_change_attribute`, that is totally fine. We simply need to find a strategy to reproduce a similar behaviour.

# Execute tests:

```sh
# optional - assuming, you worked on `main` before
rm -rf deps && rm -rf _build
mix deps.get

# run tests
mix test test/changeset/changeset_test.exs
``` 