### PR TITLE
improvement: TypedStruct required field pattern matching

### DIFF
--- a/lib/ash/typed_struct.ex
+++ b/lib/ash/typed_struct.ex
@@ -149,6 +149,12 @@ defmodule Ash.TypedStruct do
             end
           end)
 
+        map_required_fields_match =
+          enforce_keys
+          |> Enum.reject(&(&1 in Map.keys(defaults)))
+          |> Enum.map(&{&1, :_})
+          |> Enum.into(%{})
+
         map_constraints =
           [
             fields:
@@ -181,7 +187,7 @@ defmodule Ash.TypedStruct do
                constraints: unquote(Macro.escape(map_constraints))
 
              @doc "Create a new #{__MODULE__}, raising any error"
-             def new!(fields) do
+             def new!(unquote(Macro.escape(map_required_fields_match)) = fields) do
                case new(fields) do
                  {:ok, value} -> value
                  {:error, error} -> raise Ash.Error.to_error_class(error)

--- a/test/typed_struct_test.exs
+++ b/test/typed_struct_test.exs
@@ -101,6 +101,16 @@ defmodule Ash.TypedStructTest do
       assert struct.active == false
     end
 
+    test "new! raises match error when required fields with no default are missing" do
+      assert_raise FunctionClauseError, fn ->
+        UserStruct.new!(%{
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          email: "invalid-email",
+          age: 30
+        })
+      end
+    end
+
     test "new! raises on errors" do
       assert_raise Ash.Error.Invalid, fn ->
         UserStruct.new!(%{


### PR DESCRIPTION
I think this covers the requirement for #2253.  But adding the function head match for `new!/1` causes the current test to fail.  So, is this the behavior you were after?  If so, I can remove the other test.

Current test that is now failing since there isn't a match on the function head
```elixir
    test "new! raises on errors" do
      assert_raise Ash.Error.Invalid, fn ->
        UserStruct.new!(%{
          id: "123e4567-e89b-12d3-a456-426614174000",
          name: "John Doe",
          email: "invalid-email",
          age: 30
        })
      end
    end
```

New test for function head match error
```elixir
    test "new! raises match error when required fields with no default are missing" do
      assert_raise FunctionClauseError, fn ->
        UserStruct.new!(%{
          id: "123e4567-e89b-12d3-a456-426614174000",
          email: "invalid-email",
          age: 30
        })
      end
    end
```

### Improvements
- Adds generated function head for `new!/1` for required fields

closes #2253

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
