### PR TITLE
Runtime upsert_fields option is not passed to data layer in certain cases

### DIFF
--- a/lib/ash/actions/create/create.ex
+++ b/lib/ash/actions/create/create.ex
@@ -111,6 +111,13 @@ defmodule Ash.Actions.Create do
         opts[:upsert_identity] || get_in(changeset.context, [:private, :upsert_identity])
       end
 
+    upsert_fields =
+      Ash.Changeset.expand_upsert_fields(
+        opts[:upsert_fields] || get_in(changeset.context, [:private, :upsert_fields]) ||
+          action.upsert_fields,
+        changeset.resource
+      )
+
     opts =
       if get_in(changeset.context, [:private, :return_skipped_upsert?]) do
         Keyword.put(opts, :return_skipped_upsert?, true)
@@ -123,7 +130,11 @@ defmodule Ash.Actions.Create do
 
     changeset =
       Ash.Changeset.set_context(changeset, %{
-        private: %{upsert?: true, upsert_identity: upsert_identity}
+        private: %{
+          upsert?: true,
+          upsert_identity: upsert_identity,
+          upsert_fields: upsert_fields
+        }
       })
 
     with %{valid?: true} = changeset <- changeset(changeset, domain, action, opts),

--- a/test/actions/create_test.exs
+++ b/test/actions/create_test.exs
@@ -634,11 +634,12 @@ defmodule Ash.Test.Actions.CreateTest do
                Post
                |> Ash.Changeset.new()
                |> Ash.Changeset.change_attributes(%{
-                 title: "foo"
+                 title: "foo",
+                 tag: "v1"
                })
                |> Ash.create!()
 
-      assert %Post{id: ^id, title: "foo", contents: "bar", updated_at: new_updated_at} =
+      assert %Post{id: ^id, title: "foo", contents: "bar", tag: tag, updated_at: new_updated_at} =
                Post
                |> Ash.Changeset.new()
                |> Ash.Changeset.change_attributes(%{
@@ -648,10 +649,12 @@ defmodule Ash.Test.Actions.CreateTest do
                |> Ash.create!(
                  upsert?: true,
                  upsert_identity: :unique_title,
-                 upsert_fields: [:contents, :updated_at]
+                 upsert_fields: [:contents, :tag, :updated_at]
                )
 
       refute updated_at == new_updated_at
+      # tag not set (but included in upsert_fields) so it reverts to default
+      assert tag == "garbage"
     end
 
     test "skips upsert when condition doesn't match" do


### PR DESCRIPTION
following up on https://elixirforum.com/t/anybody-working-on-or-interested-in-ash-mongo-ash-datalayer-for-mongodb/72189/4

when creating a resource directly without creating a changeset first, upsert_fields is not passed to the datalayer:  (new test case in commit 72b161d)

```
Ash.create!(
  Post,
  %{
   title: "foo",
   contents: "test"
  },
  upsert?: true,
  upsert_identity: :unique_title,
  upsert_fields: [:contents] # this gets lost
)
```

the fix in commit c7e6376 is my best guess on how to fix it (and all tests pass) but:
- I am not 100% confident that this is the right place or way to do it
- there might be a different helper that I haven't seen that should be called

=> i.e. I understand what I am doing, but not why upsert_fields need to be in the changeset, when they are already in the opts
=> I would appreciate a review here.

Next, I have updated an existing test to make the behaviour of "reverts to default" for fields missing in the changeset more explicit. I can remove that if not appropriate.

Finally, I have a doubt about `upsert?: true` in

```
# lib/ash/actions/create/create.ex 133:140
    changeset =
      Ash.Changeset.set_context(changeset, %{
        private: %{
          upsert?: true,
          upsert_identity: upsert_identity,
          upsert_fields: upsert_fields
        }
      })
```

I have tried to remove it, set it to false, or to `upsert?: opts[:upsert?]` (which my instincts tell me it should be) and all tests still pass. I have not yet been able to write a failing test case.

=> not sure what to do ... maybe that should be a separate issue?

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
