### PR TITLE
improvement: allow pure-binary sigils in expr fragments

### DIFF
--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -823,6 +823,11 @@ defmodule Ash.Expr do
     soft_escape(Ash.CiString.sigil_i(str, mods), escape?)
   end
 
+  def do_expr({:fragment, opts, [{_, _, [{:<<>>, _, [query]}, []]} | rest]}, escape?)
+      when is_binary(query) do
+    do_expr({:fragment, opts, [Macro.expand(query, __ENV__) | rest]}, escape?)
+  end
+
   def do_expr({:fragment, _, [first | _] = args}, escape?)
       when is_binary(first) or is_function(first) do
     last_arg = List.last(args)

--- a/lib/ash/notifier/notifier.ex
+++ b/lib/ash/notifier/notifier.ex
@@ -76,7 +76,8 @@ defmodule Ash.Notifier do
           actor: notification.changeset && notification.changeset.context[:private][:actor],
           tenant: notification.changeset && notification.changeset.context[:private][:tenant],
           action: notification.action.name,
-          authorize?: notification.changeset && notification.changeset.context[:private][:authorize?]
+          authorize?:
+            notification.changeset && notification.changeset.context[:private][:authorize?]
         }
       end
 

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -19,6 +19,23 @@ defmodule Ash.Test.ExprTest do
     end
   end
 
+  describe "fragments" do
+    test "allow pure binary sigils" do
+      assert expr(fragment(~SQL"? > ?", 2, 1)) = expr(fragment("? > ?", 2, 1))
+      assert expr(fragment(~S"? > ?", 2, 1)) = expr(fragment("? > ?", 2, 1))
+      assert expr(fragment(~s"? > ?", 2, 1)) = expr(fragment("? > ?", 2, 1))
+
+      injection_ast =
+        quote do
+          expr(fragment(~s"#{"sneaky"} ? > ?", 2, 1))
+        end
+
+      assert_raise RuntimeError, fn ->
+        Code.eval_quoted(injection_ast)
+      end
+    end
+  end
+
   describe "determine_types" do
     test "it determines the type of an if statement with complex values" do
       {:ok, %func{arguments: args}} =


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
