### PR TITLE
Add another example to `has_one`

### DIFF
--- a/documentation/topics/resources/relationships.md
+++ b/documentation/topics/resources/relationships.md
@@ -142,6 +142,22 @@ attribute on `MyApp.Profile` is `:user_id`.
 A `has_one` is similar to a `belongs_to` except the reference attribute is on
 the destination resource, instead of the source.
 
+`has_one` is specially useful when trying to load only one of a `has_many`. For example, to load the latest tweet.
+
+```elixir
+# on MyApp.User
+has_many :tweets, MyApp.Tweet
+
+has_one :latest_tweet, MyApp.Tweet do
+  sort inserted_at: :desc
+end
+
+# then load it
+iex> Ash.get!(User, 1, load: [:latest_tweet])
+# %User{id: 1, latest_tweet: %Tweet{id: 23}}
+
+```
+
 #### Attribute Defaults
 
 By default, the `source_attribute` is assumed to be `:id`, and


### PR DESCRIPTION
I got a bit excited about how easy it was to get the latest of something. I feel it's my duty to tell the others.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
