### PR TITLE
fix: properly escape collection defaults in TypedStruct macro

### DIFF
--- a/lib/ash/typed_struct.ex
+++ b/lib/ash/typed_struct.ex
@@ -209,7 +209,7 @@ defmodule Ash.TypedStruct do
       ) do
     quote do
       @enforce_keys unquote(enforce_keys)
-      defstruct unquote(fields_with_defaults)
+      defstruct unquote(Macro.escape(fields_with_defaults))
 
       use Ash.Type.NewType,
         subtype_of: :struct,


### PR DESCRIPTION
Fixes compilation failure when TypedStruct fields have map or non-empty collection defaults. The issue was that runtime values like %{} and %{key: "value"} need to be escaped before being unquoted in the macro.

This change adds Macro.escape/1 to properly handle collection defaults in the defstruct generation.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
