### PR TITLE
test: add tests for updates with argument-based changes

### DIFF
--- a/test/resource/actions/update_test.exs
+++ b/test/resource/actions/update_test.exs
@@ -74,4 +74,74 @@ defmodule Ash.Test.Dsl.Resource.Actions.UpdateTest do
       )
     end
   end
+
+  describe "updates with argument-based changes" do
+    test "atomic_update should work with argument expressions without requiring attribute in accept list" do
+      defmodule Post1 do
+        @moduledoc false
+        use Ash.Resource,
+          domain: Domain,
+          data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          attribute :oban_job_id, :integer
+        end
+
+        actions do
+          defaults [:read, create: []]
+
+          update :set_oban_job_id do
+            argument :job_id, :integer, allow_nil?: false
+
+            change atomic_update(:oban_job_id, expr(^arg(:job_id)))
+          end
+        end
+
+        code_interface do
+          define :create, action: :create
+          define :set_oban_job_id, action: :set_oban_job_id, args: [:job_id]
+        end
+      end
+
+      {:ok, post} = Post1.create()
+
+      assert {:ok, updated_post} = Post1.set_oban_job_id(post, 123)
+      assert updated_post.oban_job_id == 123
+    end
+
+    test "set_attribute should work with argument expressions without requiring attribute in accept list" do
+      defmodule Post2 do
+        @moduledoc false
+        use Ash.Resource,
+          domain: Domain,
+          data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          attribute :oban_job_id, :integer
+        end
+
+        actions do
+          defaults [:read, create: []]
+
+          update :set_oban_job_id do
+            argument :job_id, :integer, allow_nil?: false
+
+            change set_attribute(:oban_job_id, arg(:job_id))
+          end
+        end
+
+        code_interface do
+          define :create, action: :create
+          define :set_oban_job_id, action: :set_oban_job_id, args: [:job_id]
+        end
+      end
+
+      {:ok, post} = Post2.create()
+
+      assert {:ok, updated_post} = Post2.set_oban_job_id(post, 123)
+      assert updated_post.oban_job_id == 123
+    end
+  end
 end


### PR DESCRIPTION
Given a resource with attributes defined as

```elixir
attributes do
  ...

  attribute :oban_job_id, :integer
end
```

and an update action defined as

```elixir
update :set_oban_job_id do
  argument :job_id, allow_nil?: false

  change atomic_update(:oban_job_id, expr(^arg(:job_id)))
end
```

alongside a code interface like

```elixir
define :set_oban_job_id, action: :set_oban_job_id, args: [:job_id]
```

running the `Resource.set_oban_job_id(resource, 123)` results in:

```
Invalid Error

* No such input `oban_job_id` for action MyApp.Products.Product.set_oban_job_id

The attribute exists on MyApp.Products.Product, but is not accepted by MyApp.Products.Product.set_oban_job_id

Perhaps you meant to add it to the accept list for MyApp.Products.Product.set_oban_job_id?

Valid Inputs:

* job_id
```

Changing `atomic_update` to `set_attribute` fixes it.

This PR introduces two new tests: one that exactly mimics the above set up, and one that uses `set_attribute` instead. The first test fails, the second test passes.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] ~Bug fixes~ include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
