### PR TITLE
fix: evaluate action_type earlier in the simplify phase to enable short-circuit evaluation

### DIFF
--- a/lib/ash/policy/check/action_type.ex
+++ b/lib/ash/policy/check/action_type.ex
@@ -6,8 +6,6 @@ defmodule Ash.Policy.Check.ActionType do
   @moduledoc "This check is true when the action type matches the provided type"
   use Ash.Policy.SimpleCheck
 
-  import Crux.Expression, only: [b: 1]
-
   @impl true
   def describe(options) do
     {operator, type} =
@@ -25,16 +23,8 @@ defmodule Ash.Policy.Check.ActionType do
   end
 
   @impl true
-  def simplify({__MODULE__, options}, _context) do
-    case List.wrap(options[:type]) do
-      [] ->
-        false
-
-      [_ | _] = multiple_types ->
-        multiple_types
-        |> Enum.map(&{__MODULE__, Keyword.put(options, :type, [&1])})
-        |> Enum.reduce(&b(&2 or &1))
-    end
+  def simplify({__MODULE__, options}, context) do
+    context.action.type in options[:type]
   end
 
   @impl true

--- a/lib/ash/policy/policy.ex
+++ b/lib/ash/policy/policy.ex
@@ -352,8 +352,8 @@ defmodule Ash.Policy.Policy do
   end
 
   @spec check_context(authorizer :: Authorizer.t()) :: Check.context()
-  defp check_context(%Authorizer{resource: resource}) do
-    %{resource: resource}
+  defp check_context(%Authorizer{resource: resource, action: action}) do
+    %{resource: resource, action: action}
   end
 
   @spec expand_invariants(


### PR DESCRIPTION
`action_type` wasn’t being evaluated early enough. Even when the action was already known, the policy would still attempt to evaluate all checks — even when the action type didn’t match.

For example, with the following policy (which worked fine in 3.6.2 but broke afterward):

```elixir
policy action_type([:create, :update]) do
  authorize_if AshStateMachine.Checks.ValidNextState
end
```

When running a read action, `action_type` wouldn’t immediately evaluate to false. As a result, the expression `action_type([:create, :update]) and ValidNextState` remained as-is, and `ValidNextState` was still evaluated even though the action type didn’t match. Since `ValidNextState.filter/3` only works with changesets, this caused a FunctionClauseError when called with a query.

With this change, `action_type` evaluates to false immediately for read actions, causing the entire expression to become false, and `ValidNextState` is skipped.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
