### PR TITLE
fix: Allow ^actor() in upsert_condition

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1896,10 +1896,6 @@ defmodule Ash.Changeset do
         upsert_condition: upsert_condition
       }
     })
-    |> then(fn
-      changeset when upsert_condition != nil -> filter(changeset, upsert_condition)
-      changeset -> changeset
-    end)
     |> do_for_action(action, params, opts)
   end
 
@@ -2541,6 +2537,7 @@ defmodule Ash.Changeset do
                 changeset
                 |> prepare_changeset_for_action(action, opts)
                 |> handle_params(action, params, opts)
+                |> handle_upsert()
                 |> run_action_changes(
                   action,
                   opts[:actor],
@@ -2712,6 +2709,14 @@ defmodule Ash.Changeset do
     |> validate_attributes_accepted(action)
     |> require_values(action.type, false, action.require_attributes)
     |> set_defaults(changeset.action_type, false)
+  end
+
+  defp handle_upsert(changeset) do
+    if changeset.context.private[:upsert_condition] do
+      filter(changeset, changeset.context.private.upsert_condition)
+    else
+      changeset
+    end
   end
 
   defp get_action_entity(resource, name) when is_atom(name),

--- a/test/resource/upsert_test.exs
+++ b/test/resource/upsert_test.exs
@@ -29,6 +29,7 @@ defmodule Ash.Test.Resource.UpsertTest do
       define(:create)
       define(:upsert_variants, args: [:variants])
       define :upsert
+      define :upsert_condition
     end
 
     changes do
@@ -67,6 +68,12 @@ defmodule Ash.Test.Resource.UpsertTest do
         upsert? true
         upsert_identity :unique_name
         upsert_fields({:replace, [:name]})
+      end
+
+      create :upsert_condition do
+        upsert? true
+        upsert_identity :unique_name
+        upsert_condition expr(other == ^actor(:name))
       end
     end
 
@@ -244,6 +251,27 @@ defmodule Ash.Test.Resource.UpsertTest do
         |> Ash.create!()
 
       assert product.other == "george"
+    end
+  end
+
+  describe "upsert with upsert_condition referencing actor" do
+    test "with correct actor" do
+      Product.upsert_condition!(%{name: "fred", other: "george"}, actor: %{name: "george"})
+      Product.upsert_condition!(%{name: "fred", other: "george"}, actor: %{name: "george"})
+    end
+
+    test "with wrong actor" do
+      Product.upsert_condition!(%{name: "fred", other: "george"}, actor: %{name: "george"})
+
+      assert_raise Ash.Error.Invalid, fn ->
+        Product.upsert_condition!(%{name: "fred", other: "george"}, actor: %{name: "bob"})
+      end
+    end
+
+    test "with no actor" do
+      assert_raise Ash.Error.Invalid, fn ->
+        Product.upsert_condition!(%{name: "fred", other: "george"})
+      end
     end
   end
 end


### PR DESCRIPTION
[The docs for upserts](https://hexdocs.pm/ash/create-actions.html#upserts) say to use `upsert_condition expr(user_id == ^actor(:id))` to restrict access to updating resources to the owner of the resource, as the create policy will be used and not the update policy when an upsert occurs.

When I attempted to do something similar I would consistently get an `Ash.Error.Changes.ActionRequiresActor` error, despite always passing in an `actor`. Upon digging in, the issue is that `filter` attempts to expand the `upsert_condition` expression and replace the `{:_actor, field}` placeholders immediately. However `Ash.Changeset.for_create` isn't populating the context with `actor`, I suspect because `do_for_action` is responsible for that logic.

I was unsure the best approach and opted for the simplest fix of adding `actor` to the context passed in to `filter`. 

This fixes #1445

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
