### PR TITLE
Fix Application ER Mermaid Diagram

### DIFF
--- a/test/domain/diagram_test.exs
+++ b/test/domain/diagram_test.exs
@@ -5,18 +5,18 @@ defmodule Ash.Test.Domain.Info.DiagramTest do
   test "generate a mermaid entity relationship diagram from a domain" do
     assert Ash.Domain.Info.Diagram.mermaid_er_diagram(Ash.Test.Flow.Domain) == """
            erDiagram
-               User {
+               "User" {
                    UUID id
                    String first_name
                    String last_name
                    String email
                }
-               Org {
+               "Org" {
                    UUID id
                    String name
                }
 
-               Org ||--|| User : ""
+               "Org" ||--|| "User" : ""
            """
   end
 
@@ -57,7 +57,7 @@ defmodule Ash.Test.Domain.Info.DiagramTest do
     assert Ash.Domain.Info.Diagram.mermaid_er_diagram(Ash.Test.Flow.Domain, show_private?: true) ==
              """
              erDiagram
-                 User {
+                 "User" {
                      UUID id
                      String first_name
                      String last_name
@@ -65,12 +65,31 @@ defmodule Ash.Test.Domain.Info.DiagramTest do
                      Boolean approved
                      UUID org_id
                  }
-                 Org {
+                 "Org" {
                      UUID id
                      String name
                  }
 
-                 Org ||--|| User : ""
+                 "Org" ||--|| "User" : ""
+             """
+  end
+
+  test "include long names in mermaid entity relationship diagram if specified" do
+    assert Ash.Domain.Info.Diagram.mermaid_er_diagram([Ash.Test.Flow.Domain], name: :full) ==
+             """
+             erDiagram
+                 "Ash.Test.Flow.User" {
+                     UUID id
+                     String first_name
+                     String last_name
+                     String email
+                 }
+                 "Ash.Test.Flow.Org" {
+                     UUID id
+                     String name
+                 }
+
+                 "Ash.Test.Flow.Org" ||--|| "Ash.Test.Flow.User" : ""
              """
   end
 

--- a/test/domain/livebook_test.exs
+++ b/test/domain/livebook_test.exs
@@ -44,18 +44,18 @@ defmodule Ash.Test.Domain.Info.LivebookTest do
 
              ```mermaid
              erDiagram
-                 User {
+                 "User" {
                      UUID id
                      String first_name
                      String last_name
                      String email
                  }
-                 Org {
+                 "Org" {
                      UUID id
                      String name
                  }
 
-                 Org ||--|| User : ""
+                 "Org" ||--|| "User" : ""
              ```
 
              ### Resources


### PR DESCRIPTION
# Fixes

`Ash.Info.mermaid_overview/2` type `:entity_relationship` produced a parse error:

```
Uncaught (in promise) Error: Parse error on line 2:
erDiagram    AshHq.Accounts    AshHq.
------------------^
Expecting 'EOF', 'SPACE', 'NEWLINE', 'COLON', 'STYLE_SEPARATOR', 'BLOCK_START', 'SQS', 'SQE', 'title', 'acc_title', 'acc_descr', 'acc_descr_multiline_value', 'direction_tb', 'direction_bt', 'direction_rl', 'direction_lr', 'CLASSDEF', 'UNICODE_TEXT', 'CLASS', 'STYLE', 'ENTITY_NAME', 'ZERO_OR_ONE', 'ZERO_OR_MORE', 'ONE_OR_MORE', 'ONLY_ONE', 'MD_PARENT', got '.'
    at rA.parseError (app-b61a0ac225a159bb5806be5f6e266c11.js:644:9248)
    at rA.parse (app-b61a0ac225a159bb5806be5f6e266c11.js:646:179)
    at Diagram.fromText (app-b61a0ac225a159bb5806be5f6e266c11.js:2740:303)
    at Object.render (app-b61a0ac225a159bb5806be5f6e266c11.js:2747:1281)
    at app-b61a0ac225a159bb5806be5f6e266c11.js:2747:5852
    at new Promise (<anonymous>)
    at performCall (app-b61a0ac225a159bb5806be5f6e266c11.js:2747:5829)
    at executeQueue (app-b61a0ac225a159bb5806be5f6e266c11.js:2747:5462)
    at app-b61a0ac225a159bb5806be5f6e266c11.js:2747:6002
    at new Promise (<anonymous>)
```

# Changes

Before:

```
erDiagram
    Ash.Test.Flow.Domain
    Ash.Test.Flow.User {
        Domain: Ash.Test.Flow.Domain
        Source: test/support/flow/user.ex

        Ash.Type.UUID id
        Ash.Type.String first_name
        Ash.Type.String last_name
        Ash.Type.String email
    }
    Ash.Test.Flow.Org {
        Domain: Ash.Test.Flow.Domain
        Source: test/support/flow/org.ex

        Ash.Type.UUID id
        Ash.Type.String name
    }

    Ash.Test.Flow.Org ||--|| Ash.Test.Flow.User : ""
```

After:

```
erDiagram
    "Ash.Test.Flow.User" {
        UUID id
        String first_name
        String last_name
        String email
    }
    "Ash.Test.Flow.Org" {
        UUID id
        String name
    }

    "Ash.Test.Flow.Org" ||--|| "Ash.Test.Flow.User" : ""
```

* Names need to be escaped if they contain special characters (`"`)
* The syntax `Domain: ..` inside a resource is invalid. I removed it. **← Better Idea?**
* The syntax `Source: ..` inside a resource is invalid. I removed it. **← Better Idea?**
* The domain was displayed as a box without any connections to the resources. That didn't make sense. I removed it. **← Better Idea?**
* Type Names are always shortened even if `name: :full` is provided. The field can't be escaped in mermaid and therefore types can't contain any dots.
* Refactored code so that a single domain and multiple domains use the same implementation.
* Added tests.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
