### PR TITLE
fix variable swapping in authorizer reducer

### DIFF
--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -1535,7 +1535,7 @@ defmodule Ash.Policy.Authorizer do
   defp check_result(authorizer) do
     {data, authorizer, any_forbidden?} =
       authorizer.data
-      |> Enum.reduce({[], false, authorizer}, fn record, {data, any_forbidden?, authorizer} ->
+      |> Enum.reduce({[], authorizer, false}, fn record, {data, authorizer, any_forbidden?} ->
         authorizer.scenarios
         |> Enum.reject(&scenario_impossible?(&1, authorizer, record))
         |> case do


### PR DESCRIPTION
# Contributor checklist

I was getting this stacktrace:

```
* ** (KeyError) key :subject not found in: false

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
  (ash 3.5.34) lib/ash/policy/authorizer/authorizer.ex:1568: Ash.Policy.Authorizer.log_successful_policy_breakdown/2
  (ash 3.5.34) lib/ash/policy/authorizer/authorizer.ex:1556: Ash.Policy.Authorizer.check_result/1
  (ash 3.5.34) lib/ash/can.ex:664: anonymous fn/5 in Ash.Can.run_check/4
  (ash 3.5.34) lib/ash/actions/read/read.ex:3462: anonymous fn/2 in Ash.Actions.Read.run_authorize_results/2
  (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
  (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
  (ash 3.5.34) lib/ash/actions/read/read.ex:3461: Ash.Actions.Read.run_authorize_results/2
  (ash 3.5.34) lib/ash/actions/read/read.ex:745: anonymous fn/8 in Ash.Actions.Read.do_read/5
  (ash 3.5.34) lib/ash/actions/read/read.ex:1466: Ash.Actions.Read.maybe_in_transaction/3
  (ash 3.5.34) lib/ash/actions/read/read.ex:597: Ash.Actions.Read.do_read/5
  (ash 3.5.34) lib/ash/actions/read/read.ex:420: Ash.Actions.Read.do_run/3
  (ash 3.5.34) lib/ash/actions/read/read.ex:86: anonymous fn/3 in Ash.Actions.Read.run/3
  (ash 3.5.34) lib/ash/actions/read/read.ex:85: Ash.Actions.Read.run/3
  (ash 3.5.34) lib/ash.ex:3007: Ash.do_read_one/3
  (ash 3.5.34) lib/ash.ex:2915: Ash.read_one/2
```

This seems to be the culprit.

regression testing this seemed overkill, so I didn't 😅 

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
