### PR TITLE
fix min/max length constraint handling in Ash.Type for array types

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -1203,54 +1203,49 @@ defmodule Ash.Type do
   def apply_constraints({:array, type}, term, constraints) when is_list(term) do
     type = get_type(type)
 
-    list_constraint_errors = list_constraint_errors(term, constraints)
     item_constraints = item_constraints(constraints)
 
-    case list_constraint_errors do
-      [] ->
-        nil_items? = Keyword.get(constraints, :nil_items?, false)
-        remove_nil_items? = Keyword.get(constraints, :remove_nil_items?, false)
+    nil_items? = Keyword.get(constraints, :nil_items?, false)
+    remove_nil_items? = Keyword.get(constraints, :remove_nil_items?, false)
 
-        term
-        |> Enum.with_index()
-        |> Enum.reduce({[], []}, fn {item, index}, {items, errors} ->
-          if type.custom_apply_constraints_array?() do
-            maybe_handle_nil_item(item, index, items, errors, nil_items?, remove_nil_items?)
-          else
-            case apply_constraints(type, item, item_constraints) do
-              {:ok, value} ->
-                maybe_handle_nil_item(value, index, items, errors, nil_items?, remove_nil_items?)
+    {terms, errors} =
+      term
+      |> Enum.with_index()
+      |> Enum.reduce({[], []}, fn {item, index}, {items, errors} ->
+        if type.custom_apply_constraints_array?() do
+          maybe_handle_nil_item(item, index, items, errors, nil_items?, remove_nil_items?)
+        else
+          case apply_constraints(type, item, item_constraints) do
+            {:ok, value} ->
+              maybe_handle_nil_item(value, index, items, errors, nil_items?, remove_nil_items?)
 
-              {:error, new_errors} ->
-                new_errors =
-                  new_errors
-                  |> List.wrap()
-                  |> Ash.Helpers.flatten_preserving_keywords()
-                  |> Enum.map(fn
-                    string when is_binary(string) ->
-                      [message: string, index: index]
+            {:error, new_errors} ->
+              new_errors =
+                new_errors
+                |> List.wrap()
+                |> Ash.Helpers.flatten_preserving_keywords()
+                |> Enum.map(fn
+                  string when is_binary(string) ->
+                    [message: string, index: index]
 
-                    vars ->
-                      Keyword.put(vars, :index, index)
-                  end)
+                  vars ->
+                    Keyword.put(vars, :index, index)
+                end)
 
-                {[item | items], List.wrap(new_errors) ++ errors}
-            end
+              {[item | items], List.wrap(new_errors) ++ errors}
           end
-        end)
-        |> case do
-          {terms, []} ->
-            if type.custom_apply_constraints_array?() do
-              case type.apply_constraints_array(Enum.reverse(terms), item_constraints) do
-                :ok -> {:ok, term}
-                other -> other
-              end
-            else
-              {:ok, Enum.reverse(terms)}
-            end
+        end
+      end)
 
-          {_, errors} ->
-            {:error, errors}
+    case errors ++ list_constraint_errors(terms, constraints) do
+      [] ->
+        if type.custom_apply_constraints_array?() do
+          case type.apply_constraints_array(Enum.reverse(terms), item_constraints) do
+            :ok -> {:ok, term}
+            other -> other
+          end
+        else
+          {:ok, Enum.reverse(terms)}
         end
 
       errors ->

--- a/test/type/array_test.exs
+++ b/test/type/array_test.exs
@@ -34,4 +34,16 @@ defmodule Ash.Test.Type.ArrayTest do
                Keyword.put(@default_constraints, :remove_nil_items?, true)
              )
   end
+
+  test "it errors when array length is below min_length constraint" do
+    assert {:error, [message: "must have %{min} or more items", min: 1]} =
+             Ash.Type.apply_constraints(
+               {:array, :string},
+               [""],
+               Keyword.merge(@default_constraints,
+                 min_length: 1,
+                 remove_nil_items?: true
+               )
+             )
+  end
 end


### PR DESCRIPTION
run the min/max length constraints for `{:array, _}` types after all the other constraints have been applied
