### PR TITLE
fix: allow Ash @global_opts authorize? to accept boolean or nil

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -58,7 +58,7 @@ defmodule Ash do
       doc: "The action to use, either an Action struct or the name of the action"
     ],
     authorize?: [
-      type: :boolean,
+      type: {:or, [:boolean, {:literal, nil}]},
       doc:
         "If an actor option is provided (even if it is `nil`), authorization happens automatically. If not, this flag can be used to authorize with no user."
     ],


### PR DESCRIPTION
- Revert 7e34bbd change that updated Ash @global_opts `authorize?` to only accept boolean.

fixes #2224

All existing tests are passing

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
