### PR TITLE
docs: Fix syntax error in `Ash.Policy.Check.Builtins.changing_attributes` example

### DIFF
--- a/lib/ash/policy/check/built_in_checks.ex
+++ b/lib/ash/policy/check/built_in_checks.ex
@@ -272,7 +272,7 @@ defmodule Ash.Policy.Check.Builtins do
   changing_attributes(last_name: [from: "bob"])
 
   # if you are changing :first_name at all, last_name from "bob" and middle name from "tom" to "george"
-  changing_attributes([:first_name, last_name: [from: "bob"], middle_name: [from: "tom", to: "george]])
+  changing_attributes([:first_name, last_name: [from: "bob"], middle_name: [from: "tom", to: "george"]])
   ```
   """
   def changing_attributes(opts) do


### PR DESCRIPTION
This one!

<img width="218" alt="Screenshot 2025-06-18 at 3 14 34 PM" src="https://github.com/user-attachments/assets/06c39953-4458-4a34-8164-1947ee576c1b" />

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
