### PR TITLE
[POC] Introduce typed_struct_generator

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -519,6 +519,18 @@ defmodule Ash.Generator do
     end
   end
 
+  def typed_struct_generator(module, opts \\ []) do
+    generators =
+      opts[:defaults]
+      |> Kernel.||([])
+      |> Map.new()
+      |> Map.merge(Map.new(opts[:overrides] || %{}))
+
+    Spark.Dsl.Extension.get_entities(module, [:typed_struct])
+    |> generate_attributes(generators, true, :create, [])
+    |> StreamData.map(fn data -> module.new!(data) end)
+  end
+
   @doc """
   Generate globally unique values.
 

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -231,6 +231,21 @@ defmodule Ash.Test.GeneratorTest do
     end
   end
 
+  defmodule TypedEvent do
+    use Ash.TypedStruct
+
+    typed_struct do
+      field(:event_source, :atom,
+        allow_nil?: false,
+        constraints: [one_of: [:first_party, :third_pary]]
+      )
+
+      field(:external_event_id, :string, allow_nil?: false, constraints: [min_length: 3])
+      field(:metadata, :map)
+      field(:timestamp, :datetime, allow_nil?: false)
+    end
+  end
+
   defmodule Generator do
     use Ash.Generator
 
@@ -753,6 +768,20 @@ defmodule Ash.Test.GeneratorTest do
       Post
       |> Ash.Generator.query(:read_with_args)
       |> Ash.read!()
+    end
+  end
+
+  describe "typed_struct_generator" do
+    test "it correctly generates a struct" do
+      assert %TypedEvent{} =
+               Ash.Generator.typed_struct_generator(
+                 TypedEvent,
+                 defaults: [
+                   external_event_id:
+                     Ash.Generator.sequence(:external_event_id, &"ext_event_#{&1}")
+                 ]
+               )
+               |> Enum.at(0)
     end
   end
 end


### PR DESCRIPTION
This is a generator Ash developers can used to generate test versions of their typed structs without need to write manual fixtures.

This is current just a POC and is missing the required documentation and such for this to be ready to merge. I wanted to get feedback from the Ash core contributors if 
1. This is even something that Ash would like as part of its API
2. This feature is even necessary?

To be honest because `typed_structs` are just NewType structs underneath the hood I feel there may be a way to access their generator already, but for the life of me I couldn't get it to work. Not only that I'm currently unaware how one may replace some of the attribute generators with custom ones like this API provides. But if an Ash core contributor could point that out I'd also be happy to close this PR and open a separate one updating the TypedStruct docs to show how one could create generators for them.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
