### PR TITLE
Fix relative link in usage-rules.md to use absolute HexDocs URL

### DIFF
--- a/usage-rules.md
+++ b/usage-rules.md
@@ -585,7 +585,7 @@ end
 - `on_missing: :destroy` - Delete records not in input
 - `value_is_key: :name` - Use field as key for simple values
 
-For comprehensive documentation, see the [Managing Relationships](documentation/topics/resources/relationships.md#managing-relationships) section.
+For comprehensive documentation, see the [Managing Relationships](https://hexdocs.pm/ash/relationships.html#managing-relationships) section.
 
 #### Examples
 


### PR DESCRIPTION
The relative link to documentation/topics/resources/relationships.md#managing-relationships was causing linter warnings when usage-rules.md was used outside of the GitHub repository context. This replaces it with the absolute HexDocs URL which works universally.

Fixes the issue where LLM instruction linters throw warnings about broken links.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
