### PR TITLE
testing: `force_change_attribute` behaviour when value is `nil` based on `main`

### DIFF
--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -1508,4 +1508,28 @@ defmodule Ash.Test.Changeset.ChangesetTest do
 
     assert :published == updated_resource.publication_status
   end
+
+  describe "force_change_attribute" do
+    test "it changes the attribute to a value" do
+      post = Ash.Changeset.for_create(Post, :create) |> Ash.create!()
+
+      changeset =
+        post
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.Changeset.force_change_attribute(:title, "foo")
+
+      assert changeset.attributes == %{title: "foo"}
+    end
+
+    test "it sets the attribute to `nil`" do
+      post = Ash.Changeset.for_create(Post, :create) |> Ash.create!()
+
+      changeset =
+        post
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.Changeset.force_change_attribute(:title, nil)
+
+      assert changeset.attributes == %{title: nil}
+    end
+  end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Context

See https://github.com/ash-project/ash/pull/2141

Related to the topic in Discord (https://discord.com/channels/711271361523351632/1383382022289883216)

This PR only exists for quickly run the same tests as shown in https://github.com/ash-project/ash/pull/2141. The 2nd test in this PR will fail as the behaviour of `force_change_attribute` seems to have changed.

<img width="729" alt="Screenshot 2025-06-15 at 19 17 07" src="https://github.com/user-attachments/assets/ddcc8887-e78d-4923-8597-ed73d2d9e031" />

# Execute tests

```sh
# optional - assuming, you worked on `testing/attributes-to-nil-3.4.23` before
rm -rf deps && rm -rf _build
mix deps.get

# run tests
mix test test/changeset/changeset_test.exs
``` 