### PR TITLE
Fix bug when casting a non-existing atom from datalayer when `unsafe_to_atom?` is set

### DIFF
--- a/lib/ash/type/atom.ex
+++ b/lib/ash/type/atom.ex
@@ -81,17 +81,7 @@ defmodule Ash.Type.Atom do
 
   def cast_input("", _), do: {:ok, nil}
 
-  # sobelow_skip ["DOS.StringToAtom"]
-  def cast_input(value, constraints) when is_binary(value) do
-    if constraints[:unsafe_to_atom?] do
-      {:ok, String.to_atom(value)}
-    else
-      {:ok, String.to_existing_atom(value)}
-    end
-  rescue
-    ArgumentError ->
-      :error
-  end
+  def cast_input(value, constraints) when is_binary(value), do: cast_value(value, constraints)
 
   def cast_input(_value, _), do: :error
 
@@ -102,14 +92,21 @@ defmodule Ash.Type.Atom do
     {:ok, value}
   end
 
-  def cast_stored(value, _) when is_binary(value) do
-    {:ok, String.to_existing_atom(value)}
+  def cast_stored(value, constraints) when is_binary(value), do: cast_value(value, constraints)
+
+  def cast_stored(_, _), do: :error
+
+  # sobelow_skip ["DOS.StringToAtom"]
+  defp cast_value(value, constraints) when is_binary(value) do
+    if constraints[:unsafe_to_atom?] do
+      {:ok, String.to_atom(value)}
+    else
+      {:ok, String.to_existing_atom(value)}
+    end
   rescue
     ArgumentError ->
       :error
   end
-
-  def cast_stored(_, _), do: :error
 
   @impl true
   def dump_to_native(nil, _), do: {:ok, nil}

--- a/test/type/atom_test.exs
+++ b/test/type/atom_test.exs
@@ -1,0 +1,114 @@
+defmodule Ash.Test.Type.AtomTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  defmodule TestResource do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Ash.Test.Domain
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+
+      defaults [:create, :read, :update, :destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :value, :atom do
+        constraints one_of: [
+                      :value_a,
+                      :value_b
+                    ]
+
+        public? true
+      end
+
+      attribute :safe_value, :atom do
+        public? true
+      end
+
+      attribute :unsafe_value, :atom do
+        constraints unsafe_to_atom?: true
+        public? true
+      end
+    end
+  end
+
+  test "it rejects invalid atom option" do
+    assert_raise(Ash.Error.Invalid, ~r/atom must be one of/, fn ->
+      TestResource
+      |> Ash.Changeset.for_create(:create, %{value: :value_c})
+      |> Ash.create!()
+    end)
+  end
+
+  test "it rejects non existing atom" do
+    new_atom = non_existing_atom_string()
+
+    assert_raise(Ash.Error.Invalid, ~r/Invalid value provided for safe_value/, fn ->
+      TestResource
+      |> Ash.Changeset.for_create(:create, %{safe_value: new_atom})
+      |> Ash.create!()
+    end)
+  end
+
+  test "it accepts non existing atom when unsafe_to_atom constraint is set" do
+    new_atom = non_existing_atom_string()
+
+    assert {:ok, %{unsafe_value: cast_atom}} =
+             TestResource
+             |> Ash.Changeset.for_create(:create, %{unsafe_value: new_atom})
+             |> Ash.create()
+
+    # Atom should now exist, so this shouldn't throw an error
+    assert cast_atom == String.to_existing_atom(new_atom)
+  end
+
+  test "it should cast non-existing atoms when unsafe_to_atom constraint is set" do
+    %{id: created_id} =
+      TestResource
+      |> Ash.Changeset.for_create(:create, %{unsafe_value: "non_existing_atom"})
+      |> Ash.create!()
+
+    new_atom = non_existing_atom_string()
+
+    # Modify the record stored in ETS
+    # This will ensure that there is no atom with this key in the system.
+    table = Process.get({:ash_ets_table, TestResource, nil})
+    {key, record} = ETS.Set.get!(table, %{id: created_id})
+
+    updated_record = %{
+      record
+      | unsafe_value: new_atom
+    }
+
+    ETS.Set.put(table, {key, updated_record})
+
+    # Make sure the atom doesnt exist
+    assert_raise(ArgumentError, fn -> String.to_existing_atom(new_atom) end)
+
+    # Load the record using Ash, this should cast the string to an atom
+    assert [%{id: ^created_id, unsafe_value: cast_atom}] = TestResource |> Ash.read!()
+
+    # Ensure that the atom is created
+    assert cast_atom == String.to_existing_atom(new_atom)
+  end
+
+  def non_existing_atom_string do
+    atom_string = "non_existing_atom_#{:rand.uniform(100_000_000)}"
+
+    try do
+      _ = String.to_existing_atom(atom_string)
+      non_existing_atom_string()
+    rescue
+      ArgumentError -> atom_string
+    end
+  end
+end

--- a/test/type/atom_test.exs
+++ b/test/type/atom_test.exs
@@ -102,13 +102,7 @@ defmodule Ash.Test.Type.AtomTest do
   end
 
   def non_existing_atom_string do
-    atom_string = "non_existing_atom_#{:rand.uniform(100_000_000)}"
-
-    try do
-      _ = String.to_existing_atom(atom_string)
-      non_existing_atom_string()
-    rescue
-      ArgumentError -> atom_string
-    end
+    uuid = Ash.UUID.generate() |> String.replace("-", "_")
+    "non_existing_atom_#{uuid}"
   end
 end

--- a/test/type/type_test.exs
+++ b/test/type/type_test.exs
@@ -87,14 +87,6 @@ defmodule Ash.Test.Type.TypeTest do
     end)
   end
 
-  test "it rejects invalid atom data" do
-    assert_raise(Ash.Error.Invalid, ~r/atom must be one of/, fn ->
-      Post
-      |> Ash.Changeset.for_create(:create, %{title: "foobar", post_type: :something_else})
-      |> Ash.create!()
-    end)
-  end
-
   test "returns error for invalid keys" do
     foo = {:foo, [type: :string]}
     bar = {:bar, [type: :integer]}


### PR DESCRIPTION
The `unsafe_to_atom?` constraint was not used by the `Ash.Type.Atom.cast_stored/2` function so when casting a stored string to an atom it would throw errors. 

I've added a test that demonstrates the problem. The test uses the ETS directly to insert a non-existing atom. I've put this in a new test module specifically for Atom type tests.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
