### PR TITLE
Replace inexistent at_least_one_of_present in validation examples

### DIFF
--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -1400,7 +1400,7 @@ validate {Mod, [foo: :bar]}
 ```
 
 ```
-validate at_least_one_of_present([:first_name, :last_name])
+validate present([:first_name, :last_name], at_least: 1)
 ```
 
 
@@ -2617,7 +2617,7 @@ Declare validations prior to performing actions against the resource
 ```
 validations do
   validate {Mod, [foo: :bar]}
-  validate at_least_one_of_present([:first_name, :last_name])
+  validate present([:first_name, :last_name], at_least: 1)
 end
 
 ```
@@ -2644,7 +2644,7 @@ validate {Mod, [foo: :bar]}
 ```
 
 ```
-validate at_least_one_of_present([:first_name, :last_name])
+validate present([:first_name, :last_name], at_least: 1)
 ```
 
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -477,7 +477,7 @@ defmodule Ash.Resource.Dsl do
     """,
     examples: [
       "validate {Mod, [foo: :bar]}",
-      "validate at_least_one_of_present([:first_name, :last_name])"
+      "validate present([:first_name, :last_name], at_least: 1)"
     ],
     target: Ash.Resource.Validation,
     schema: Ash.Resource.Validation.opt_schema(),
@@ -1043,7 +1043,7 @@ defmodule Ash.Resource.Dsl do
       """
       validations do
         validate {Mod, [foo: :bar]}
-        validate at_least_one_of_present([:first_name, :last_name])
+        validate present([:first_name, :last_name], at_least: 1)
       end
       """
     ],


### PR DESCRIPTION
This PR replaces the example
```
validate at_least_one_of_present([:first_name, :last_name])
```
with 
```
validate present([:first_name, :last_name], at_least: 1)
```

I was confused because I tried to use `at_least_one_of_present` from the example, and my editor refused to autocomplete. It seems that it doesn't exist and (AFAICT from search the history) has never existed?

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
