### PR TITLE
improvement: Add prepend? opt to hooks and Ash.Subject transaction hooks

### DIFF
--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -998,10 +998,15 @@ defmodule Ash.ActionInput do
   """
   @spec after_action(
           input :: t(),
-          fun :: after_action_fun()
+          fun :: after_action_fun(),
+          opts :: Keyword.t()
         ) :: t()
-  def after_action(input, func) do
-    %{input | after_action: input.after_action ++ [func]}
+  def after_action(input, func, opts \\ []) do
+    if opts[:prepend?] do
+      %{input | after_action: [func | input.after_action]}
+    else
+      %{input | after_action: input.after_action ++ [func]}
+    end
   end
 
   @doc """
@@ -1025,9 +1030,17 @@ defmodule Ash.ActionInput do
   - `around_transaction/2` for hooks that wrap the entire transaction
   - `before_action/3` for hooks that run before the action (inside transaction)
   """
-  @spec before_transaction(t, before_transaction_fun) :: t
-  def before_transaction(input, func) do
-    %{input | before_transaction: input.before_transaction ++ [func]}
+  @spec before_transaction(
+          input :: t(),
+          fun :: before_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def before_transaction(input, func, opts \\ []) do
+    if opts[:prepend?] do
+      %{input | before_transaction: [func | input.before_transaction]}
+    else
+      %{input | before_transaction: input.before_transaction ++ [func]}
+    end
   end
 
   @doc """
@@ -1051,9 +1064,17 @@ defmodule Ash.ActionInput do
   - `around_transaction/2` for hooks that wrap the entire transaction
   - `after_action/2` for hooks that run after the action (inside transaction)
   """
-  @spec after_transaction(t, after_transaction_fun) :: t
-  def after_transaction(input, func) do
-    %{input | after_transaction: input.after_transaction ++ [func]}
+  @spec after_transaction(
+          input :: t(),
+          fun :: after_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def after_transaction(input, func, opts \\ []) do
+    if opts[:prepend?] do
+      %{input | after_transaction: [func | input.after_transaction]}
+    else
+      %{input | after_transaction: input.after_transaction ++ [func]}
+    end
   end
 
   @doc """
@@ -1081,9 +1102,17 @@ defmodule Ash.ActionInput do
   - `after_transaction/2` for hooks that run after the transaction
   - `before_action/3` and `after_action/2` for hooks that run inside the transaction
   """
-  @spec around_transaction(t, around_transaction_fun) :: t
-  def around_transaction(input, func) do
-    %{input | around_transaction: input.around_transaction ++ [func]}
+  @spec around_transaction(
+          input :: t(),
+          fun :: around_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def around_transaction(input, func, opts \\ []) do
+    if opts[:prepend?] do
+      %{input | around_transaction: [func | input.around_transaction]}
+    else
+      %{input | around_transaction: input.around_transaction ++ [func]}
+    end
   end
 
   @doc false

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -507,7 +507,7 @@ defmodule Ash.ActionInput do
   - `set_private_argument/3` for setting private arguments
   - `for_action/4` for providing initial arguments
   """
-  @spec set_argument(input :: t(), name :: atom, value :: term()) :: t()
+  @spec set_argument(input :: t(), name :: atom | String.t(), value :: term()) :: t()
   def set_argument(input, argument, value) do
     if input.action do
       argument =
@@ -551,6 +551,26 @@ defmodule Ash.ActionInput do
     else
       input
     end
+  end
+
+  @doc """
+  Deletes one or more arguments from the subject.
+
+  ## Parameters
+
+    * `subject` - The subject to delete arguments from
+    * `arguments` - Single argument name or list of argument names to delete
+  """
+  @spec delete_argument(
+          input :: t(),
+          argument_or_arguments :: atom | String.t() | list(atom | String.t())
+        ) :: t()
+  def delete_argument(input, argument_or_arguments) do
+    argument_or_arguments
+    |> List.wrap()
+    |> Enum.reduce(input, fn argument, input ->
+      %{input | arguments: Map.delete(input.arguments, argument)}
+    end)
   end
 
   @doc """

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -4828,12 +4828,53 @@ defmodule Ash.Changeset do
     end
   end
 
+  @doc """
+  Fetches the changing value or the original value of an attribute.
+
+  ## Example
+
+      iex> changeset = Ash.Changeset.for_update(post, :update, %{title: "New Title"})
+      iex> Ash.Changeset.fetch_attribute(changeset, :title)
+      {:ok, "New Title"}
+      iex> Ash.Changeset.fetch_attribute(changeset, :content)
+      :error
+  """
+  @spec fetch_attribute(t, atom) :: {:ok, term} | :error
+  def fetch_attribute(changeset, attribute) do
+    case fetch_change(changeset, attribute) do
+      {:ok, value} ->
+        {:ok, value}
+
+      :error ->
+        fetch_data(changeset, attribute)
+    end
+  end
+
   @doc "Gets the value of an argument provided to the changeset, falling back to `Ash.Changeset.get_attribute/2` if nothing was provided."
   @spec get_argument_or_attribute(t, atom) :: term
   def get_argument_or_attribute(changeset, attribute) do
     case fetch_argument(changeset, attribute) do
       {:ok, value} -> value
       :error -> get_attribute(changeset, attribute)
+    end
+  end
+
+  @doc """
+  Fetches the value of an argument provided to the changeset, falling back to `Ash.Changeset.fetch_attribute/2` if nothing was provided.
+
+  ## Example
+
+      iex> changeset = Ash.Changeset.for_update(post, :update, %{title: "New Title"})
+      iex> Ash.Changeset.fetch_argument_or_attribute(changeset, :title)
+      {:ok, "New Title"}
+      iex> Ash.Changeset.fetch_argument_or_attribute(changeset, :content)
+      :error
+  """
+  @spec fetch_argument_or_attribute(t, atom) :: {:ok, term} | :error
+  def fetch_argument_or_attribute(changeset, argument_or_attribute) do
+    case fetch_argument(changeset, argument_or_attribute) do
+      {:ok, value} -> {:ok, value}
+      :error -> fetch_attribute(changeset, argument_or_attribute)
     end
   end
 
@@ -4856,6 +4897,22 @@ defmodule Ash.Changeset do
   @spec get_data(t, atom) :: term
   def get_data(changeset, attribute) do
     Map.get(changeset.data, attribute)
+  end
+
+  @doc """
+  Gets the original value for an attribute, or `:error` if it is not available.
+
+  ## Example
+
+      iex> changeset = Ash.Changeset.for_update(post, :update, %{title: "New Title"})
+      iex> Ash.Changeset.fetch_data(changeset, :title)
+      {:ok, "Original Title"}
+      iex> Ash.Changeset.fetch_data(changeset, :content)
+      :error
+  """
+  @spec fetch_data(t, atom) :: {:ok, term} | :error
+  def fetch_data(changeset, attribute) do
+    Map.fetch(changeset.data, attribute)
   end
 
   @doc """

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -6546,9 +6546,9 @@ defmodule Ash.Changeset do
   - `around_transaction/2` for hooks that wrap the entire transaction
   """
   @spec before_transaction(
-          t(),
-          before_transaction_fun(),
-          Keyword.t()
+          changeset :: t(),
+          fun :: before_transaction_fun(),
+          opts :: Keyword.t()
         ) :: t()
   def before_transaction(changeset, func, opts \\ []) do
     changeset = maybe_dirty_hook(changeset, :before_transaction)
@@ -6622,9 +6622,9 @@ defmodule Ash.Changeset do
   - `around_action/2` for hooks that wrap the data layer action
   """
   @spec after_action(
-          t(),
-          after_action_fun(),
-          Keyword.t()
+          changeset :: t(),
+          fun :: after_action_fun(),
+          opts :: Keyword.t()
         ) :: t()
   def after_action(changeset, func, opts \\ []) do
     changeset = maybe_dirty_hook(changeset, :after_action)
@@ -6724,9 +6724,9 @@ defmodule Ash.Changeset do
   - `around_transaction/2` for hooks that wrap the entire transaction
   """
   @spec after_transaction(
-          t(),
-          after_transaction_fun(),
-          Keyword.t()
+          changeset :: t(),
+          fun :: after_transaction_fun(),
+          opts :: Keyword.t()
         ) :: t()
   def after_transaction(changeset, func, opts \\ []) do
     changeset = maybe_dirty_hook(changeset, :after_transaction)
@@ -6784,10 +6784,19 @@ defmodule Ash.Changeset do
   - Multi-step actions guide for complex workflow patterns
   """
 
-  @spec around_action(t(), around_action_fun()) :: t()
-  def around_action(changeset, func) do
+  @spec around_action(
+          changeset :: t(),
+          fun :: around_action_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def around_action(changeset, func, opts \\ []) do
     changeset = maybe_dirty_hook(changeset, :around_action)
-    %{changeset | around_action: changeset.around_action ++ [func]}
+
+    if opts[:prepend?] do
+      %{changeset | around_action: [func | changeset.around_action]}
+    else
+      %{changeset | around_action: changeset.around_action ++ [func]}
+    end
   end
 
   @doc """
@@ -6829,10 +6838,19 @@ defmodule Ash.Changeset do
   - Multi-step actions guide for complex workflow patterns
   """
 
-  @spec around_transaction(t(), around_transaction_fun()) :: t()
-  def around_transaction(changeset, func) do
+  @spec around_transaction(
+          changeset :: t(),
+          fun :: around_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def around_transaction(changeset, func, opts \\ []) do
     changeset = maybe_dirty_hook(changeset, :around_transaction)
-    %{changeset | around_transaction: changeset.around_transaction ++ [func]}
+
+    if opts[:prepend?] do
+      %{changeset | around_transaction: [func | changeset.around_transaction]}
+    else
+      %{changeset | around_transaction: changeset.around_transaction ++ [func]}
+    end
   end
 
   defp maybe_dirty_hook(changeset, type) do

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -2796,9 +2796,12 @@ defmodule Ash.Query do
   - `set_argument/3` for adding arguments to queries
   - `for_read/4` for creating queries with arguments
   """
-  @spec get_argument(t, atom) :: term
-  def get_argument(query, argument) when is_atom(argument) do
-    Map.get(query.arguments, argument) || Map.get(query.arguments, to_string(argument))
+  @spec get_argument(t, atom | String.t()) :: term
+  def get_argument(query, argument) when is_atom(argument) or is_binary(argument) do
+    case fetch_argument(query, argument) do
+      {:ok, value} -> value
+      :error -> nil
+    end
   end
 
   @doc """
@@ -2831,8 +2834,10 @@ defmodule Ash.Query do
   - `set_argument/3` for adding arguments to queries
   - `for_read/4` for creating queries with arguments
   """
-  @spec fetch_argument(t, atom) :: {:ok, term} | :error
-  def fetch_argument(query, argument) when is_atom(argument) do
+  @spec fetch_argument(t, atom | String.t()) :: {:ok, term} | :error
+  def fetch_argument(query, argument) when is_atom(argument) or is_binary(argument) do
+    query = new(query)
+
     case Map.fetch(query.arguments, argument) do
       {:ok, value} ->
         {:ok, value}

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1325,10 +1325,19 @@ defmodule Ash.Query do
   - `around_transaction/2` for hooks that wrap the entire transaction
   - `before_action/3` for hooks that run before the action (inside transaction)
   """
-  @spec before_transaction(t(), before_transaction_fun()) :: t()
-  def before_transaction(query, func) do
+  @spec before_transaction(
+          query :: t(),
+          fun :: before_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def before_transaction(query, func, opts \\ []) do
     query = new(query)
-    %{query | before_transaction: query.before_transaction ++ [func]}
+
+    if opts[:prepend?] do
+      %{query | before_transaction: [func | query.before_transaction]}
+    else
+      %{query | before_transaction: query.before_transaction ++ [func]}
+    end
   end
 
   @doc """
@@ -1352,10 +1361,19 @@ defmodule Ash.Query do
   - `around_transaction/2` for hooks that wrap the entire transaction
   - `after_action/2` for hooks that run after the action (inside transaction)
   """
-  @spec after_transaction(t(), after_transaction_fun()) :: t()
-  def after_transaction(query, func) do
+  @spec after_transaction(
+          query :: t(),
+          fun :: after_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def after_transaction(query, func, opts \\ []) do
     query = new(query)
-    %{query | after_transaction: query.after_transaction ++ [func]}
+
+    if opts[:prepend?] do
+      %{query | after_transaction: [func | query.after_transaction]}
+    else
+      %{query | after_transaction: query.after_transaction ++ [func]}
+    end
   end
 
   @doc """
@@ -1403,10 +1421,19 @@ defmodule Ash.Query do
   - `Ash.read/2` for executing queries with hooks
   """
 
-  @spec around_transaction(t(), around_transaction_fun()) :: t()
-  def around_transaction(query, func) do
+  @spec around_transaction(
+          query :: t(),
+          fun :: around_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def around_transaction(query, func, opts \\ []) do
     query = new(query)
-    %{query | around_transaction: query.around_transaction ++ [func]}
+
+    if opts[:prepend?] do
+      %{query | around_transaction: [func | query.around_transaction]}
+    else
+      %{query | around_transaction: query.around_transaction ++ [func]}
+    end
   end
 
   @doc """
@@ -1529,11 +1556,11 @@ defmodule Ash.Query do
   - `Ash.read/2` for executing queries with hooks
   """
   @spec after_action(
-          t(),
-          (t(), [Ash.Resource.record()] ->
-             {:ok, [Ash.Resource.record()]}
-             | {:ok, [Ash.Resource.record()], list(Ash.Notifier.Notification.t())}
-             | {:error, term})
+          query :: t(),
+          fun :: (t(), [Ash.Resource.record()] ->
+                    {:ok, [Ash.Resource.record()]}
+                    | {:ok, [Ash.Resource.record()], list(Ash.Notifier.Notification.t())}
+                    | {:error, term})
         ) :: t()
   # in 4.0, add an option to prepend hooks
   def after_action(query, func) do

--- a/lib/ash/subject.ex
+++ b/lib/ash/subject.ex
@@ -7,6 +7,53 @@ defmodule Ash.Subject do
 
   @type t :: Ash.Changeset.t() | Ash.Query.t() | Ash.ActionInput.t()
 
+  @typedoc """
+  Function type for before action hooks.
+
+  Receives an action input and returns a modified action input, optionally with notifications.
+  """
+  @type before_action_fun :: (t() ->
+                                t() | {t(), %{notifications: [Ash.Notifier.Notification.t()]}})
+
+  @typedoc """
+  Function type for after action hooks.
+
+  Receives the action input and the result of the action, and can return
+  the result optionally with notifications, or an error.
+  """
+  @type after_action_fun ::
+          (t(), term() ->
+             {:ok, term()}
+             | {:ok, term(), [Ash.Notifier.Notification.t()]}
+             | {:error, any()})
+
+  @typedoc """
+  Function type for before transaction hooks.
+
+  Receives an action input and returns a modified action input or an error.
+  """
+  @type before_transaction_fun :: (t() -> t() | {:error, any()})
+
+  @typedoc """
+  Function type for after transaction hooks.
+
+  Receives the action input and the result of the transaction, and returns
+  the result (potentially modified) or an error.
+  """
+  @type after_transaction_fun ::
+          (t(), {:ok, term()} | {:error, any()} ->
+             {:ok, term()} | {:error, any()})
+
+  @typedoc """
+  Function type for around transaction hooks.
+
+  Receives an action input and a callback function that executes the transaction,
+  and returns the result of calling the callback or an error.
+  """
+  @type around_transaction_fun ::
+          (t(), (t() -> {:ok, term()} | {:error, any()}) ->
+             {:ok, term()} | {:error, any()})
+
   @doc """
   Adds an error or list of errors to the subject.
 
@@ -18,7 +65,10 @@ defmodule Ash.Subject do
     * `subject` - The subject to add errors to
     * `errors` - Error or list of errors to add
   """
-  @spec add_error(t(), Ash.Error.error_input() | list(Ash.Error.error_input())) :: t()
+  @spec add_error(
+          subject :: t(),
+          error_input :: Ash.Error.error_input() | list(Ash.Error.error_input())
+        ) :: t()
   def add_error(subject, []), do: subject
 
   def add_error(%Ash.Changeset{} = subject, error) do
@@ -42,7 +92,11 @@ defmodule Ash.Subject do
     * `key` - The context key
     * `value` - The value to store
   """
-  @spec put_context(t(), atom, term()) :: t()
+  @spec put_context(
+          subject :: t(),
+          key :: atom(),
+          value :: term()
+        ) :: t()
   def put_context(subject, key, value) do
     set_context(subject, %{key => value})
   end
@@ -58,7 +112,7 @@ defmodule Ash.Subject do
     * `subject` - The subject to set context on
     * `context` - Map of context data to merge
   """
-  @spec set_context(t(), map) :: t()
+  @spec set_context(subject :: t(), context :: map()) :: t()
   def set_context(%Ash.Changeset{} = subject, map) do
     Ash.Changeset.set_context(subject, map)
   end
@@ -90,7 +144,10 @@ defmodule Ash.Subject do
     * `subject` - The subject to get value from
     * `name` - The argument or attribute name (atom or string)
   """
-  @spec get_argument_or_attribute(t(), atom | binary) :: term()
+  @spec get_argument_or_attribute(
+          subject :: t(),
+          argument_or_attribute :: atom() | binary()
+        ) :: term()
   def get_argument_or_attribute(subject, argument_or_attribute, default \\ nil)
 
   def get_argument_or_attribute(%Ash.Changeset{} = subject, argument_or_attribute, default) do
@@ -114,7 +171,7 @@ defmodule Ash.Subject do
     * `subject` - The subject to get argument from
     * `argument` - The argument name (atom or string)
   """
-  @spec get_argument(t(), atom | binary) :: term()
+  @spec get_argument(subject :: t(), argument :: atom() | binary(), default :: term()) :: term()
   def get_argument(subject, argument, default \\ nil)
 
   def get_argument(subject, argument, default) when is_atom(argument) do
@@ -146,7 +203,7 @@ defmodule Ash.Subject do
     end
   end
 
-  @spec get_attribute(t(), atom) :: term()
+  @spec get_attribute(subject :: t(), attribute :: atom()) :: term()
   def get_attribute(%Ash.Changeset{} = subject, attribute) do
     Ash.Changeset.get_attribute(subject, attribute)
   end
@@ -166,7 +223,7 @@ defmodule Ash.Subject do
     * `subject` - The subject to fetch argument from
     * `argument` - The argument name (atom or string)
   """
-  @spec fetch_argument(t(), atom | binary) :: {:ok, term()} | :error
+  @spec fetch_argument(subject :: t(), argument :: atom() | binary()) :: {:ok, term()} | :error
   def fetch_argument(subject, argument) when is_atom(argument) do
     case Map.fetch(subject.arguments, argument) do
       {:ok, value} ->
@@ -204,7 +261,7 @@ defmodule Ash.Subject do
     * `subject` - The subject to set arguments on
     * `arguments` - Map of argument names to values
   """
-  @spec set_arguments(t(), map) :: t()
+  @spec set_arguments(subject :: t(), arguments :: map()) :: t()
   def set_arguments(subject, map) do
     Enum.reduce(map, subject, fn {key, value}, subject ->
       set_argument(subject, key, value)
@@ -220,7 +277,7 @@ defmodule Ash.Subject do
     * `argument` - The argument name (atom or string)
     * `value` - The value to set
   """
-  @spec set_argument(t(), atom | binary, term()) :: t()
+  @spec set_argument(subject :: t(), argument :: atom() | binary(), value :: term()) :: t()
   def set_argument(%Ash.Changeset{} = subject, argument, value) do
     Ash.Changeset.set_argument(subject, argument, value)
   end
@@ -241,7 +298,10 @@ defmodule Ash.Subject do
     * `subject` - The subject to delete arguments from
     * `arguments` - Single argument name or list of argument names to delete
   """
-  @spec delete_argument(t(), atom | binary | list(atom | binary)) :: t()
+  @spec delete_argument(
+          subject :: t(),
+          argument_or_arguments :: atom() | binary() | list(atom() | binary())
+        ) :: t()
   def delete_argument(%Ash.Changeset{} = subject, argument_or_arguments) do
     Ash.Changeset.delete_argument(subject, argument_or_arguments)
   end
@@ -270,7 +330,11 @@ defmodule Ash.Subject do
     * `argument` - The argument name (atom or string)
     * `value` - The value to set
   """
-  @spec set_private_argument(Ash.Changeset.t() | Ash.ActionInput.t(), atom | binary, term()) ::
+  @spec set_private_argument(
+          subject :: Ash.Changeset.t() | Ash.ActionInput.t(),
+          argument :: atom() | binary(),
+          value :: term()
+        ) ::
           Ash.Changeset.t() | Ash.ActionInput.t()
   def set_private_argument(%Ash.Changeset{} = subject, argument, value) do
     Ash.Changeset.set_private_argument(subject, argument, value)
@@ -291,7 +355,10 @@ defmodule Ash.Subject do
     * `subject` - The subject to set private arguments on (Changeset or ActionInput)
     * `arguments` - Map of argument names to values
   """
-  @spec set_private_arguments(Ash.Changeset.t() | Ash.ActionInput.t(), map) ::
+  @spec set_private_arguments(
+          subject :: Ash.Changeset.t() | Ash.ActionInput.t(),
+          arguments :: map()
+        ) ::
           Ash.Changeset.t() | Ash.ActionInput.t()
   def set_private_arguments(subject, map) do
     Enum.reduce(map, subject, fn {key, value}, subject ->
@@ -308,7 +375,11 @@ defmodule Ash.Subject do
     * `callback` - Function that takes and returns the subject
     * `opts` - Options including `:prepend?` to add at beginning
   """
-  @spec before_action(t(), (t() -> t()), Keyword.t()) :: t()
+  @spec before_action(
+          subject :: t(),
+          callback :: before_action_fun(),
+          opts :: Keyword.t()
+        ) :: t()
   def before_action(subject, callback, opts \\ [])
 
   def before_action(%Ash.Changeset{} = subject, callback, opts) do
@@ -338,7 +409,11 @@ defmodule Ash.Subject do
     * `callback` - Function that processes the result
     * `opts` - Options including `:prepend?` (ignored for Query)
   """
-  @spec after_action(t(), (t(), term() -> {:ok, term()} | {:error, term()}), Keyword.t()) :: t()
+  @spec after_action(
+          subject :: t(),
+          callback :: after_action_fun(),
+          opts :: Keyword.t()
+        ) :: t()
   def after_action(subject, callback, opts \\ [])
 
   def after_action(%Ash.Changeset{} = subject, callback, opts) do
@@ -354,6 +429,234 @@ defmodule Ash.Subject do
       %{subject | after_action: [callback | subject.after_action]}
     else
       %{subject | after_action: subject.after_action ++ [callback]}
+    end
+  end
+
+  @doc """
+  Adds a before_transaction hook to the subject.
+
+  Before transaction hooks are executed before the database transaction begins.
+  They receive the subject and must return either a modified subject or an error tuple.
+  These hooks are useful for validation, authorization checks, or preparatory logic
+  that should run outside of the transaction.
+
+  ## Parameters
+
+    * `subject` - The subject to add the hook to (Changeset, Query, or ActionInput)
+    * `callback` - Function that takes the subject and returns the subject or `{:error, reason}`
+    * `opts` - Options including `:prepend?` to add at beginning of hooks list
+
+  ## Examples
+
+      # Add validation before transaction starts
+      iex> changeset
+      ...> |> Ash.Subject.before_transaction(fn changeset ->
+      ...>   if valid_state?(changeset) do
+      ...>     changeset
+      ...>   else
+      ...>     {:error, "Invalid state for this operation"}
+      ...>   end
+      ...> end)
+
+      # Add logging for all subject types
+      iex> subject
+      ...> |> Ash.Subject.before_transaction(fn subject ->
+      ...>   Logger.info("Starting transaction for \#{inspect(subject.resource)}")
+      ...>   subject
+      ...> end)
+
+      # Prepend a hook to run first
+      iex> query
+      ...> |> Ash.Subject.before_transaction(check_permissions, prepend?: true)
+
+  ## See also
+
+  - `after_transaction/3` for hooks that run after the transaction completes
+  - `around_transaction/3` for hooks that wrap the entire transaction
+  - `before_action/3` for hooks that run before the action (inside transaction)
+  """
+  @spec before_transaction(
+          subject :: t(),
+          callback :: before_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def before_transaction(subject, callback, opts \\ [])
+
+  def before_transaction(%Ash.Changeset{} = subject, callback, opts) do
+    Ash.Changeset.before_transaction(subject, callback, opts)
+  end
+
+  def before_transaction(%Ash.Query{} = subject, callback, opts) do
+    Ash.Query.before_transaction(subject, callback, opts)
+  end
+
+  def before_transaction(subject, callback, opts) do
+    if opts[:prepend?] do
+      %{subject | before_transaction: [callback | subject.before_transaction]}
+    else
+      %{subject | before_transaction: subject.before_transaction ++ [callback]}
+    end
+  end
+
+  @doc """
+  Adds an after_transaction hook to the subject.
+
+  After transaction hooks are executed after the database transaction completes,
+  regardless of success or failure. They receive both the subject and the transaction
+  result, allowing for cleanup operations, logging, or result modification.
+
+  ## Parameters
+
+    * `subject` - The subject to add the hook to (Changeset, Query, or ActionInput)
+    * `callback` - Function that takes the subject and result, returns modified result
+    * `opts` - Options including `:prepend?` to add at beginning of hooks list
+
+  ## Examples
+
+      # Add cleanup after transaction
+      iex> changeset
+      ...> |> Ash.Subject.after_transaction(fn changeset, result ->
+      ...>   cleanup_temp_resources()
+      ...>   result
+      ...> end)
+
+      # Log transaction outcome
+      iex> query
+      ...> |> Ash.Subject.after_transaction(fn query, result ->
+      ...>   case result do
+      ...>     {:ok, _} -> Logger.info("Query succeeded")
+      ...>     {:error, reason} -> Logger.error("Query failed: \#{inspect(reason)}")
+      ...>   end
+      ...>   result
+      ...> end)
+
+      # Modify successful results
+      iex> action_input
+      ...> |> Ash.Subject.after_transaction(fn input, result ->
+      ...>   case result do
+      ...>     {:ok, data} -> {:ok, Map.put(data, :processed_at, DateTime.utc_now())}
+      ...>     error -> error
+      ...>   end
+      ...> end)
+
+  ## Important Notes
+
+  - These hooks run whether the transaction succeeds or fails
+  - They run outside the transaction, so database operations here are not rolled back
+  - The hook must return a result in the same format it received
+
+  ## See also
+
+  - `before_transaction/3` for hooks that run before the transaction starts
+  - `around_transaction/3` for hooks that wrap the entire transaction
+  - `after_action/3` for hooks that run after the action (inside transaction, success only)
+  """
+  @spec after_transaction(
+          subject :: t(),
+          callback :: after_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def after_transaction(subject, callback, opts \\ [])
+
+  def after_transaction(%Ash.Changeset{} = subject, callback, opts) do
+    Ash.Changeset.after_transaction(subject, callback, opts)
+  end
+
+  def after_transaction(%Ash.Query{} = subject, callback, opts) do
+    Ash.Query.after_transaction(subject, callback, opts)
+  end
+
+  def after_transaction(subject, callback, opts) do
+    if opts[:prepend?] do
+      %{subject | after_transaction: [callback | subject.after_transaction]}
+    else
+      %{subject | after_transaction: subject.after_transaction ++ [callback]}
+    end
+  end
+
+  @doc """
+  Adds an around_transaction hook to the subject.
+
+  Around transaction hooks wrap the entire transaction execution. They receive the subject
+  and a callback function that executes the transaction. This allows adding logic both
+  before and after the transaction while maintaining full control over its execution.
+
+  ## Parameters
+
+    * `subject` - The subject to add the hook to (Changeset, Query, or ActionInput)
+    * `callback` - Function that takes the subject and a callback, must call the callback
+    * `opts` - Options including `:prepend?` to add at beginning of hooks list
+
+  ## Examples
+
+      # Add timing measurements
+      iex> changeset
+      ...> |> Ash.Subject.around_transaction(fn changeset, callback ->
+      ...>   start_time = System.monotonic_time(:millisecond)
+      ...>   result = callback.(changeset)
+      ...>   duration = System.monotonic_time(:millisecond) - start_time
+      ...>   Logger.info("Transaction took \#{duration}ms")
+      ...>   result
+      ...> end)
+
+      # Add retry logic for transient failures
+      iex> query
+      ...> |> Ash.Subject.around_transaction(fn query, callback ->
+      ...>   case callback.(query) do
+      ...>     {:error, %{retryable?: true}} = error ->
+      ...>       Logger.warn("Retrying after error: \#{inspect(error)}")
+      ...>       :timer.sleep(100)
+      ...>       callback.(query)
+      ...>     result ->
+      ...>       result
+      ...>   end
+      ...> end)
+
+      # Wrap with custom error handling
+      iex> action_input
+      ...> |> Ash.Subject.around_transaction(fn input, callback ->
+      ...>   try do
+      ...>     callback.(input)
+      ...>   rescue
+      ...>     exception ->
+      ...>       Logger.error("Transaction failed: \#{Exception.message(exception)}")
+      ...>       {:error, Exception.message(exception)}
+      ...>   end
+      ...> end)
+
+  ## Warning
+
+  This is an advanced hook that controls transaction execution. You **must** call the
+  callback function provided to your hook, and the return value must match the structure
+  returned by the callback (typically `{:ok, result}` or `{:error, reason}`).
+
+  Failing to call the callback will prevent the transaction from executing at all.
+
+  ## See also
+
+  - `before_transaction/3` and `after_transaction/3` for simpler hooks
+  - `around_action/2` for wrapping just the action execution
+  """
+  @spec around_transaction(
+          subject :: t(),
+          callback :: around_transaction_fun(),
+          opts :: Keyword.t()
+        ) :: t()
+  def around_transaction(subject, callback, opts \\ [])
+
+  def around_transaction(%Ash.Changeset{} = subject, callback, opts) do
+    Ash.Changeset.around_transaction(subject, callback, opts)
+  end
+
+  def around_transaction(%Ash.Query{} = subject, callback, opts) do
+    Ash.Query.around_transaction(subject, callback, opts)
+  end
+
+  def around_transaction(subject, callback, opts) do
+    if opts[:prepend?] do
+      %{subject | around_transaction: [callback | subject.around_transaction]}
+    else
+      %{subject | around_transaction: subject.around_transaction ++ [callback]}
     end
   end
 end

--- a/test/subject_test.exs
+++ b/test/subject_test.exs
@@ -652,4 +652,155 @@ defmodule Ash.SubjectTest do
       end
     end
   end
+
+  describe "before_transaction/2-3 - All Subject Types" do
+    test "registers before_transaction callback" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback = fn subj -> subj end
+
+        result = Ash.Subject.before_transaction(subject, callback)
+
+        assert is_struct(result, subject_type)
+        assert length(result.before_transaction) == 1
+        assert [^callback] = result.before_transaction
+      end
+    end
+
+    test "handles prepend option" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback1 = fn subj -> subj end
+        callback2 = fn subj -> subj end
+
+        result =
+          subject
+          |> Ash.Subject.before_transaction(callback1)
+          |> Ash.Subject.before_transaction(callback2, prepend?: true)
+
+        assert is_struct(result, subject_type)
+        assert length(result.before_transaction) == 2
+        assert [^callback2, ^callback1] = result.before_transaction
+      end
+    end
+
+    test "appends callbacks by default" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback1 = fn subj -> subj end
+        callback2 = fn subj -> subj end
+        callback3 = fn subj -> subj end
+
+        result =
+          subject
+          |> Ash.Subject.before_transaction(callback1)
+          |> Ash.Subject.before_transaction(callback2)
+          |> Ash.Subject.before_transaction(callback3)
+
+        assert is_struct(result, subject_type)
+        assert length(result.before_transaction) == 3
+        assert [^callback1, ^callback2, ^callback3] = result.before_transaction
+      end
+    end
+  end
+
+  describe "after_transaction/2-3 - All Subject Types" do
+    test "registers after_transaction callback" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback = fn _subj, result -> result end
+
+        result = Ash.Subject.after_transaction(subject, callback)
+
+        assert is_struct(result, subject_type)
+        assert length(result.after_transaction) == 1
+        assert [^callback] = result.after_transaction
+      end
+    end
+
+    test "handles prepend option" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback1 = fn _subj, result -> result end
+        callback2 = fn _subj, result -> result end
+
+        result =
+          subject
+          |> Ash.Subject.after_transaction(callback1)
+          |> Ash.Subject.after_transaction(callback2, prepend?: true)
+
+        assert is_struct(result, subject_type)
+        assert length(result.after_transaction) == 2
+        assert [^callback2, ^callback1] = result.after_transaction
+      end
+    end
+
+    test "appends callbacks by default" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback1 = fn _subj, result -> result end
+        callback2 = fn _subj, result -> result end
+        callback3 = fn _subj, result -> result end
+
+        result =
+          subject
+          |> Ash.Subject.after_transaction(callback1)
+          |> Ash.Subject.after_transaction(callback2)
+          |> Ash.Subject.after_transaction(callback3)
+
+        assert length(result.after_transaction) == 3
+        assert [^callback1, ^callback2, ^callback3] = result.after_transaction
+      end
+    end
+  end
+
+  describe "around_transaction/2-3 - All Subject Types" do
+    test "registers around_transaction callback" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback = fn subj, func -> func.(subj) end
+
+        result = Ash.Subject.around_transaction(subject, callback)
+
+        assert is_struct(result, subject_type)
+        assert length(result.around_transaction) == 1
+        assert [^callback] = result.around_transaction
+      end
+    end
+
+    test "handles prepend option" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback1 = fn subj, func -> func.(subj) end
+        callback2 = fn subj, func -> func.(subj) end
+
+        result =
+          subject
+          |> Ash.Subject.around_transaction(callback1)
+          |> Ash.Subject.around_transaction(callback2, prepend?: true)
+
+        assert is_struct(result, subject_type)
+        assert length(result.around_transaction) == 2
+        assert [^callback2, ^callback1] = result.around_transaction
+      end
+    end
+
+    test "appends callbacks by default" do
+      for subject_type <- @subject_types do
+        subject = new_subject(subject_type)
+        callback1 = fn subj, func -> func.(subj) end
+        callback2 = fn subj, func -> func.(subj) end
+        callback3 = fn subj, func -> func.(subj) end
+
+        result =
+          subject
+          |> Ash.Subject.around_transaction(callback1)
+          |> Ash.Subject.around_transaction(callback2)
+          |> Ash.Subject.around_transaction(callback3)
+
+        assert length(result.around_transaction) == 3
+        assert [^callback1, ^callback2, ^callback3] = result.around_transaction
+      end
+    end
+  end
 end

--- a/test/subject_test.exs
+++ b/test/subject_test.exs
@@ -3,21 +3,33 @@ defmodule Ash.SubjectTest do
 
   defmodule Post do
     use Ash.Resource,
-      domain: Ash.Test.Domain
+      domain: Ash.Test.Domain,
+      primary_read_warning?: false
 
     actions do
-      default_accept :*
-      defaults [:read, :destroy, create: :*, update: :*]
+      defaults [:destroy, :update]
+      default_accept [:title, :body, :published, :tenant_id]
+
+      read :read do
+        primary? true
+
+        argument :name, :string, public?: false
+      end
+
+      create :create do
+        primary? true
+        argument :name, :string, public?: false
+      end
 
       action :custom_action, :struct do
-        argument :name, :string, allow_nil?: false
+        argument :name, :string, public?: false
         run fn input, _ -> {:ok, input} end
       end
     end
 
     attributes do
       uuid_primary_key :id
-      attribute :title, :string, allow_nil?: false
+      attribute :title, :string
       attribute :body, :string
       attribute :published, :boolean, default: false
       attribute :tenant_id, :string
@@ -43,13 +55,9 @@ defmodule Ash.SubjectTest do
 
   # Helper function to create subjects consistently for each type
   defp new_subject(subject_type) do
-    subject = apply(subject_type, :new, [Post])
-
-    if subject_type == Ash.ActionInput do
-      # ActionInput needs an action to properly handle arguments
-      Ash.ActionInput.for_action(subject, :custom_action, %{name: "test"})
-    else
-      subject
+    case subject_type do
+      Ash.ActionInput -> Ash.ActionInput.for_action(Post, :custom_action, %{})
+      _ -> apply(subject_type, :new, [Post])
     end
   end
 
@@ -181,15 +189,9 @@ defmodule Ash.SubjectTest do
         subject = new_subject(subject_type)
 
         # Set an argument that works for all types
-        result =
-          case subject_type do
-            Ash.ActionInput -> Ash.Subject.set_argument(subject, :name, "value")
-            _ -> Ash.Subject.set_argument(subject, :custom_arg, "value")
-          end
+        result = %{subject | arguments: %{age: 42}}
 
-        expected_arg = if subject_type == Ash.ActionInput, do: :name, else: :custom_arg
-        assert Ash.Subject.get_argument(result, expected_arg) == "value"
-        assert Ash.Subject.get_argument(result, :non_existent) == nil
+        assert Ash.Subject.get_argument(result, :age) == 42
         assert is_struct(result, subject_type)
       end
     end
@@ -199,15 +201,9 @@ defmodule Ash.SubjectTest do
         subject = new_subject(subject_type)
 
         # Set an argument that works for all types
-        result =
-          case subject_type do
-            Ash.ActionInput -> Ash.Subject.set_argument(subject, :name, "value")
-            _ -> Ash.Subject.set_argument(subject, :test_arg, "value")
-          end
+        result = %{subject | arguments: %{"age" => 42}}
 
-        # Should find argument by string key even though it was set with atom
-        expected_arg_str = if subject_type == Ash.ActionInput, do: "name", else: "test_arg"
-        assert Ash.Subject.get_argument(result, expected_arg_str) == "value"
+        assert Ash.Subject.get_argument(result, "age") == 42
         assert is_struct(result, subject_type)
       end
     end
@@ -218,7 +214,6 @@ defmodule Ash.SubjectTest do
 
         assert Ash.Subject.get_argument(subject, :missing_arg, "default_value") == "default_value"
         assert Ash.Subject.get_argument(subject, "missing_arg", :default_atom) == :default_atom
-        assert Ash.Subject.get_argument(subject, :missing_arg, 42) == 42
         assert is_struct(subject, subject_type)
       end
     end
@@ -228,20 +223,9 @@ defmodule Ash.SubjectTest do
         subject = new_subject(subject_type)
 
         # Set an argument that works for all types
-        result =
-          case subject_type do
-            Ash.ActionInput -> Ash.Subject.set_argument(subject, :name, "actual_value")
-            _ -> Ash.Subject.set_argument(subject, :existing_arg, "actual_value")
-          end
+        result = %{subject | arguments: %{name: "actual_value"}}
 
-        expected_arg = if subject_type == Ash.ActionInput, do: :name, else: :existing_arg
-        expected_arg_str = if subject_type == Ash.ActionInput, do: "name", else: "existing_arg"
-
-        assert Ash.Subject.get_argument(result, expected_arg, "default_value") == "actual_value"
-
-        assert Ash.Subject.get_argument(result, expected_arg_str, "default_value") ==
-                 "actual_value"
-
+        assert Ash.Subject.get_argument(result, :name, "default_value") == "actual_value"
         assert is_struct(result, subject_type)
       end
     end
@@ -253,14 +237,10 @@ defmodule Ash.SubjectTest do
         subject = new_subject(subject_type)
 
         # Set an argument that works for all types
-        result =
-          case subject_type do
-            Ash.ActionInput -> Ash.Subject.set_argument(subject, :name, "value")
-            _ -> Ash.Subject.set_argument(subject, :custom_arg, "value")
-          end
+        result = %{subject | arguments: %{"age" => 42, name: "value"}}
 
-        expected_arg = if subject_type == Ash.ActionInput, do: :name, else: :custom_arg
-        assert {:ok, "value"} = Ash.Subject.fetch_argument(result, expected_arg)
+        assert {:ok, "value"} = Ash.Subject.fetch_argument(result, :name)
+        assert {:ok, 42} = Ash.Subject.fetch_argument(result, "age")
         assert :error = Ash.Subject.fetch_argument(result, :missing)
         assert is_struct(result, subject_type)
       end
@@ -271,14 +251,9 @@ defmodule Ash.SubjectTest do
         subject = new_subject(subject_type)
 
         # Set an argument that works for all types
-        result =
-          case subject_type do
-            Ash.ActionInput -> Ash.Subject.set_argument(subject, :name, "value")
-            _ -> Ash.Subject.set_argument(subject, :test_arg, "value")
-          end
+        result = %{subject | arguments: %{"name" => "value"}}
 
-        expected_arg_str = if subject_type == Ash.ActionInput, do: "name", else: "test_arg"
-        assert {:ok, "value"} = Ash.Subject.fetch_argument(result, expected_arg_str)
+        assert {:ok, "value"} = Ash.Subject.fetch_argument(result, :name)
         assert is_struct(result, subject_type)
       end
     end
@@ -329,61 +304,37 @@ defmodule Ash.SubjectTest do
 
   describe "get_argument_or_attribute/2,3 - All Subject Types" do
     test "gets argument when exists for all types" do
-      # Test Changeset and Query
-      for subject_type <- [Ash.Changeset, Ash.Query] do
-        subject =
-          new_subject(subject_type)
-          |> Ash.Subject.set_argument(:custom_arg, "arg_value")
+      for subject_type <- [Ash.Changeset, Ash.Query, Ash.ActionInput] do
+        subject = new_subject(subject_type)
+
+        subject = %{subject | arguments: %{custom_arg: "arg_value"}}
 
         assert Ash.Subject.get_argument_or_attribute(subject, :custom_arg) == "arg_value"
         assert is_struct(subject, subject_type)
       end
-
-      # Test ActionInput
-      input = Ash.ActionInput.for_action(Post, :custom_action, %{name: "arg_value"})
-      assert Ash.Subject.get_argument_or_attribute(input, :name) == "arg_value"
-      assert is_struct(input, Ash.ActionInput)
     end
 
     test "gets attribute for Changeset, falls back to argument for others" do
       # For Changeset - tests both argument priority and attribute fallback
-      changeset =
-        Post
-        |> Ash.Changeset.new()
-        |> Ash.Changeset.set_argument(:custom_arg, "arg_value")
-        |> Ash.Changeset.change_attribute(:title, "Test Title")
+      changeset = Ash.Changeset.new(%Post{title: "Existing Title"})
 
-      # Should get argument when both exist
-      assert Ash.Subject.get_argument_or_attribute(changeset, :custom_arg) == "arg_value"
-      # Should get attribute when no argument exists
-      assert Ash.Subject.get_argument_or_attribute(changeset, :title) == "Test Title"
+      assert Ash.Subject.get_argument_or_attribute(changeset, :title) == "Existing Title"
 
-      # For Query - only arguments
-      query =
-        Post
-        |> Ash.Query.new()
-        |> Ash.Query.set_argument(:test_arg, "test_value")
+      changeset = %{changeset | arguments: %{title: "New Title"}}
 
-      assert Ash.Subject.get_argument_or_attribute(query, :test_arg) == "test_value"
-      assert is_struct(query, Ash.Query)
+      assert Ash.Subject.get_argument_or_attribute(changeset, :title) == "New Title"
 
-      # For ActionInput - only arguments
-      input = Ash.ActionInput.for_action(Post, :custom_action, %{name: "test_value"})
-      assert Ash.Subject.get_argument_or_attribute(input, :name) == "test_value"
-      assert is_struct(input, Ash.ActionInput)
+      for subject_type <- [Ash.Query, Ash.ActionInput] do
+        subject = new_subject(subject_type)
+        subject = %{subject | arguments: %{name: "New Title"}}
+        assert Ash.Subject.get_argument_or_attribute(subject, :name) == "New Title"
+        assert is_struct(subject, subject_type)
+      end
     end
 
     test "returns default when not found" do
       for subject_type <- @subject_types do
-        subject =
-          case subject_type do
-            Ash.Changeset -> Ash.Changeset.new(Post)
-            Ash.Query -> Ash.Query.new(Post)
-            Ash.ActionInput -> Ash.ActionInput.new(Post)
-          end
-
-        assert Ash.Subject.get_argument_or_attribute(subject, :missing, "default_value") ==
-                 "default_value"
+        subject = new_subject(subject_type)
 
         assert Ash.Subject.get_argument_or_attribute(subject, :missing, 42) == 42
       end
@@ -391,34 +342,12 @@ defmodule Ash.SubjectTest do
 
     test "returns actual value when found, ignoring default" do
       for subject_type <- @subject_types do
-        subject =
-          case subject_type do
-            Ash.Changeset ->
-              Post
-              |> Ash.Changeset.new()
-              |> Ash.Changeset.set_argument(:arg_name, "arg_value")
-              |> Ash.Changeset.change_attribute(:title, "Title Value")
+        subject = new_subject(subject_type)
 
-            Ash.Query ->
-              Post
-              |> Ash.Query.new()
-              |> Ash.Query.set_argument(:arg_name, "arg_value")
+        subject = %{subject | arguments: %{name: "arg_value"}}
 
-            Ash.ActionInput ->
-              Ash.ActionInput.for_action(Post, :custom_action, %{name: "arg_value"})
-          end
-
-        # Should get argument value and ignore default
-        expected_arg = if subject_type == Ash.ActionInput, do: :name, else: :arg_name
-
-        assert Ash.Subject.get_argument_or_attribute(subject, expected_arg, "default") ==
+        assert Ash.Subject.get_argument_or_attribute(subject, :name, "default") ==
                  "arg_value"
-
-        # For Changeset, also test attribute value
-        if subject_type == Ash.Changeset do
-          assert Ash.Subject.get_argument_or_attribute(subject, :title, "default") ==
-                   "Title Value"
-        end
 
         assert is_struct(subject, subject_type)
       end
@@ -430,15 +359,9 @@ defmodule Ash.SubjectTest do
       for subject_type <- @subject_types do
         subject = new_subject(subject_type)
 
-        # Set an argument that works for all types
-        result =
-          case subject_type do
-            Ash.ActionInput -> Ash.Subject.set_argument(subject, :name, "value1")
-            _ -> Ash.Subject.set_argument(subject, :arg1, "value1")
-          end
+        result = %{subject | arguments: %{name: "value1"}}
 
-        expected_arg = if subject_type == Ash.ActionInput, do: :name, else: :arg1
-        assert Ash.Subject.get_argument(result, expected_arg) == "value1"
+        assert Ash.Subject.get_argument(result, :name) == "value1"
         assert is_struct(result, subject_type)
       end
     end
@@ -449,35 +372,10 @@ defmodule Ash.SubjectTest do
       for subject_type <- @subject_types do
         subject = new_subject(subject_type)
 
-        # Use arguments that work for each type
-        args =
-          case subject_type do
-            # ActionInput can only set defined action arguments
-            Ash.ActionInput -> %{name: "value1"}
-            _ -> %{arg1: "value1", arg2: "value2", arg3: "value3"}
-          end
-
-        result = Ash.Subject.set_arguments(subject, args)
-
-        if subject_type == Ash.ActionInput do
-          assert Ash.Subject.get_argument(result, :name) == "value1"
-        else
-          assert Ash.Subject.get_argument(result, :arg1) == "value1"
-          assert Ash.Subject.get_argument(result, :arg2) == "value2"
-          assert Ash.Subject.get_argument(result, :arg3) == "value3"
-        end
+        result = Ash.Subject.set_arguments(subject, %{name: "value1"})
 
         assert is_struct(result, subject_type)
-      end
-    end
-
-    test "handles empty map" do
-      for subject_type <- @subject_types do
-        subject = new_subject(subject_type)
-
-        result = Ash.Subject.set_arguments(subject, %{})
-
-        assert is_struct(result, subject_type)
+        assert result.arguments.name == "value1"
       end
     end
   end
@@ -487,31 +385,12 @@ defmodule Ash.SubjectTest do
       for subject_type <- @subject_types do
         subject = new_subject(subject_type)
 
-        # Set arguments that work for each type first
-        with_args =
-          case subject_type do
-            Ash.ActionInput ->
-              # ActionInput starts with name="test", add more if possible
-              Ash.Subject.set_argument(subject, :name, "v1")
+        subject = %{subject | arguments: %{name: "value1"}}
 
-            _ ->
-              Ash.Subject.set_arguments(subject, %{arg1: "v1", arg2: "v2", arg3: "v3"})
-          end
-
-        result =
-          if subject_type == Ash.ActionInput do
-            # For ActionInput, we can only delete the name argument
-            delete_result = Ash.Subject.delete_argument(with_args, :name)
-            refute Map.has_key?(delete_result.arguments, :name)
-            delete_result
-          else
-            delete_result = Ash.Subject.delete_argument(with_args, :arg1)
-            refute Map.has_key?(delete_result.arguments, :arg1)
-            assert Map.has_key?(delete_result.arguments, :arg2)
-            delete_result
-          end
+        result = Ash.Subject.delete_argument(subject, :name)
 
         assert is_struct(result, subject_type)
+        refute Map.has_key?(result.arguments, :name)
       end
     end
 
@@ -519,69 +398,13 @@ defmodule Ash.SubjectTest do
       for subject_type <- @subject_types do
         subject = new_subject(subject_type)
 
-        # Set arguments that work for each type first
-        with_args =
-          case subject_type do
-            Ash.ActionInput ->
-              # ActionInput only has name argument defined, so we can only test deleting that
-              subject
+        subject = %{subject | arguments: %{name: "value1", age: 42}}
 
-            _ ->
-              Ash.Subject.set_arguments(subject, %{arg1: "v1", arg2: "v2", arg3: "v3"})
-          end
-
-        result =
-          if subject_type == Ash.ActionInput do
-            # For ActionInput, delete the name argument
-            delete_result = Ash.Subject.delete_argument(with_args, [:name])
-            refute Map.has_key?(delete_result.arguments, :name)
-            delete_result
-          else
-            delete_result = Ash.Subject.delete_argument(with_args, [:arg1, :arg2])
-            refute Map.has_key?(delete_result.arguments, :arg1)
-            refute Map.has_key?(delete_result.arguments, :arg2)
-            assert Map.has_key?(delete_result.arguments, :arg3)
-            delete_result
-          end
+        result = Ash.Subject.delete_argument(subject, [:name, :age])
 
         assert is_struct(result, subject_type)
-      end
-    end
-
-    test "deletes non-existing argument gracefully" do
-      for subject_type <- @subject_types do
-        subject = new_subject(subject_type)
-
-        result = Ash.Subject.delete_argument(subject, :non_existent)
-
-        assert is_struct(result, subject_type)
-      end
-    end
-  end
-
-  describe "set_private_argument/3 - Changeset & ActionInput Only" do
-    @supported_types [Ash.Changeset, Ash.ActionInput]
-
-    test "sets private argument for supported types" do
-      for subject_type <- @supported_types do
-        subject =
-          case subject_type do
-            Ash.Changeset -> Ash.Changeset.for_create(Post, :create, %{title: "Test"})
-            Ash.ActionInput -> Ash.ActionInput.for_action(Post, :custom_action, %{name: "test"})
-          end
-
-        result = Ash.Subject.set_private_argument(subject, :private_arg, "secret")
-
-        # Private arguments are stored internally - just verify no error
-        assert is_struct(result, subject_type)
-      end
-    end
-
-    test "raises FunctionClauseError for Query (unsupported)" do
-      query = Ash.Query.new(Post)
-
-      assert_raise FunctionClauseError, fn ->
-        Ash.Subject.set_private_argument(query, :private_arg, "secret")
+        refute Map.has_key?(result.arguments, :name)
+        refute Map.has_key?(result.arguments, :age)
       end
     end
   end


### PR DESCRIPTION
## Changes
- Add support for `prepend?` option to Changeset, ActionInput, and Query hooks.  Except for `Ash.Query.after_action` which uses `@read_action_after_action_hooks_in_order?`
- Add transaction hooks to `Ash.Subject` since Changeset, ActionInput, and Query now all support them.
- Update all functions to delegate to the subject type module function
- Align type specs with subject type module types
- Update `get_argument/3` to only return the default value when `:error` is returned from `fetch_argument/2`
- Add `Ash.ActionInput.delete_argument/3`
- Add `Ash.Changeset.fetch_attribute/2`
- Add `Ash.Changeset.fetch_data/2`
- Add `Ash.Changeset.fetch_argument_or_attribute/2`
- Update `Ash.Query.fetch_argument/2` to first call `Ash.Query.new(query)` like other functions to ensure the subject is a query.
- Remove `set_private_argument/3` tests because there is a bug where `new/1` doesn't add the `arguments`, but `set_argument/3` is using dot syntax to access the arguments.  So, there's no way to use `set_private_argument/3` without getting the warning message.  I'll submit another PR to fix this"

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
