### PR TITLE
fix: reuse type constraints when matching relationship records

### DIFF
--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -1727,7 +1727,7 @@ defmodule Ash.Actions.ManagedRelationships do
 
         if field == relationship.destination_attribute do
           if is_struct(input) do
-            do_matches?(current_value, input, field, attr.type)
+            do_matches?(current_value, input, field, attr.type, attr.constraints)
           else
             # We know that it will be the same as all other records in this relationship
             # (because that's how has_one and has_many relationships work), so we
@@ -1735,22 +1735,22 @@ defmodule Ash.Actions.ManagedRelationships do
             true
           end
         else
-          do_matches?(current_value, input, field, attr.type)
+          do_matches?(current_value, input, field, attr.type, attr.constraints)
         end
       end)
     else
       Enum.all?(pkey, fn field ->
         attr = Ash.Resource.Info.attribute(relationship.destination, field)
-        do_matches?(current_value, input, field, attr.type)
+        do_matches?(current_value, input, field, attr.type, attr.constraints)
       end)
     end
   end
 
-  defp do_matches?(current_value, input, field, type) do
+  defp do_matches?(current_value, input, field, type, constraints) do
     with {:ok, current_val} when not is_nil(current_val) <- Map.fetch(current_value, field),
          {:ok, input_val} when not is_nil(input_val) <- fetch_field(input, field),
-         {:ok, current_val} <- Ash.Type.cast_input(type, current_val),
-         {:ok, input_val} <- Ash.Type.cast_input(type, input_val) do
+         {:ok, current_val} <- Ash.Type.cast_input(type, current_val, constraints),
+         {:ok, input_val} <- Ash.Type.cast_input(type, input_val, constraints) do
       Ash.Type.equal?(type, current_val, input_val)
     else
       _ ->


### PR DESCRIPTION
> **Disclaimer:** I used AI to find the cause of this bug (not the bug itself), but I manually verified and tested the fix in my own application. The following description is also written by me.

I tried to use `manage_relationship` to manage the many-to-many relationship between users and teams. Note that we use AshUUID with prefixes as PK.

```elixir
defmodule User do
  attributes do
    uuid_attribute :id, prefix: "user"
  end

  relationships do
    many_to_many :teams, Team do
      through UserTeam
      source_attribute_on_join_resource :user_id
      destination_attribute_on_join_resource :team_id
    end
  end

  update :remove_teams do
    require_atomic? false
    argument :teams_to_remove, {:array, :term}, allow_nil?: false
    change manage_relationship(:teams_to_remove, :teams, type: :remove)
  end
end
```

```elixir
defmodule Team do
  attributes do
    uuid_attribute :id, prefix: "team"
  end
end
```

```elixir
defmodule UserTeam do
  relationships do
    belongs_to :user, User, primary_key?: true, allow_nil?: false
    belongs_to :team, Team, primary_key?: true, allow_nil?: false
  end
end
```

When using the `remove_teams` action, I got the following error:

```
09:00:45.743 pid=<0.5089.0> [error] Failed to remove team from user: %Ash.Error.Invalid{bread_crumbs: ["Error returned from: MyApp.Accounts.User.remove_teams"],  changeset: "#Changeset<>",  errors: [%Ash.Error.Changes.InvalidRelationship{relationship: :teams, message: "changes would create a new related record", splode: Ash.Error, bread_crumbs: ["Error returned from: MyApp.Accounts.User.remove_teams"], vars: [], path: [], stacktrace: #Splode.Stacktrace<>, class: :invalid}]}
```

The problem was caused when trying to match existing records without providing the `prefix:` constraint required by `AshUUID` when casting primary keys for comparing:

1. For `AshUUID.UUID` with `prefix: "team"`, the ID is stored as `"team_031KkLD7BuWTaorAtkev86"`
2. Calling `Ash.Type.cast_input(AshUUID.UUID, "team_031KkLD7BuWTaorAtkev86")` **without constraints** fails with `{:error, "got invalid prefixed term"}`
3. Since the cast fails without constraints, matching fails, `find_match` returns `nil`, and with `on_no_match: :error`, the error is triggered

I'm sorry for not adding any tests, but I could not find an easy way to test this in the Ash codebase 😕

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
