### PR TITLE
docs: add missing contraints header for map type

### DIFF
--- a/lib/ash/type/map.ex
+++ b/lib/ash/type/map.ex
@@ -61,6 +61,8 @@ defmodule Ash.Type.Map do
 
   A builtin type that can be referenced via `:map`
 
+  ### Constraints
+
   #{Spark.Options.docs(@constraints)}
   """
   use Ash.Type


### PR DESCRIPTION
Seems to be a convention for other types but missing for that one which made the doc confusing.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
