### PR TITLE
chore: Use the same parent query timeout for the count query, for `read` actions

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -651,7 +651,7 @@ defmodule Ash.Actions.Read do
              results <- add_keysets(query, results, query.sort),
              {:ok, results} <- run_authorize_results(query, results),
              {:ok, results, after_notifications} <- run_after_action(query, results),
-             {:ok, count} <- maybe_await(count) do
+             {:ok, count} <- maybe_await(count, query.timeout) do
           notify_callback.(query, before_notifications ++ after_notifications)
           {:ok, results, count, calculations_at_runtime, calculations_in_query, query}
         else
@@ -3201,8 +3201,8 @@ defmodule Ash.Actions.Read do
     end)
   end
 
-  defp maybe_await(%Task{} = task) do
-    case Task.await(task) do
+  defp maybe_await(%Task{} = task, timeout) do
+    case Task.await(task, timeout) do
       {:__exception__, e, stacktrace} ->
         reraise e, stacktrace
 
@@ -3211,7 +3211,7 @@ defmodule Ash.Actions.Read do
     end
   end
 
-  defp maybe_await(other), do: other
+  defp maybe_await(other, _timeout), do: other
 
   defp fetch_count(
          %{context: %{full_count: full_count}},


### PR DESCRIPTION
As discussed [in Slack](https://discord.com/channels/711271361523351632/1386661506904621147).

When supplying the `timeout` option to `Ash.read`, that timeout is not being used for the `count` query that also gets run (when fetching a total count, for pagination purposes).

Doing some testing via a Cinder table (as that's what the original error was coming from), when specifying `query_opts={[timeout: 10000]}` this gets passed through to the `count` query.

If no `timeout` is specified from the table, `query.timeout` is `:infinity`.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
