### PR TITLE
Fix bypass field policy with condition

### DIFF
--- a/test/support/policy_field/resources/ticket.ex
+++ b/test/support/policy_field/resources/ticket.ex
@@ -55,6 +55,10 @@ defmodule Ash.Test.Support.PolicyField.Ticket do
   field_policies do
     private_fields :hide
 
+    field_policy_bypass :*, actor_attribute_equals(:role, :admin) do
+      authorize_if true
+    end
+
     field_policy :status do
       authorize_if relates_to_actor_via(:representative)
       authorize_if relates_to_actor_via(:reporter)


### PR DESCRIPTION
# Changes

Fixes application of field policies that contain a bypass with entry conditions.

Fiexes: https://github.com/ash-project/ash/actions/runs/18414010761/job/52473216042

```
** (Ash.Error.Framework) 
Bread Crumbs:
  > Exception raised in: GF.Event.read> Exception raised in: GF.Attendee.read

Framework Error

* Assumption failed: FieldPolicy conditions should always be true. Condition:

"actor.__struct__ == GF.Member"

This should not be possible, please report a detailed bug at:

https://github.com/ash-project/ash/issues/new?assignees=&labels=bug%2C+needs+review&template=bug_report.md&title=

  (ash 3.6.2) lib/ash/error/framework/assumption_failed.ex:3: Ash.Error.Framework.AssumptionFailed.exception/1
  (ash 3.6.2) lib/ash/policy/policy.ex:75: anonymous fn/2 in Ash.Policy.Policy.expression/1
  (ash 3.6.2) lib/ash/policy/policy.ex:50: Ash.Policy.Policy.expression/1
  (ash 3.6.2) lib/ash/policy/policy.ex:151: Ash.Policy.Policy.build_requirements_expression/1
  (ash 3.6.2) lib/ash/policy/policy.ex:95: Ash.Policy.Policy.solve/1
  (ash 3.6.2) lib/ash/policy/checker.ex:65: Ash.Policy.Checker.strict_check_scenarios/1
  (ash 3.6.2) lib/ash/policy/authorizer/authorizer.ex:1732: Ash.Policy.Authorizer.strict_check_result/2
  (ash 3.6.2) lib/ash/policy/authorizer/authorizer.ex:1127: Ash.Policy.Authorizer.field_condition/5
  (ash 3.6.2) lib/ash/policy/authorizer/authorizer.ex:1081: Ash.Policy.Authorizer.expression_for_ref/6
  (ash 3.6.2) lib/ash/policy/authorizer/authorizer.ex:1005: Ash.Policy.Authorizer.replace_refs/2
  (ash 3.6.2) lib/ash/policy/authorizer/authorizer.ex:971: Ash.Policy.Authorizer.replace_refs/2
  (ash 3.6.2) lib/ash/policy/authorizer/authorizer.ex:727: Ash.Policy.Authorizer.alter_filter/3
  (ash 3.6.2) lib/ash/can.ex:495: Ash.Can.alter_query/5
  (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
  (ash 3.6.2) lib/ash.ex:1812: Ash.can/3
  (ash 3.6.2) lib/ash/actions/read/read.ex:2053: Ash.Actions.Read.authorize_query/2
  (ash 3.6.2) lib/ash/actions/read/read.ex:583: Ash.Actions.Read.do_read/5
  (ash 3.6.2) lib/ash/actions/read/read.ex:432: Ash.Actions.Read.do_run/3
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
