### PR TITLE
docs(validation): replace `:attribute` with `:field` in the example

### DIFF
--- a/documentation/topics/resources/validations.md
+++ b/documentation/topics/resources/validations.md
@@ -67,10 +67,10 @@ defmodule MyApp.Validations.IsPrime do
 
   @impl true
   def init(opts) do
-    if opts[:attribute] != nil && is_atom(opts[:attribute]) do
+    if opts[:field] != nil && is_atom(opts[:field]) do
       {:ok, opts}
     else
-      {:error, "attribute must be an atom!"}
+      {:error, "field must be an atom!"}
     end
   end
 
@@ -79,13 +79,13 @@ defmodule MyApp.Validations.IsPrime do
 
   @impl true
   def validate(changeset, opts, _context) do
-    value = Ash.Changeset.get_attribute(changeset, opts[:attribute])
+    value = Ash.Changeset.get_attribute(changeset, opts[:field])
     # this is a function I made up for example
     if is_nil(value) || Math.is_prime?(value) do
       :ok
     else
       # The returned error will be passed into `Ash.Error.to_ash_error/3`
-      {:error, field: opts[:attribute], message: "must be prime"}
+      {:error, field: opts[:field], message: "must be prime"}
     end
   end
 end
@@ -109,12 +109,12 @@ defmodule MyApp.Validations.ValidEmail do
 
   @impl true
   def validate(subject, opts, _context) do
-    value = get_value(subject, opts[:attribute])
+    value = get_value(subject, opts[:field])
     
     if is_nil(value) || valid_email?(value) do
       :ok
     else
-      {:error, field: opts[:attribute], message: "must be a valid email"}
+      {:error, field: opts[:field], message: "must be a valid email"}
     end
   end
 
@@ -259,19 +259,19 @@ defmodule MyApp.Validations.IsPrime do
     # lets ignore that there is no easy/built-in way to check prime numbers in postgres
     {:atomic,
       # the list of attributes that are involved in the validation
-      [opts[:attribute]],
+      [opts[:field]],
       # the condition that should cause the error
       # here we refer to the new value or the current value
-      expr(not(fragment("is_prime(?)", ^atomic_ref(opts[:attribute])))),
+      expr(not(fragment("is_prime(?)", ^atomic_ref(opts[:field])))),
       # the error expression
       expr(
         error(^InvalidAttribute, %{
-          field: ^opts[:attribute],
+          field: ^opts[:field],
           # the value that caused the error
-          value: ^atomic_ref(opts[:attribute]),
+          value: ^atomic_ref(opts[:field]),
           # the message to display
           message: ^(context.message || "%{field} must be prime"),
-          vars: %{field: ^opts[:attribute]}
+          vars: %{field: ^opts[:field]}
         })
       )
     }


### PR DESCRIPTION
The `opts` list contains a key named `field`, not `attribute`


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
