### PR TITLE
feat: short-circuit load function when load is empty

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -2437,6 +2437,8 @@ defmodule Ash do
   def load(nil, _, _), do: {:ok, nil}
   def load(:ok, _, _), do: {:ok, :ok}
   def load({:error, error}, _, _), do: {:error, error}
+  def load({:ok, data}, load, _) when load in [nil, []], do: {:ok, data}
+  def load(data, load, _) when load in [nil, []], do: {:ok, data}
 
   def load({:ok, values}, query, opts) do
     Ash.Helpers.expect_options!(opts)


### PR DESCRIPTION
Add early return clauses to the load function when the load parameter is nil or an empty list, avoiding unnecessary processing.
