### PR TITLE
fix: allow module validations in generic actions

### DIFF
--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -156,7 +156,7 @@ defmodule Ash.Resource.Validation do
       def init(opts), do: {:ok, opts}
 
       @impl true
-      def supports(_opts), do: [Ash.Changeset]
+      def supports(_opts), do: [Ash.Changeset, Ash.ActionInput]
 
       defp with_description(keyword, opts) do
         if Kernel.function_exported?(__MODULE__, :describe, 1) do


### PR DESCRIPTION
Module validations are described in the documentation for generic actions but were missing `Ash.ActionInput` in `supports/1`. https://hexdocs.pm/ash/generic-actions.html#validations

<img width="852" height="396" alt="image" src="https://github.com/user-attachments/assets/22feb94f-77c9-4e6d-ac36-01bd4d4ac6a3" />


# Contributor checklist
- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests

