### PR TITLE
test: asserting update authorized on post only if all comments are erased

### DIFF
--- a/test/policy/complex_test.exs
+++ b/test/policy/complex_test.exs
@@ -284,4 +284,10 @@ defmodule Ash.Test.Policy.ComplexTest do
     assert [_] = Post.erasable!(actor: me, context: %{post_id: post.id})
     assert %{text: "[deleted]"} = Post.erase!(post, actor: me, context: %{post_id: post.id})
   end
+
+  test "authorize update on post only if all comments are erased", %{post_by_me: post} do
+    assert {:error, %Ash.Error.Forbidden{}} = Post.update(post, "new text")
+    Comment.erase!(Ash.load!(post, :comments, authorize?: false).comments)
+    assert {:ok, _post} = Post.update(Ash.load!(post, :comments, authorize?: false), "new text")
+  end
 end

--- a/test/support/policy_complex/resources/comment/comment.ex
+++ b/test/support/policy_complex/resources/comment/comment.ex
@@ -61,6 +61,10 @@ defmodule Ash.Test.Support.PolicyComplex.Comment do
       change relate_actor(:author)
     end
 
+    update :erase do
+      change set_attribute(:text, "[deleted]")
+    end
+
     read :read_through_post
 
     read :read_with_runtime_check
@@ -68,6 +72,7 @@ defmodule Ash.Test.Support.PolicyComplex.Comment do
 
   code_interface do
     define :create, args: [:post_id, :text]
+    define :erase
   end
 
   relationships do

--- a/test/support/policy_complex/resources/post.ex
+++ b/test/support/policy_complex/resources/post.ex
@@ -26,6 +26,11 @@ defmodule Ash.Test.Support.PolicyComplex.Post do
     policy action([:erase, :erasable]) do
       authorize_if expr(has_context)
     end
+
+    policy action(:update) do
+      forbid_if expr(exists(comments, text != "[deleted]"))
+      authorize_if always()
+    end
   end
 
   ets do
@@ -93,6 +98,7 @@ defmodule Ash.Test.Support.PolicyComplex.Post do
 
   code_interface do
     define :create, args: [:text]
+    define :update, args: [:text]
     define :erase
     define :erasable
   end


### PR DESCRIPTION
#2275 
So I tried recreating this and could not reproduce. What am I missing here? 🤔 
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
