### PR TITLE
chore: Remove `Elixir.` from module name printed in Igniter error message

### DIFF
--- a/lib/mix/tasks/ash.extend.ex
+++ b/lib/mix/tasks/ash.extend.ex
@@ -101,7 +101,7 @@ if Code.ensure_loaded?(Igniter) do
               :error ->
                 Igniter.add_issue(
                   igniter,
-                  "Could not determine whether #{subject} is an `Ash.Resource` or an `Ash.Domain`."
+                  "Could not determine whether #{inspect(subject)} is an `Ash.Resource` or an `Ash.Domain`."
                 )
             end
         end


### PR DESCRIPTION
Before:

```
Issues:

* Could not determine whether Elixir.Tunez.Music.Artist is an `Ash.Resource` or an `Ash.Domain`.
```

After:

```
Issues:

* Could not determine whether Tunez.Music.Artist is an `Ash.Resource` or an `Ash.Domain`.
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
