### PR TITLE
Update before_action docs to use force_change_attribute/2

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -6493,14 +6493,16 @@ defmodule Ash.Changeset do
   ## Examples
 
       # Set computed fields based on other attributes
+      # Note: Use Ash.Changeset.force_change_attribute/2 instead of Ash.Changeset.change_attribute/2,
+      # as the latter will log a warning saying that validations have already been run.
       iex> changeset = Ash.Changeset.for_create(MyApp.Order, :create, %{items: [%{price: 10}, %{price: 15}]})
       iex> changeset = Ash.Changeset.before_action(changeset, fn changeset ->
       ...>   total = changeset.attributes.items |> Enum.map(& &1.price) |> Enum.sum()
       ...>   tax = total * 0.08
       ...>   changeset
-      ...>   |> Ash.Changeset.change_attribute(:subtotal, total)
-      ...>   |> Ash.Changeset.change_attribute(:tax, tax)
-      ...>   |> Ash.Changeset.change_attribute(:total, total + tax)
+      ...>   |> Ash.Changeset.force_change_attribute(:subtotal, total)
+      ...>   |> Ash.Changeset.force_change_attribute(:tax, tax)
+      ...>   |> Ash.Changeset.force_change_attribute(:total, total + tax)
       ...> end)
 
       # Assign resources based on complex business logic
@@ -6510,7 +6512,7 @@ defmodule Ash.Changeset do
       ...>     :urgent ->
       ...>       # Query for available senior agents
       ...>       agent = MyApp.Agent |> MyApp.Query.for_read(:available_senior) |> MyApp.read_one!()
-      ...>       Ash.Changeset.change_attribute(changeset, :assigned_agent_id, agent.id)
+      ...>       Ash.Changeset.force_change_attribute(changeset, :assigned_agent_id, agent.id)
       ...>     _ ->
       ...>       changeset
       ...>   end


### PR DESCRIPTION
Using change_attribute/2 in a before_action hook triggers a warning that the changeset has already been validated, suggests a new pattern that isn't compatible with the before_action hook. This confused me at first when copying the patterns from the documentation, so I suggest using force_change_attribute in the examples instead, as well as adding a small note about why.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
