### PR TITLE
Update behaviour in preparation.ex

### DIFF
--- a/lib/ash/resource/preparation/preparation.ex
+++ b/lib/ash/resource/preparation/preparation.ex
@@ -109,7 +109,7 @@ defmodule Ash.Resource.Preparation do
               Ash.Query.t() | Ash.ActionInput.t()
   @callback supports(opts :: Keyword.t()) :: [module()]
 
-  @optional_callbacks init:1, supports:1
+  @optional_callbacks init: 1, supports: 1
 
   defmacro __using__(_) do
     quote do

--- a/lib/ash/resource/preparation/preparation.ex
+++ b/lib/ash/resource/preparation/preparation.ex
@@ -109,6 +109,8 @@ defmodule Ash.Resource.Preparation do
               Ash.Query.t() | Ash.ActionInput.t()
   @callback supports(opts :: Keyword.t()) :: [module()]
 
+  @optional_callbacks init:1, supports:1
+
   defmacro __using__(_) do
     quote do
       @behaviour Ash.Resource.Preparation


### PR DESCRIPTION
Since `init/1` and `supports/1` have default implementation they can be optional callbacks

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
