### PR TITLE
fix: avoid crashing on new exception

### DIFF
--- a/lib/ash/error/invalid/no_such_input.ex
+++ b/lib/ash/error/invalid/no_such_input.ex
@@ -2,7 +2,7 @@ defmodule Ash.Error.Invalid.NoSuchInput do
   @moduledoc "Used when an input is provided to an action or calculation that is not accepted"
 
   use Splode.Error,
-    fields: [:calculation, :resource, :action, :input, :inputs, did_you_mean: []],
+    fields: [:calculation, :resource, :action, :input, inputs: [], did_you_mean: []],
     class: :invalid
 
   def exception(opts) do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

`opts[:inputs]` is expected to be a list at line 12.
It makes some calls to exception/1 crash, which end up showing a cryptic error msg instead of the exception.
