### PR TITLE
skip count of records when paginating if filter evaluates to false

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -3376,6 +3376,15 @@ defmodule Ash.Actions.Read do
            (page[:count] != false and action.pagination.countable == :by_default))
 
     cond do
+      query.filter && query.filter.expression == false ->
+        result = if needs_count?, do: 0, else: nil
+
+        if return? do
+          {:ok, {:ok, result}}
+        else
+          {:ok, fn -> {:ok, result} end}
+        end
+
       Map.has_key?(query.context, :accessing_from) and needs_count? ->
         if return? do
           # Relationship count is fetched by the parent using aggregates, just return nil here

--- a/test/support/policy_simple/resources/car.ex
+++ b/test/support/policy_simple/resources/car.ex
@@ -33,6 +33,10 @@ defmodule Ash.Test.Support.PolicySimple.Car do
     end
 
     create :authorize_unless
+
+    read :with_pagination do
+      pagination offset?: true
+    end
   end
 
   attributes do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I was not able to test that the count query was not made. I tried: 
- shutting down the ETS layer: action fails due to table not found
- checking telemetry events for read: no changes between code with fix / without fix in the read events
- capture logs: debug events are not logged because of global logger settings.
