### PR TITLE
temporarily hide new functions for release

### DIFF
--- a/lib/ash/policy/policy.ex
+++ b/lib/ash/policy/policy.ex
@@ -39,6 +39,10 @@ defmodule Ash.Policy.Policy do
   defguardp is_expression_check(term)
             when not is_expression_operation(term) and not is_boolean(term)
 
+  # Temporarily making this private so that the function can be changed without
+  # a major version bump in the SAT refactoring PR.
+  # TODO: Make public with #2375 
+  @doc false
   @spec expression(policies :: t() | FieldPolicy.t() | [t() | FieldPolicy.t()]) ::
           SatSolver.boolean_expr(Check.ref())
   def expression(policies) do

--- a/lib/sat_solver/sat_solver.ex
+++ b/lib/sat_solver/sat_solver.ex
@@ -487,13 +487,10 @@ defmodule Ash.SatSolver do
     b(not (left and not right))
   end
 
-  @doc """
-  Generates random boolean expressions for property-based testing.
-
-  Uses StreamData.tree to create recursive boolean expressions with the provided
-  leaf generator for terminal values. Automatically includes boolean constants (true/false)
-  alongside the provided inner generator.
-  """
+  # Temporarily making this private so that the function can be moved without
+  # a major version bump in the SAT refactoring PR.
+  # TODO: Make public with #2375 
+  @doc false
   @spec generate_expression(StreamData.t(term())) :: StreamData.t(boolean_expr())
   def generate_expression(inner_generator) do
     inner_generator = StreamData.one_of([StreamData.boolean(), inner_generator])


### PR DESCRIPTION
Some of the new & unreleased functions will change in the SAT Refactor PR. Hiding them for now to prevent breaking changes / neccesary deprecations.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
