### PR TITLE
pass actor: nil to ash.get in get_and_lock_for_update

### DIFF
--- a/lib/ash/resource/change/get_and_lock.ex
+++ b/lib/ash/resource/change/get_and_lock.ex
@@ -16,6 +16,7 @@ defmodule Ash.Resource.Change.GetAndLock do
              domain: changeset.domain,
              tracer: context.tracer,
              tenant: context.tenant,
+             actor: context.actor,
              authorize?: false,
              lock: opts[:lock]
            ) do

--- a/lib/ash/resource/change/get_and_lock.ex
+++ b/lib/ash/resource/change/get_and_lock.ex
@@ -16,7 +16,7 @@ defmodule Ash.Resource.Change.GetAndLock do
              domain: changeset.domain,
              tracer: context.tracer,
              tenant: context.tenant,
-             actor: context.actor,
+             actor: nil,
              authorize?: false,
              lock: opts[:lock]
            ) do

--- a/lib/ash/resource/change/get_and_lock_for_update.ex
+++ b/lib/ash/resource/change/get_and_lock_for_update.ex
@@ -16,6 +16,7 @@ defmodule Ash.Resource.Change.GetAndLockForUpdate do
              domain: changeset.domain,
              tracer: context.tracer,
              tenant: context.tenant,
+             actor: context.actor,
              authorize?: false,
              lock: :for_update
            ) do

--- a/lib/ash/resource/change/get_and_lock_for_update.ex
+++ b/lib/ash/resource/change/get_and_lock_for_update.ex
@@ -16,7 +16,7 @@ defmodule Ash.Resource.Change.GetAndLockForUpdate do
              domain: changeset.domain,
              tracer: context.tracer,
              tenant: context.tenant,
-             actor: context.actor,
+             actor: nil,
              authorize?: false,
              lock: :for_update
            ) do


### PR DESCRIPTION
My domain uses `require_actor? true`, which means I'm actually unable to use these changes right now, since they don't pass the actor to `Ash.get`

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
