### PR TITLE
Update docs for preparation.ex

### DIFF
--- a/lib/ash/resource/preparation/preparation.ex
+++ b/lib/ash/resource/preparation/preparation.ex
@@ -5,7 +5,7 @@ defmodule Ash.Resource.Preparation do
   `c:init/1` is defined automatically by `use Ash.Resource.Preparation`, but can be implemented if you want to validate/transform any
   options passed to the module.
 
-  `c:supports/1` is also required and returns a list containing any of the following: `[Ash.Changeset, Ash.Query, Ash.ActionInput]`
+  `c:supports/1` is also required and returns a list containing any or all of the following: `[Ash.Changeset, Ash.Query, Ash.ActionInput]` based on what your `c:prepare/3` implementation supports
 
   The main function is `c:prepare/3`. It takes the query, any options that were provided
   when this preparation was configured on a resource, and the context, which currently only has


### PR DESCRIPTION
Based on what I could find this seems to be the valid returns for the `supports/1` callback?

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
