### PR TITLE
fix: Ash.Query.after_transaction result argument issues.

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -769,12 +769,12 @@ defmodule Ash.Actions.Read do
                     {:ok, results, count, calculations_at_runtime, calculations_in_query, query}
                   else
                     other ->
-                      handle_failed_query(other, notify_callback, query)
+                      handle_failed_query(other, notify_callback)
                   end
                 end)
               else
                 other ->
-                  handle_failed_query(other, notify_callback, query)
+                  handle_failed_query(other, notify_callback)
               end
             end)
 
@@ -801,11 +801,11 @@ defmodule Ash.Actions.Read do
 
   defp ensure_task_stopped(_, fun), do: fun.()
 
-  defp handle_failed_query(result, notify_callback, query) do
+  defp handle_failed_query(result, notify_callback) do
     case result do
       {%{valid?: false} = query, before_notifications} ->
         notify_callback.(query, before_notifications)
-        {{:error, query}, query}
+        {:error, query}
 
       {{:error, %Ash.Query{} = query}, _} ->
         {:error, query}
@@ -814,13 +814,13 @@ defmodule Ash.Actions.Read do
         {:error, Ash.Query.add_error(query, error)}
 
       {:ok, %Ash.Query{valid?: false} = query} ->
-        {{:error, query}, query}
+        {:error, query}
 
       %Ash.Query{} = query ->
-        {{:error, query}, query}
+        {:error, query}
 
       {:error, error} ->
-        {{:error, error}, query}
+        {:error, error}
     end
   end
 

--- a/test/actions/read_test.exs
+++ b/test/actions/read_test.exs
@@ -1397,13 +1397,11 @@ defmodule Ash.Test.Actions.ReadTest do
           result
         end)
 
-      results = Ash.read!(query, action: :in_transaction)
-
+      author_id = author.id
+      [%{id: ^author_id}] = Ash.read!(query, action: :in_transaction)
       {resource, result_tuple} = Agent.get(agent, & &1)
       assert resource == Author
-      assert {:ok, _, _, _, _, _} = result_tuple
-      assert length(results) == 1
-      assert List.first(results).id == author.id
+      assert {:ok, [%{id: ^author_id}]} = result_tuple
     end
 
     test "after_transaction hook can modify the result" do
@@ -1412,10 +1410,9 @@ defmodule Ash.Test.Actions.ReadTest do
       query =
         Author
         |> Ash.Query.filter(name == "Test")
-        |> Ash.Query.after_transaction(fn _query,
-                                          {:ok, results, count, calc_runtime, calc_query, query} ->
+        |> Ash.Query.after_transaction(fn _query, {:ok, results} ->
           modified_results = Enum.map(results, &Map.put(&1, :__metadata__, :modified))
-          {:ok, modified_results, count, calc_runtime, calc_query, query}
+          {:ok, modified_results}
         end)
 
       results = Ash.read!(query, action: :in_transaction)


### PR DESCRIPTION
Fixes issues where the after_transaction callbacks are being passed arguments that don't match the typespec of `t:Ash.Query.after_transaction_fun/0`. 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
