### PR TITLE
refactor: remove the extra nil check in do_arguments

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -6087,22 +6087,17 @@ defmodule Ash.Changeset do
                Ash.Type.include_source(argument.type, changeset, argument.constraints),
              {:ok, casted} <-
                Ash.Type.cast_input(argument.type, value, constraints),
-             {:constrained, {:ok, casted}, _last_val} when not is_nil(casted) <-
-               {:constrained, Ash.Type.apply_constraints(argument.type, casted, constraints),
-                casted} do
+             {{:ok, casted}, _last_val}  <-
+                {Ash.Type.apply_constraints(argument.type, casted, constraints), casted} do
           %{changeset | arguments: Map.put(changeset.arguments, argument.name, casted)}
           |> store_casted_argument(argument.name, casted, store_casted?)
         else
-          {:constrained, {:ok, nil}, _} ->
-            %{changeset | arguments: Map.put(changeset.arguments, argument.name, nil)}
-            |> store_casted_argument(argument.name, nil, store_casted?)
-
-          {:constrained, {:error, error}, last_val} ->
-            add_invalid_errors(value, :argument, changeset, argument, error)
-            |> store_casted_argument(argument.name, last_val, store_casted?)
-
           {:error, error} ->
             add_invalid_errors(value, :argument, changeset, argument, error)
+
+          {{:error, error}, last_val} ->
+            add_invalid_errors(value, :argument, changeset, argument, error)
+            |> store_casted_argument(argument.name, last_val, store_casted?)
         end
       else
         %{changeset | arguments: Map.put(changeset.arguments, argument, value)}


### PR DESCRIPTION
Both when changing or force_changing attributes apply_constraints is called with `nil`, this makes the behaviour more consistent.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
