### PR TITLE
Fix usage of Ash.Notifier.requires_original_data/2 in VerifyActionsAtomic

### DIFF
--- a/lib/ash/resource/verifiers/verify_actions_atomic.ex
+++ b/lib/ash/resource/verifiers/verify_actions_atomic.ex
@@ -71,7 +71,7 @@ defmodule Ash.Resource.Verifiers.VerifyActionsAtomic do
           dsl
           |> Ash.Resource.Info.notifiers()
           |> Enum.filter(fn notifier ->
-            notifier.requires_original_data?(module, action.name)
+            notifier.requires_original_data?(module, action)
           end)
           |> case do
             [] ->


### PR DESCRIPTION
Fixes https://github.com/ash-project/ash/issues/2326

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
