### PR TITLE
fix: Incorrect return type checking for generic action hooks

### DIFF
--- a/documentation/topics/advanced/reactor.md
+++ b/documentation/topics/advanced/reactor.md
@@ -25,7 +25,7 @@ Notes:
 
 - Every Reactor input must have a corresponding action argument.
 - Ash's action context is passed in as the Reactor's context (including things like actor, tenant, etc).
-- [Reactor runtime options](`t:Reactor.options/0`) can be set by setting `run {MyReactor, opts}` instead of just `run MyReactor`.
+- [Reactor runtime options](`t:Reactor.run_options/0`) can be set by setting `run {MyReactor, opts}` instead of just `run MyReactor`.
 - If you set the `transaction?` action DSL option to true then the Reactor will be run synchronously - regardless of the value of the `async?` runtime option.
 
 ### Example

--- a/test/actions/generic_actions_test.exs
+++ b/test/actions/generic_actions_test.exs
@@ -588,6 +588,18 @@ defmodule Ash.Test.Actions.GenericActionsTest do
 
       assert result == "Processed: test_first_second"
     end
+
+    test "after_action hook works with untyped action (no return value)" do
+      result =
+        Post
+        |> Ash.ActionInput.for_action(:untyped_without_value, %{})
+        |> Ash.ActionInput.after_action(fn _input, nil ->
+          :ok
+        end)
+        |> Ash.run_action!()
+
+      assert result == :ok
+    end
   end
 
   describe "full lifecycle integration on generic actions" do
@@ -1032,6 +1044,33 @@ defmodule Ash.Test.Actions.GenericActionsTest do
         end)
         |> Ash.run_action!()
       end
+    end
+
+    test "after_transaction hook works with untyped action (no return value)" do
+      result =
+        Post
+        |> Ash.ActionInput.for_action(:untyped_without_value, %{})
+        |> Ash.ActionInput.after_transaction(fn _input, :ok ->
+          :ok
+        end)
+        |> Ash.run_action!()
+
+      assert result == :ok
+    end
+
+    test "around_transaction hook works with untyped action (no return value)" do
+      result =
+        Post
+        |> Ash.ActionInput.for_action(:untyped_without_value, %{})
+        |> Ash.ActionInput.around_transaction(fn input, callback ->
+          case callback.(input) do
+            :ok -> :ok
+            error -> error
+          end
+        end)
+        |> Ash.run_action!()
+
+      assert result == :ok
     end
   end
 end


### PR DESCRIPTION
Generic action after_action, after_transaction and around_transaction hooks were not correctly validating return types for generic actions with no return type.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
