### PR TITLE
fix(nif rustler_precompiled): update targets to ubuntu-22.04 and extend release list to prevent stuck builds

### DIFF
--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -555,30 +555,27 @@ jobs:
         job:
           # cranelift-codegen panics at 'error when identifying target: "no supported isa found for arch `arm`"'
           # - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
+          - { target: aarch64-apple-darwin, os: macos-15 }
+          - { target: aarch64-apple-ios-sim, os: macos-15 }
+          - { target: aarch64-apple-ios, os: macos-15 }
           - {
               target: aarch64-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
             }
           - {
               target: aarch64-unknown-linux-musl,
-              os: ubuntu-20.04,
-              use-cross: true,
-            }
-          - { target: aarch64-apple-darwin, os: macos-15 }
-          - { target: x86_64-apple-darwin, os: macos-15 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          - {
-              target: x86_64-unknown-linux-musl,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
             }
           - {
               target: riscv64gc-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
               cargo-args: "--no-default-features",
             }
+          - { target: x86_64-apple-darwin, os: macos-15 }
+          - { target: x86_64-apple-ios, os: macos-15 }
           - { target: x86_64-pc-windows-gnu, os: windows-2022 }
           - { target: x86_64-pc-windows-msvc, os: windows-2022 }
           - {
@@ -586,6 +583,12 @@ jobs:
               os: ubuntu-22.04,
               use-cross: true,
               cross-version: v0.2.5,
+            }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - {
+              target: x86_64-unknown-linux-musl,
+              os: ubuntu-22.04,
+              use-cross: true,
             }
 
     steps:


### PR DESCRIPTION
After researching I found some targets like `ubuntu-20.04` has problem and i think kinda deprecated and some another release are not in our list
 
- Based on https://github.com/tessi/wasmex/blob/main/.github/workflows/release.yml

I tested the list inside my test repo and works! and I hope fixes the IgniterJs build

Thank you in advance