### PR TITLE
fix: extended context collision prevention to all bulk operation types

### DIFF
--- a/lib/ash/actions/bulk_manual_action_helpers.ex
+++ b/lib/ash/actions/bulk_manual_action_helpers.ex
@@ -1,6 +1,60 @@
 defmodule Ash.Actions.BulkManualActionHelpers do
   @moduledoc """
-    Helper functions used for handling manual actions when used in bulk operations.
+  Helper functions used for handling manual actions when used in bulk operations.
+
+  This module provides utilities for managing bulk operation context and metadata,
+  with special emphasis on preventing context collisions in nested bulk operations.
+
+  ## Context Collision Prevention
+
+  Bulk operations use namespaced context keys to prevent collisions when operations
+  are nested. Instead of simple atoms like `:bulk_create`, the system uses tuples
+  like `{:bulk_create, ref}` where `ref` is a unique reference.
+
+  ## Examples
+
+  ### Basic Usage in Manual Actions
+
+      def bulk_create(changesets, _opts, _context) do
+        Enum.map(changesets, fn changeset ->
+          # Extract the index for ordering
+          index = BulkManualActionHelpers.get_changeset_index(changeset, :bulk_create)
+          
+          # Extract both index and metadata key for record tagging
+          {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+          
+          case create_record(changeset) do
+            {:ok, record} ->
+              # Tag the record with its bulk operation metadata
+              {:ok, Ash.Resource.put_metadata(record, metadata_key, index)}
+            error ->
+              error
+          end
+        end)
+      end
+
+  ### Nested Bulk Operations
+
+  The namespaced keys prevent context collisions in scenarios like:
+
+      def bulk_create(changesets, _opts, _context) do
+        Enum.map(changesets, fn changeset ->
+          # This nested bulk_create won't interfere with the parent operation
+          Ash.bulk_create!([%{related_field: "value"}], RelatedResource, :create)
+          
+          # Parent operation context remains intact
+          {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+          create_and_tag_record(changeset, index, metadata_key)
+        end)
+      end
+
+  ## Key Functions
+
+  - `extract_bulk_metadata/2` - Gets both index and metadata key
+  - `get_changeset_index/2` - Gets only the index (convenience function)
+  - `get_changeset_metadata_key/2` - Gets only the metadata key (convenience function)
+  - `create_bulk_operation_keys/1` - Creates namespaced context and metadata keys
+  - `pair_changesets_with_results/3` - Matches results back to changesets
   """
 
   @doc """
@@ -100,11 +154,89 @@ defmodule Ash.Actions.BulkManualActionHelpers do
 
   Returns a tuple of `{index, metadata_key}` for the bulk operation.
   """
-  def extract_bulk_metadata(changeset, bulk_action_type \\ :bulk_update) do
+  # Handles context_key tuples from bulk operations
+  def extract_bulk_metadata(changeset, {bulk_action_type, _ref}) do
+    extract_bulk_metadata(changeset, bulk_action_type)
+  end
+
+  # Handles atoms from simple operations
+  def extract_bulk_metadata(changeset, bulk_action_type) when is_atom(bulk_action_type) do
     changeset.context
     |> Enum.find_value(fn
       {{^bulk_action_type, ref}, value} -> {value.index, {:"#{bulk_action_type}_index", ref}}
       _ -> nil
     end)
+  end
+
+  @doc """
+  Creates unique namespaced keys for bulk operations to prevent collisions between
+  nested operations. The context key stores operation data during processing,
+  while the metadata key is attached to records for later index-based lookup.
+
+  Returns `{context_key, metadata_key}` tuple.
+  """
+  def create_bulk_operation_keys(action_type) do
+    ref = make_ref()
+
+    case action_type do
+      :create ->
+        {{:bulk_create, ref}, {:bulk_create_index, ref}}
+
+      :update ->
+        {{:bulk_update, ref}, {:bulk_update_index, ref}}
+
+      :destroy ->
+        {{:bulk_destroy, ref}, {:bulk_destroy_index, ref}}
+    end
+  end
+
+  @doc """
+  Finds the bulk operation index value from a record's metadata, searching through
+  all possible namespaced metadata keys for the given bulk action type.
+  """
+  def get_bulk_index(record, bulk_action_type \\ :bulk_update) do
+    metadata_atom = :"#{bulk_action_type}_index"
+
+    record.__metadata__
+    |> Enum.find_value(fn
+      {{^metadata_atom, _ref}, index} -> index
+      _ -> nil
+    end)
+  end
+
+  @doc """
+  Creates changeset-record pairs from results by looking up changesets using bulk indexes.
+  Used by after-batch processing that needs to match records back to their original changesets.
+  """
+  def pair_changesets_with_results(results, changesets_by_index, metadata_key) do
+    bulk_action_type =
+      case metadata_key do
+        {:bulk_create_index, _} -> :bulk_create
+        {:bulk_update_index, _} -> :bulk_update
+        {:bulk_destroy_index, _} -> :bulk_destroy
+      end
+
+    Enum.map(results, fn result ->
+      index = get_bulk_index(result, bulk_action_type)
+      {changesets_by_index[index], result}
+    end)
+  end
+
+  @doc """
+  Extracts only the bulk operation index from a changeset context.
+  Convenience function for when only the index is needed.
+  """
+  def get_changeset_index(changeset, bulk_action_type) do
+    {index, _} = extract_bulk_metadata(changeset, bulk_action_type)
+    index
+  end
+
+  @doc """
+  Extracts only the metadata key from a changeset context.
+  Convenience function for when only the metadata key is needed.
+  """
+  def get_changeset_metadata_key(changeset, bulk_action_type) do
+    {_, metadata_key} = extract_bulk_metadata(changeset, bulk_action_type)
+    metadata_key
   end
 end

--- a/lib/ash/actions/helpers.ex
+++ b/lib/ash/actions/helpers.ex
@@ -2,6 +2,7 @@ defmodule Ash.Actions.Helpers do
   @moduledoc false
   require Logger
   require Ash.Flags
+  alias Ash.Actions.BulkManualActionHelpers
 
   @keep_read_action_loads_when_loading? Application.compile_env(
                                           :ash,
@@ -59,7 +60,8 @@ defmodule Ash.Actions.Helpers do
           all_changes
           |> Enum.flat_map(fn
             {%{change: {mod, change_opts}} = change, change_index} ->
-              index = changeset.context |> Map.get(context_key) |> Map.get(:index)
+              index =
+                BulkManualActionHelpers.get_changeset_index(changeset, context_key)
 
               applicable = changes[change_index]
 

--- a/lib/ash/data_layer/mnesia/mnesia.ex
+++ b/lib/ash/data_layer/mnesia/mnesia.ex
@@ -37,6 +37,7 @@ defmodule Ash.DataLayer.Mnesia do
     sections: [@mnesia],
     verifiers: [Ash.DataLayer.Verifiers.RequirePreCheckWith]
 
+  alias Ash.Actions.BulkManualActionHelpers
   alias Ash.Actions.Sort
   alias :mnesia, as: Mnesia
 
@@ -354,10 +355,16 @@ defmodule Ash.DataLayer.Mnesia do
           {:ok, result} ->
             result =
               if options[:return_records?] do
+                {index, metadata_key} =
+                  BulkManualActionHelpers.extract_bulk_metadata(
+                    changeset,
+                    :bulk_create
+                  )
+
                 Ash.Resource.put_metadata(
                   result,
-                  :bulk_create_index,
-                  changeset.context.bulk_create.index
+                  metadata_key,
+                  index
                 )
               else
                 result
@@ -405,10 +412,16 @@ defmodule Ash.DataLayer.Mnesia do
           {:ok, result} ->
             result =
               if options[:return_records?] do
+                {index, metadata_key} =
+                  BulkManualActionHelpers.extract_bulk_metadata(
+                    changeset,
+                    :bulk_create
+                  )
+
                 Ash.Resource.put_metadata(
                   result,
-                  :bulk_create_index,
-                  changeset.context.bulk_create.index
+                  metadata_key,
+                  index
                 )
               else
                 result

--- a/lib/ash/data_layer/simple/simple.ex
+++ b/lib/ash/data_layer/simple/simple.ex
@@ -6,6 +6,7 @@ defmodule Ash.DataLayer.Simple do
   by embedded resources, and resources without data layers.
   """
 
+  alias Ash.Actions.BulkManualActionHelpers
   use Spark.Dsl.Extension, transformers: [], sections: []
 
   @behaviour Ash.DataLayer
@@ -162,13 +163,16 @@ defmodule Ash.DataLayer.Simple do
       Enum.reduce_while(stream, {:ok, []}, fn changeset, {:ok, acc} ->
         case Ash.Changeset.apply_attributes(changeset) do
           {:ok, applied} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
             {:cont,
              {:ok,
               [
                 Ash.Resource.put_metadata(
                   applied,
-                  :bulk_create_index,
-                  changeset.context.bulk_create.index
+                  metadata_key,
+                  index
                 )
                 | acc
               ]}}

--- a/test/actions/bulk/bulk_create_manual_test.exs
+++ b/test/actions/bulk/bulk_create_manual_test.exs
@@ -2,6 +2,7 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
   @moduledoc false
   use ExUnit.Case, async: false
 
+  alias Ash.Actions.BulkManualActionHelpers
   alias Ash.Test.Actions.BulkCreateManualTest.Helpers
   alias Ash.Test.Domain, as: Domain
 
@@ -31,21 +32,27 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
         create(changeset, module_opts, create_ctx)
         |> case do
           {:ok, record} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
             record =
               Ash.Resource.put_metadata(
                 record,
-                :bulk_create_index,
-                changeset.context.bulk_create.index
+                metadata_key,
+                index
               )
 
             [{:ok, record} | results]
 
           {:ok, record, notifications} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
             record =
               Ash.Resource.put_metadata(
                 record,
-                :bulk_create_index,
-                changeset.context.bulk_create.index
+                metadata_key,
+                index
               )
 
             [{:ok, record, notifications} | results]
@@ -75,21 +82,27 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
         create(changeset, module_opts, create_ctx)
         |> case do
           {:ok, record} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
             record =
               Ash.Resource.put_metadata(
                 record,
-                :bulk_create_index,
-                changeset.context.bulk_create.index
+                metadata_key,
+                index
               )
 
             [{:ok, record} | results]
 
           {:ok, record, notifications} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
             record =
               Ash.Resource.put_metadata(
                 record,
-                :bulk_create_index,
-                changeset.context.bulk_create.index
+                metadata_key,
+                index
               )
 
             [{:ok, record, %{notifications: notifications}} | results]
@@ -119,11 +132,14 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
         create(changeset, module_opts, create_ctx)
         |> case do
           {:ok, record} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
             record =
               Ash.Resource.put_metadata(
                 record,
-                :bulk_create_index,
-                changeset.context.bulk_create.index
+                metadata_key,
+                index
               )
 
             [{:ok, record} | results]
@@ -195,6 +211,54 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
     end
   end
 
+  defmodule CreateManualWithNested do
+    use Ash.Resource.ManualCreate
+    alias Ash.Actions.BulkManualActionHelpers
+
+    def create(changeset, _module_opts, ctx) do
+      opts = Helpers.build_create_opts(ctx)
+
+      changeset.resource
+      |> Ash.Changeset.for_create(:create, Map.take(changeset.attributes, [:name]), opts)
+      |> Ash.create(opts)
+    end
+
+    def bulk_create(changesets, module_opts, ctx) do
+      create_ctx = Helpers.build_create_ctx(ctx)
+
+      Enum.reduce(changesets, [], fn changeset, results ->
+        # Trigger a nested bulk_create to test context collision prevention
+        Ash.bulk_create!(
+          [%{name: "nested"}],
+          Ash.Test.Actions.BulkCreateManualTest.Author,
+          :create,
+          return_records?: false,
+          authorize?: false
+        )
+
+        create(changeset, module_opts, create_ctx)
+        |> case do
+          {:ok, record} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
+            [{:ok, record} | results]
+
+          {:ok, record, notifications} ->
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_create)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
+            [{:ok, record, notifications} | results]
+
+          {:error, error} ->
+            [{:error, error} | results]
+        end
+      end)
+    end
+  end
+
   defmodule Author do
     @moduledoc false
     use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
@@ -230,6 +294,11 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
       create :create_manual_ok do
         accept [:name]
         manual CreateManualOk
+      end
+
+      create :create_manual_with_nested do
+        accept [:name]
+        manual CreateManualWithNested
       end
 
       create :create do
@@ -459,5 +528,19 @@ defmodule Ash.Test.Actions.BulkCreateManualTest do
     assert Enum.empty?(result.records)
     assert result.notifications == nil
     assert result.error_count == 1
+  end
+
+  test "bulk_create manual action with nested bulk operation causes context collision" do
+    result =
+      [%{name: "Author1"}, %{name: "Author2"}]
+      |> Ash.bulk_create(Author, :create_manual_with_nested,
+        return_errors?: true,
+        return_records?: true,
+        return_notifications?: false
+      )
+
+    # This test should fail due to context collision in the current implementation
+    assert Enum.count(result.records) == 2
+    assert result.error_count == 0
   end
 end

--- a/test/actions/bulk/bulk_destroy_manual_test.exs
+++ b/test/actions/bulk/bulk_destroy_manual_test.exs
@@ -2,6 +2,7 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
   @moduledoc false
   use ExUnit.Case, async: false
 
+  alias Ash.Actions.BulkManualActionHelpers
   alias Ash.Test.Actions.BulkDestroyManualTest.Helpers
   alias Ash.Test.Domain, as: Domain
 
@@ -34,22 +35,18 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
             [:ok | results]
 
           {:ok, record} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record} | results]
 
           {:ok, record, notifications} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record, notifications} | results]
 
@@ -81,22 +78,18 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
             [:ok | results]
 
           {:ok, record} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record} | results]
 
           {:ok, record, notifications} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record, %{notifications: notifications}} | results]
 
@@ -128,22 +121,18 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
             [:ok | results]
 
           {:ok, record} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record} | results]
 
           {:ok, record, _notifications} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record} | results]
 
@@ -175,12 +164,10 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
             [:ok | results]
 
           {:ok, record} ->
-            record =
-              Ash.Resource.put_metadata(
-                record,
-                :bulk_destroy_index,
-                changeset.context.bulk_destroy.index
-              )
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_destroy)
+
+            record = Ash.Resource.put_metadata(record, metadata_key, index)
 
             [{:ok, record} | results]
 

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -201,6 +201,57 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
 
       destroy :forbidden_destroy do
       end
+
+      destroy :destroy_with_nested_bulk_create do
+        require_atomic? false
+
+        change after_action(fn changeset, result, context ->
+                 Ash.bulk_create!([%{title: "nested_post"}], Post, :create,
+                   notify?: true,
+                   return_records?: false,
+                   tenant: changeset.tenant,
+                   authorize?: false
+                 )
+
+                 {:ok, result}
+               end)
+      end
+
+      destroy :destroy_with_nested_bulk_update do
+        require_atomic? false
+
+        change after_action(fn changeset, result, context ->
+                 other_posts = Post |> Ash.read!(tenant: changeset.tenant, authorize?: false)
+
+                 other_posts
+                 |> Enum.take(2)
+                 |> Ash.bulk_update!(:update, %{title2: "nested_update"},
+                   notify?: true,
+                   return_records?: false,
+                   authorize?: false
+                 )
+
+                 {:ok, result}
+               end)
+      end
+
+      destroy :destroy_with_nested_bulk_destroy do
+        require_atomic? false
+
+        change after_action(fn changeset, result, context ->
+                 other_posts = Post |> Ash.read!(tenant: changeset.tenant, authorize?: false)
+
+                 other_posts
+                 |> Enum.take(1)
+                 |> Ash.bulk_destroy!(:destroy, %{},
+                   notify?: true,
+                   return_records?: false,
+                   authorize?: false
+                 )
+
+                 {:ok, result}
+               end)
+      end
     end
 
     identities do
@@ -830,6 +881,59 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
                )
 
       assert [%Post{title: "Related 1"}, %Post{title: "Related 2"}] = post.related_posts
+    end
+  end
+
+  describe "nested bulk operations" do
+    setup do
+      posts =
+        Ash.bulk_create!(
+          [%{title: "setup1"}, %{title: "setup2"}, %{title: "setup3"}],
+          Post,
+          :create,
+          return_stream?: true,
+          return_records?: true,
+          authorize?: false
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      {:ok, %{posts: posts}}
+    end
+
+    test "supports bulk_create in after_action callbacks", %{posts: posts} do
+      post_to_destroy = List.first(posts)
+
+      assert %Ash.BulkResult{} =
+               Ash.bulk_destroy!([post_to_destroy], :destroy_with_nested_bulk_create, %{},
+                 notify?: true,
+                 return_records?: false,
+                 authorize?: false,
+                 strategy: [:stream]
+               )
+    end
+
+    test "supports bulk_update in after_action callbacks", %{posts: posts} do
+      post_to_destroy = List.first(posts)
+
+      assert %Ash.BulkResult{} =
+               Ash.bulk_destroy!([post_to_destroy], :destroy_with_nested_bulk_update, %{},
+                 notify?: true,
+                 return_records?: false,
+                 authorize?: false,
+                 strategy: [:stream]
+               )
+    end
+
+    test "supports bulk_destroy in after_action callbacks", %{posts: posts} do
+      [post_to_destroy | _] = posts
+
+      assert %Ash.BulkResult{} =
+               Ash.bulk_destroy!([post_to_destroy], :destroy_with_nested_bulk_destroy, %{},
+                 notify?: true,
+                 return_records?: false,
+                 authorize?: false,
+                 strategy: [:stream]
+               )
     end
   end
 end

--- a/test/actions/bulk/bulk_update_manual_test.exs
+++ b/test/actions/bulk/bulk_update_manual_test.exs
@@ -32,12 +32,16 @@ defmodule Ash.Test.Actions.BulkUpdateManualTest do
         update(changeset, module_opts, update_ctx)
         |> case do
           {:ok, record} ->
-            {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset)
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_update)
+
             record = Ash.Resource.put_metadata(record, metadata_key, index)
             [{:ok, record} | results]
 
           {:ok, record, notifications} ->
-            {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset)
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_update)
+
             record = Ash.Resource.put_metadata(record, metadata_key, index)
             [{:ok, record, notifications} | results]
 
@@ -67,12 +71,16 @@ defmodule Ash.Test.Actions.BulkUpdateManualTest do
         update(changeset, module_opts, update_ctx)
         |> case do
           {:ok, record} ->
-            {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset)
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_update)
+
             record = Ash.Resource.put_metadata(record, metadata_key, index)
             [{:ok, record} | results]
 
           {:ok, record, notifications} ->
-            {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset)
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_update)
+
             record = Ash.Resource.put_metadata(record, metadata_key, index)
             [{:ok, record, %{notifications: notifications}} | results]
 
@@ -102,12 +110,16 @@ defmodule Ash.Test.Actions.BulkUpdateManualTest do
         update(changeset, module_opts, update_ctx)
         |> case do
           {:ok, record} ->
-            {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset)
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_update)
+
             record = Ash.Resource.put_metadata(record, metadata_key, index)
             [{:ok, record} | results]
 
           {:ok, record, _notifications} ->
-            {index, metadata_key} = BulkManualActionHelpers.extract_bulk_metadata(changeset)
+            {index, metadata_key} =
+              BulkManualActionHelpers.extract_bulk_metadata(changeset, :bulk_update)
+
             record = Ash.Resource.put_metadata(record, metadata_key, index)
             [{:ok, record} | results]
 


### PR DESCRIPTION
and added some convenience helpers

As requested here, https://github.com/ash-project/ash/pull/2353#issuecomment-3374737225

its a bit more extensive, added bulk_destroy whilst at it. But tried to keep it to a minimum with some extra tests

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
