### PR TITLE
fix: make Ash.Type.Keyword.dump_to_native return a map

### DIFF
--- a/lib/ash/type/keyword.ex
+++ b/lib/ash/type/keyword.ex
@@ -157,7 +157,7 @@ defmodule Ash.Type.Keyword do
 
   def dump_to_native(value, _) do
     if Keyword.keyword?(value) do
-      {:ok, Keyword.new(value)}
+      {:ok, Map.new(value)}
     else
       :error
     end

--- a/test/type/keyword_test.exs
+++ b/test/type/keyword_test.exs
@@ -466,4 +466,23 @@ defmodule Type.KeywordTest do
     # The exact error messages may vary but we should have more than just the missing field
     assert length(errors) > 1
   end
+
+  test "dump_to_native converts keyword list to map" do
+    keyword_list = [foo: "bar", baz: 42]
+    assert Ash.Type.Keyword.dump_to_native(keyword_list, []) == {:ok, %{foo: "bar", baz: 42}}
+  end
+
+  test "dump_to_native handles nil" do
+    assert Ash.Type.Keyword.dump_to_native(nil, []) == {:ok, nil}
+  end
+
+  test "dump_to_native handles maps" do
+    map = %{foo: "bar", baz: 42}
+    assert Ash.Type.Keyword.dump_to_native(map, []) == {:ok, map}
+  end
+
+  test "dump_to_native returns error for invalid input" do
+    assert Ash.Type.Keyword.dump_to_native("invalid", []) == :error
+    assert Ash.Type.Keyword.dump_to_native(123, []) == :error
+  end
 end


### PR DESCRIPTION
Make Ash.Type.Keyword.dump_to_native return a map, as according to the spec.

Also added some regression tests.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
