### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The Ash ecosystem consists of numerous packages, all of which have their own doc
 
 ### AI
 
-- [AshAI](https://hexdocs.pm/ash_ai) | Structured Outpus, MCP, Vectorization and more
+- [AshAI](https://hexdocs.pm/ash_ai) | Structured Outputs, MCP, Vectorization and more
 
 ### Web
 

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -2542,7 +2542,7 @@ identity :full_name, [:first_name, :last_name]
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`where`](#identities-identity-where){: #identities-identity-where } | `any` |  | A filter that expresses only matching records are unique on the provided keys. Ignored on embedded resources. |
-| [`nils_distinct?`](#identities-identity-nils_distinct?){: #identities-identity-nils_distinct? } | `boolean` | `true` | Whether or not `nil` values are considered always distinct from eachother. `nil` values won't conflict with eachother unless you set this option to `false`. |
+| [`nils_distinct?`](#identities-identity-nils_distinct?){: #identities-identity-nils_distinct? } | `boolean` | `true` | Whether or not `nil` values are considered always distinct from each other. `nil` values won't conflict with each other unless you set this option to `false`. |
 | [`eager_check?`](#identities-identity-eager_check?){: #identities-identity-eager_check? } | `boolean` | `false` | Whether or not this identity is validated to be unique at validation time. |
 | [`eager_check_with`](#identities-identity-eager_check_with){: #identities-identity-eager_check_with } | `module` |  | Validates that the unique identity provided is unique at validation time, outside of any transactions, using the domain module provided. Will default to resource's domain. |
 | [`pre_check?`](#identities-identity-pre_check?){: #identities-identity-pre_check? } | `boolean` | `false` | Whether or not this identity is validated to be unique in a before_action hook. |

--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -39,7 +39,7 @@ The following operators are available and they behave the same as they do in Eli
 - `<>`
 - `and` - Boolean and operator
 - `or` - Boolean or operator
-- `||` - Elixir-ish or operator, if left is not `nil` or `false`, then left. Othewise right.
+- `||` - Elixir-ish or operator, if left is not `nil` or `false`, then left. Otherwise right.
 - `&&` - Elixir-ish and operator, if left is not `nil` or `false`, then right. Otherwise left.
 - `is_nil` | Only works as an operator in maps/keyword list syntax. i.e `[x: [is_nil: true]]`
 

--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -1726,7 +1726,7 @@ defmodule Ash.Actions.ManagedRelationships do
             do_matches?(current_value, input, field, attr.type)
           else
             # We know that it will be the same as all other records in this relationship
-            # (because thats how has_one and has_many relationships work), so we
+            # (because that's how has_one and has_many relationships work), so we
             # can assume its the same as the current value
             true
           end

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1495,7 +1495,7 @@ defmodule Ash.DataLayer.Ets do
     log_bulk_create(resource, stream, options)
 
     if options[:upsert?] do
-      # This is not optimized, but thats okay for now
+      # This is not optimized, but that's okay for now
       stream
       |> Enum.reduce_while({:ok, []}, fn changeset, {:ok, results} ->
         changeset =

--- a/lib/ash/domain/domain.ex
+++ b/lib/ash/domain/domain.ex
@@ -96,7 +96,7 @@ defmodule Ash.Domain do
   @impl Spark.Dsl
   def handle_before_compile(_) do
     quote do
-      if Keyword.get(@opts, :backards_compatible_interface?, false) do
+      if Keyword.get(@opts, :backwards_compatible_interface?, false) do
         use Ash.Domain.Interface
       end
 

--- a/lib/ash/filter/runtime.ex
+++ b/lib/ash/filter/runtime.ex
@@ -1,7 +1,7 @@
 defmodule Ash.Filter.Runtime do
   @moduledoc """
   Tools to checks a record to see if it matches a filter statement, or to
-  evalute expressions against records.
+  evaluate expressions against records.
   """
 
   alias Ash.Query.{BooleanExpression, Not, Ref}

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -193,7 +193,7 @@ defmodule Ash.Generator do
   * `:context` - Passed through to the changeset
   * `:after_action` - A one argument function that takes the result and returns
     a new result to run after the record is created.
-  * `:private_arguments` - A map of private arguments, whos values can also be generators. Can also
+  * `:private_arguments` - A map of private arguments, whose values can also be generators. Can also
     be a function when using the `:uses` option.
 
   ## The `uses` option

--- a/lib/ash/query/function/get_path.ex
+++ b/lib/ash/query/function/get_path.ex
@@ -11,7 +11,7 @@ defmodule Ash.Query.Function.GetPath do
   If a string key is provided, that is the only thing that is checked. If the value will or may be a struct, be sure to use atoms.
 
   The data layer may handle this differently, for example, AshPostgres only checks
-  strings at the data layer (because thats all it can be in the database anyway).
+  strings at the data layer (because that's all it can be in the database anyway).
 
   Available in query expressions using bracket syntax, e.g `foo[:bar][:baz]`.
   """

--- a/lib/ash/resource/identity.ex
+++ b/lib/ash/resource/identity.ex
@@ -43,7 +43,7 @@ defmodule Ash.Resource.Identity do
     nils_distinct?: [
       type: :boolean,
       doc:
-        "Whether or not `nil` values are considered always distinct from eachother. `nil` values won't conflict with eachother unless you set this option to `false`.",
+        "Whether or not `nil` values are considered always distinct from each other. `nil` values won't conflict with each other unless you set this option to `false`.",
       default: true
     ],
     eager_check?: [

--- a/lib/ash/scope.ex
+++ b/lib/ash/scope.ex
@@ -92,7 +92,7 @@ defmodule Ash.Scope do
       MyApp.Domain.do_something_else(..., scope: context)
       # if not using as a scope, the alternative is this
       # in the future this will be deprecated
-      MyApp.Domain.do_somethign_else(..., Ash.Context.to_opts(context))
+      MyApp.Domain.do_something_else(..., Ash.Context.to_opts(context))
     end)
   end
   ```

--- a/test/actions/bulk/bulk_create_manual_test.exs
+++ b/test/actions/bulk/bulk_create_manual_test.exs
@@ -185,7 +185,7 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
           {:ok, _record} ->
             [:ok | results]
 
-          {:ok, _record, _notificiations} ->
+          {:ok, _record, _notifications} ->
             [:ok | results]
 
           {:error, error} ->

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -422,7 +422,7 @@ defmodule Ash.Test.AshTest do
         notifiers: [Notifier]
 
       mnesia do
-        table :ash_transations
+        table :ash_transactions
       end
 
       attributes do

--- a/test/resource/require_valid_arguments_in_code_interface_test.exs
+++ b/test/resource/require_valid_arguments_in_code_interface_test.exs
@@ -4,7 +4,7 @@ defmodule Resource.RequireValidArgumentsInCodeInterfaceTest do
 
   import Ash.Test.Helpers
 
-  test "fails if one of the code_inteface arguments is not a valid attribute or argument" do
+  test "fails if one of the code_interface arguments is not a valid attribute or argument" do
     assert_raise(
       Spark.Error.DslError,
       ~r/Cannot accept the args `\[:oops\]` because they are not arguments or attributes supported by the `:read` action/,

--- a/test/support/policy_rbac/checks/role_checks.ex
+++ b/test/support/policy_rbac/checks/role_checks.ex
@@ -40,8 +40,8 @@ defmodule Ash.Test.Support.PolicyRbac.Checks.RoleChecks do
     [:query, :action]
   end
 
-  # This would be a spot for us to pre-empt doing any filtering/request work
-  # We could use this to say "we already kow the answer" For example,
+  # This would be a spot for us to preempt doing any filtering/request work
+  # We could use this to say "we already know the answer" For example,
   # if the actor had a `super_admin` flag enabled on then, we could return
   # {:ok, true} to say "whatever role you're asking about, they have it"
   # (don't implement that this way, use a bypass check, its just an example)

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -812,7 +812,7 @@ policy action_type(:update) do
 end
 ```
 
-To require BOTH conditions in that exmaple, you would use `forbid_unless` for the first condition:
+To require BOTH conditions in that example, you would use `forbid_unless` for the first condition:
 
 ```elixir
 # CORRECT - This requires BOTH conditions


### PR DESCRIPTION
Found via `codespell -S logos,deps,CHANGELOG.md -L doesnt,cant,filetest,wont,fo,nd,anc,marge,zar` and `typos --hidden --format brief`

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
