### PR TITLE
Make `Ash.PlugHelpers.set_actor/2` typespec accept term as an actor

### DIFF
--- a/lib/ash/plug_helpers.ex
+++ b/lib/ash/plug_helpers.ex
@@ -34,7 +34,7 @@ if Code.ensure_loaded?(Plug.Conn) do
         %Plug.Conn{private: %{ash: %{actor: %{email: "marty@1985.retro"}}}} = conn
 
     """
-    @spec set_actor(Conn.t(), Ash.Resource.record()) :: Conn.t()
+    @spec set_actor(Conn.t(), term()) :: Conn.t()
     def set_actor(conn, actor) do
       ash_private =
         conn.private


### PR DESCRIPTION
This fixes Dialyzer check when an application is not using a resource as an actor.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
