### PR TITLE
Fix with_transaction bug in Mnesia data layer

### DIFF
--- a/lib/ash/data_layer/mnesia/mnesia.ex
+++ b/lib/ash/data_layer/mnesia/mnesia.ex
@@ -445,7 +445,7 @@ defmodule Ash.DataLayer.Mnesia do
                Ash.DataLayer.Mnesia.Info.table(resource),
                pkey,
                values,
-               opts[:with_transaction]
+               Keyword.get(opts, :with_transaction, true)
              ) do
           # If with_transaction is false, we are in a transaction and will only return :ok
           :ok ->
@@ -466,7 +466,7 @@ defmodule Ash.DataLayer.Mnesia do
   # This allows for writing to Mnesia without a transaction in case one was
   # started elsewhere. This was explicitly created for `bulk_create/3`.
   defp do_write(table, pkey, values, with_transaction) do
-    if with_transaction do
+    if with_transaction && !Mnesia.is_transaction() do
       Mnesia.transaction(fn ->
         Mnesia.write({table, pkey, values})
       end)

--- a/test/ash/data_layer/mnesia_test.exs
+++ b/test/ash/data_layer/mnesia_test.exs
@@ -58,8 +58,11 @@ defmodule Ash.DataLayer.MnesiaTest do
 
   describe "create/2" do
     test "it creates a user" do
+      resource = MnesiaTestUser
       user = %{name: "John", age: 30, title: "Developer", roles: [:admin, :user]}
-      assert {:ok, created_user} = Ash.create(MnesiaTestUser, user)
+
+      assert {:ok, created_user} =
+               MnesiaDataLayer.create(resource, Ash.Changeset.for_create(resource, :create, user))
 
       assert %MnesiaTestUser{
                id: _,


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

When I moved the `with_transaction` in the Mnesia DataLayer to kw opts, I did not add a default value. It was not caught in the test because `Ash.create`, must be wrapping it already. I added a default value and also changed the test to use `Ash.DataLayer.Mnesia.create/2` directly.

One other thing I noticed while working through some of the Mnesia stuff is that the pkey is a List and the values are a single value in Mnesia that is wrapped in a Map. I assume this is not intentional, but wanted to check before I started working on it. It would be a backward incompatible change to move to proper Mnesia fields. Happy to have this conversation elsewhere too. ✌️ 