### PR TITLE
fix: add default values to manual action changesets

### DIFF
--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -480,12 +480,8 @@ defmodule Ash.Actions.Update do
                     if result = changeset.context[:private][:action_result] do
                       result
                     else
-                      if Enum.empty?(changeset.attributes) &&
-                           Ash.DataLayer.data_layer_can?(changeset.resource, :atomic_update) do
-                        Ash.Changeset.atomic_defaults(changeset)
-                      else
-                        Ash.Changeset.set_defaults(changeset, :update, true)
-                      end
+                      changeset
+                      |> Ash.Changeset.set_defaults(:update, true)
                       |> mod.update(
                         action_opts,
                         %Ash.Resource.ManualUpdate.Context{

--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -480,8 +480,13 @@ defmodule Ash.Actions.Update do
                     if result = changeset.context[:private][:action_result] do
                       result
                     else
-                      mod.update(
-                        changeset,
+                      if Enum.empty?(changeset.attributes) &&
+                           Ash.DataLayer.data_layer_can?(changeset.resource, :atomic_update) do
+                        Ash.Changeset.atomic_defaults(changeset)
+                      else
+                        Ash.Changeset.set_defaults(changeset, :update, true)
+                      end
+                      |> mod.update(
                         action_opts,
                         %Ash.Resource.ManualUpdate.Context{
                           select: changeset.select,


### PR DESCRIPTION
Ensure that changesets for manual update actions get default values applied before handing up to manual update module's `update/3`

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
