### PR TITLE
fix: respect disable_async config during pagination count

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -3405,7 +3405,8 @@ defmodule Ash.Actions.Read do
              {:ok, data_layer_query} <- Ash.Query.data_layer_query(query) do
           if return? do
             if Ash.DataLayer.in_transaction?(resource) ||
-                 !Ash.DataLayer.can?(:async_engine, resource) do
+                 !Ash.DataLayer.can?(:async_engine, resource) ||
+                 Application.get_env(:ash, :disable_async?) do
               case do_fetch_count(query, data_layer_query) do
                 {:ok, count} -> {:ok, {:ok, count}}
                 {:error, error} -> {:error, error}

--- a/test/actions/pagination_test.exs
+++ b/test/actions/pagination_test.exs
@@ -990,9 +990,10 @@ defmodule Ash.Actions.PaginationTest do
 
   describe "counting" do
     test "counts synchronously when async is disabled" do
+      disable_async? = Application.get_env(:ash, :disable_async?)
       Application.put_env(:ash, :disable_async?, true)
+      on_exit(fn -> Application.put_env(:ash, :disable_async?, disable_async?) end)
 
-      expect(Ash.DataLayer, :in_transaction?, fn _ -> true end)
       reject(&Ash.ProcessHelpers.async/2)
 
       assert Ash.read!(User, action: :optional_offset, page: [limit: 1, count: true]).count ==
@@ -1000,7 +1001,9 @@ defmodule Ash.Actions.PaginationTest do
     end
 
     test "counts asynchronously when async is enabled" do
+      disable_async? = Application.get_env(:ash, :disable_async?)
       Application.put_env(:ash, :disable_async?, false)
+      on_exit(fn -> Application.put_env(:ash, :disable_async?, disable_async?) end)
 
       stub(Ash.DataLayer, :in_transaction?, fn _ -> false end)
 
@@ -1018,8 +1021,6 @@ defmodule Ash.Actions.PaginationTest do
 
       assert Ash.read!(User, action: :optional_offset, page: [limit: 1, count: true]).count ==
                0
-
-      Application.put_env(:ash, :disable_async?, true)
     end
   end
 end

--- a/test/actions/pagination_test.exs
+++ b/test/actions/pagination_test.exs
@@ -1,5 +1,6 @@
 defmodule Ash.Actions.PaginationTest do
   use ExUnit.Case, async: true
+  use Mimic
 
   require Ash.Query
 
@@ -984,6 +985,41 @@ defmodule Ash.Actions.PaginationTest do
              |> Ash.read!(page: [limit: 3])
              |> Map.fetch!(:results)
              |> Enum.count() == 3
+    end
+  end
+
+  describe "counting" do
+    test "counts synchronously when async is disabled" do
+      Application.put_env(:ash, :disable_async?, true)
+
+      expect(Ash.DataLayer, :in_transaction?, fn _ -> true end)
+      reject(&Ash.ProcessHelpers.async/2)
+
+      assert Ash.read!(User, action: :optional_offset, page: [limit: 1, count: true]).count ==
+               0
+    end
+
+    test "counts asynchronously when async is enabled" do
+      Application.put_env(:ash, :disable_async?, false)
+
+      stub(Ash.DataLayer, :in_transaction?, fn _ -> false end)
+
+      stub(Ash.DataLayer, :can?, fn
+        :async_engine, _ -> true
+        feature, resource -> Mimic.call_original(Ash.DataLayer, :can?, [feature, resource])
+      end)
+
+      expect(
+        Ash.ProcessHelpers,
+        :async,
+        1,
+        &Mimic.call_original(Ash.ProcessHelpers, :async, [&1, &2])
+      )
+
+      assert Ash.read!(User, action: :optional_offset, page: [limit: 1, count: true]).count ==
+               0
+
+      Application.put_env(:ash, :disable_async?, true)
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,7 @@
 # We compile modules with the same name often while testing the DSL
 Mimic.copy(Ash.Reactor.Notifications)
 Mimic.copy(Ash.DataLayer)
+Mimic.copy(Ash.ProcessHelpers)
 
 Code.compiler_options(ignore_module_conflict: true)
 


### PR DESCRIPTION
Fixes pagination counts not respecting `:disable_async?` config.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
