### PR TITLE
Fix Ash.TypedStruct & Ash.Type.Struct inconsistencies.

### DIFF
--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -459,7 +459,7 @@ defmodule Ash.Type.NewType do
                   {key, field}, :ok ->
                     field_keys = field |> List.wrap() |> Keyword.keys()
 
-                    case field_keys -- [:type, :constraints, :allow_nil?] do
+                    case field_keys -- [:type, :constraints, :allow_nil?, :description] do
                       [] ->
                         {:cont, validate_constraints(field[:type], field[:constraints])}
 

--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -25,7 +25,7 @@ defmodule Ash.Type.Struct do
               default: true
             ],
             description: [
-              type: :string
+              type: {:or, [:string, nil]}
             ],
             constraints: [
               type: :keyword_list,
@@ -83,7 +83,7 @@ defmodule Ash.Type.Struct do
   Example:
 
       defmodule MyStruct do
-        use Ash.TypedStruct 
+        use Ash.TypedStruct
         typed_struct do
           field :name, :string, allow_nil?: false
           field :age, :integer, constraints: [min: 0]

--- a/lib/ash/typed_struct.ex
+++ b/lib/ash/typed_struct.ex
@@ -10,7 +10,7 @@ defmodule Ash.TypedStruct do
   ## Example
 
       defmodule MyApp.UserProfile do
-        use Ash.TypedStruct 
+        use Ash.TypedStruct
 
         typed_struct do
           field :username, :string, allow_nil?: false
@@ -23,14 +23,14 @@ defmodule Ash.TypedStruct do
 
       # Creating instances
       {:ok, profile} = MyApp.UserProfile.new(username: "john", email: "john@example.com")
-      
+
       # Using new! for raising on errors
       profile = MyApp.UserProfile.new!(username: "jane", email: "jane@example.com", age: 25)
 
       # Can be used as an Ash type
       defmodule MyApp.User do
         use Ash.Resource
-        
+
         attributes do
           attribute :profile, MyApp.UserProfile
         end
@@ -98,7 +98,8 @@ defmodule Ash.TypedStruct do
           doc: "the default value for the field"
         ],
         description: [
-          type: :any,
+          type: {:or, [:string, nil]},
+          default: nil,
           doc: "a description for the field"
         ],
         constraints: [
@@ -112,7 +113,7 @@ defmodule Ash.TypedStruct do
           type: :boolean,
           default: true,
           doc: """
-          Whether or not the field can be set to nil. 
+          Whether or not the field can be set to nil.
           """
         ]
       ]

--- a/test/typed_struct_test.exs
+++ b/test/typed_struct_test.exs
@@ -13,7 +13,11 @@ defmodule Ash.TypedStructTest do
     use Ash.TypedStruct
 
     typed_struct do
-      field(:id, Ash.Type.UUID, allow_nil?: false, description: "The unique identifier for the user")
+      field(:id, Ash.Type.UUID,
+        allow_nil?: false,
+        description: "The unique identifier for the user"
+      )
+
       field(:name, :string, allow_nil?: false, description: "The name of the user")
       field(:email, :string, constraints: [match: ~r/@/])
       field(:age, :integer, constraints: [min: 0, max: 150])

--- a/test/typed_struct_test.exs
+++ b/test/typed_struct_test.exs
@@ -13,8 +13,8 @@ defmodule Ash.TypedStructTest do
     use Ash.TypedStruct
 
     typed_struct do
-      field(:id, Ash.Type.UUID, allow_nil?: false)
-      field(:name, :string, allow_nil?: false)
+      field(:id, Ash.Type.UUID, allow_nil?: false, description: "The unique identifier for the user")
+      field(:name, :string, allow_nil?: false, description: "The name of the user")
       field(:email, :string, constraints: [match: ~r/@/])
       field(:age, :integer, constraints: [min: 0, max: 150])
       field(:active, :boolean, default: true)


### PR DESCRIPTION
Update Ash.Type.NewType validation, set description to be either :string or nil for both Ash.TypedStruct & Ash.Type.Struct.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
