### PR TITLE
Update validations.md (doc fix, correct example init() call because `nil` is an atom)

### DIFF
--- a/documentation/topics/resources/validations.md
+++ b/documentation/topics/resources/validations.md
@@ -67,7 +67,7 @@ defmodule MyApp.Validations.IsPrime do
 
   @impl true
   def init(opts) do
-    if is_atom(opts[:attribute]) do
+    if opts[:attribute] != nil && is_atom(opts[:attribute]) do
       {:ok, opts}
     else
       {:error, "attribute must be an atom!"}


### PR DESCRIPTION
Because:
```
iex(7)> opts = %{status: "blue", thing: 5}
%{status: "blue", thing: 5}
iex(8)> opts[:attribute]
nil
iex(9)> opts[:status]
"blue"
iex(10)> is_atom(opts[:attribute])
true
iex(11)> opts[:attribute] != nil && is_atom([:attribute]) false
```
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
