### PR TITLE
fix: add default impl for rewrite/3 & get_rewrites/4 for Ash.Type.

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -2275,7 +2275,7 @@ defmodule Ash.Type do
 
     if Enum.any?(used_reserved_keys) do
       raise """
-      Reserved constraint key used: 
+      Reserved constraint key used:
 
       #{inspect(used_reserved_keys)}
 
@@ -2413,6 +2413,16 @@ defmodule Ash.Type do
         else
           def can_load?(_), do: false
         end
+      end
+
+      if !Module.defines?(__MODULE__, {:rewrite, 3}, :def) do
+        @impl Ash.Type
+        def rewrite(value, _rewrites, _constraints), do: value
+      end
+
+      if !Module.defines?(__MODULE__, {:get_rewrites, 4}, :def) do
+        @impl Ash.Type
+        def get_rewrites(_merged_load, _calculation, _path, _constraints), do: []
       end
     end
   end

--- a/test/calculations/calculation_with_union_type.exs
+++ b/test/calculations/calculation_with_union_type.exs
@@ -18,7 +18,7 @@ defmodule Ash.Test.Calculations.CalculationWithUnionTypeTest do
           items: [
             fields: [
               text: [type: :string, allow_nil?: false],
-              completed: [type: :boolean],
+              completed: [type: :boolean]
             ]
           ]
         ]
@@ -43,7 +43,6 @@ defmodule Ash.Test.Calculations.CalculationWithUnionTypeTest do
       end
     end
   end
-
 
   defmodule TextContent do
     use Ash.Resource,
@@ -130,7 +129,9 @@ defmodule Ash.Test.Calculations.CalculationWithUnionTypeTest do
 
   test "load statement for calculations on embedded resource in union type can be loaded when value is an embedded resource" do
     assert %Author{content: content} =
-             Changeset.for_create(Author, :create, %{content: %{text: "Text content", content_type: "text"}})
+             Changeset.for_create(Author, :create, %{
+               content: %{text: "Text content", content_type: "text"}
+             })
              |> Ash.create!()
              |> Ash.load!(content: [text: [:is_formatted], checklist: [:total_items]])
 

--- a/test/calculations/calculation_with_union_type.exs
+++ b/test/calculations/calculation_with_union_type.exs
@@ -1,0 +1,139 @@
+defmodule Ash.Test.Calculations.CalculationWithUnionTypeTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Changeset
+
+  defmodule ChecklistContent do
+    use Ash.Resource,
+      data_layer: :embedded
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :items, {:array, :map},
+        public?: true,
+        default: [],
+        constraints: [
+          items: [
+            fields: [
+              text: [type: :string, allow_nil?: false],
+              completed: [type: :boolean],
+            ]
+          ]
+        ]
+
+      attribute :allow_reordering, :boolean, public?: true, default: true
+      attribute :content_type, :string, public?: true, default: "checklist"
+    end
+
+    calculations do
+      calculate :total_items, :integer, expr(length(items)) do
+        public? true
+      end
+
+      calculate :completed_count, :integer, expr(0) do
+        # In a real implementation, this would count completed items
+        public? true
+      end
+
+      calculate :progress_percentage, :float, expr(0.0) do
+        # In a real implementation, this would calculate percentage
+        public? true
+      end
+    end
+  end
+
+
+  defmodule TextContent do
+    use Ash.Resource,
+      data_layer: :embedded
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :text, :string, public?: true, allow_nil?: false
+
+      attribute :formatting, :atom,
+        public?: true,
+        constraints: [one_of: [:plain, :markdown, :html]],
+        default: :plain
+
+      attribute :word_count, :integer, public?: true, default: 0
+      attribute :content_type, :string, public?: true, default: "text"
+    end
+
+    calculations do
+      calculate :display_text, :string, expr(text) do
+        public? true
+      end
+
+      calculate :is_formatted, :boolean, expr(formatting != :plain) do
+        public? true
+      end
+    end
+  end
+
+  defmodule Author do
+    use Ash.Resource,
+      domain: Ash.Test.Calculations.CalculationWithUnionTypeTest.Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:create, :read]
+    end
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+
+      attribute :content, :union do
+        public? true
+
+        constraints types: [
+                      text: [
+                        type: TextContent,
+                        tag: :content_type,
+                        tag_value: "text"
+                      ],
+                      # Simple types for testing untagged unions
+                      note: [
+                        type: :string
+                      ]
+                    ],
+                    storage: :type_and_value
+      end
+    end
+  end
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain
+
+    resources do
+      resource Author
+    end
+  end
+
+  test "load statement for calculations on embedded resource in union type doesn't fail when value is primitive" do
+    assert %Author{content: content} =
+             Changeset.for_create(Author, :create, %{content: "Just a note"})
+             |> Ash.create!()
+             |> Ash.load!(content: [text: [:is_formatted], checklist: [:total_items]])
+
+    assert content == %Ash.Union{type: :note, value: "Just a note"}
+  end
+
+  test "load statement for calculations on embedded resource in union type can be loaded when value is an embedded resource" do
+    assert %Author{content: content} =
+             Changeset.for_create(Author, :create, %{content: %{text: "Text content", content_type: "text"}})
+             |> Ash.create!()
+             |> Ash.load!(content: [text: [:is_formatted], checklist: [:total_items]])
+
+    assert %Ash.Union{type: :text, value: %{content_type: "text", text: "Text content"}} = content
+  end
+end


### PR DESCRIPTION
This fixes that load statements for calculations on embedded resources in a union type doesn't crash, when the value in the union type is currently a primitive.

In order to verify the bug exists:
- Comment out the new default implementations in type.ex
- Run the tests


- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
