### PR TITLE
fix: Accept nil input for maps and TypedStructs

### DIFF
--- a/lib/ash/type/map.ex
+++ b/lib/ash/type/map.ex
@@ -175,6 +175,8 @@ defmodule Ash.Type.Map do
   def dump_to_native(_, _), do: :error
 
   @impl true
+  def apply_constraints(nil, _constraints), do: {:ok, nil}
+
   def apply_constraints(value, constraints) do
     Enum.reduce(constraints, {:ok, value}, fn
       {:fields, fields}, {:ok, value} ->

--- a/test/type/map_test.exs
+++ b/test/type/map_test.exs
@@ -79,6 +79,24 @@ defmodule Ash.Type.MapTest do
     assert changeset.valid?
   end
 
+  test "it handles missing maps" do
+    changeset =
+      Post
+      |> Ash.Changeset.for_create(:create, %{})
+
+    assert changeset.valid?
+  end
+
+  test "it handles nil maps" do
+    changeset =
+      Post
+      |> Ash.Changeset.for_create(:create, %{
+        metadata: nil
+      })
+
+    assert changeset.valid?
+  end
+
   test "allow_nil? is true by default" do
     changeset =
       Post

--- a/test/type/struct_test.exs
+++ b/test/type/struct_test.exs
@@ -98,6 +98,24 @@ defmodule Type.StructTest do
     assert changeset.valid?
   end
 
+  test "it handles missing maps" do
+    changeset =
+      Post
+      |> Ash.Changeset.for_create(:create, %{})
+
+    assert changeset.valid?
+  end
+
+  test "it handles nil maps" do
+    changeset =
+      Post
+      |> Ash.Changeset.for_create(:create, %{
+        metadata: nil
+      })
+
+    assert changeset.valid?
+  end
+
   test "allow_nil? is true by default" do
     changeset =
       Post


### PR DESCRIPTION
This adds tests for `Ash.Type.Map`, `Ash.Type.Struct` and `Ash.TypedStruct` to ensure `nil` is a valid input when `allow_nil?` is `true`.

It then fixes `Ash.Type.Map` by explicitly handling `nil` in `apply_constraints`.

Finally it fixes `Ash.TypedStruct` by moving early escapes for `nil`, `""`, and `:binary` from `do_cast_input` to `cast_input`. From what I could tell, `do_cast_input` is only called by `new` and is guaranteed to always get a `map`, so the type checking wasn't being used. I felt that `new` only accepting maps and structs made sense, so `cast_input` seemed like the correct place to put the checks. `cast_input` still calls `new` for maps and structs, so I believe the intent is maintained. I apologize if this change is overreaching.

This fixes #2254

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
