### PR TITLE
docs: clarify enum labels

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -95,6 +95,12 @@ defmodule Ash.Type.Enum do
   iex> "Closed"
   ```
 
+  A default label is generated based on the value.
+  ```elixir
+  MyApp.TicketStatus.label(:open)
+  iex> "Open"
+  ```
+
   Both the description and label can be retrieved with `details/1`
 
   ```elixir


### PR DESCRIPTION
Mention that Ash.Type.Enum.label/1 generates a label based on the value if no label was defined, rather than returning nil.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
