### PR TITLE
fix: ensure tenant fallback to `changeset.tenant` in managed relationships

### DIFF
--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -46,7 +46,7 @@ defmodule Ash.Actions.ManagedRelationships do
               Enum.any?(relationships, fn {_, opts} -> opts[:authorize?] end)
 
           actor = engine_opts[:actor]
-          tenant = engine_opts[:tenant]
+          tenant = engine_opts[:tenant] || changeset.tenant
 
           case Ash.load(acc, key,
                  authorize?: authorize?,


### PR DESCRIPTION
Updates the tenant assignment in managed relationships to use `changeset.tenant` as a fallback when `engine_opts[:tenant]` is not provided. This ensures the correct tenant context is used during relationship management.

### Problem Scenario

Imagine a multi-tenant system where you have a generic action executed by a **master user**. In this action, the tenant is manually assigned to the `changeset`.

Under normal circumstances, everything works fine. However, when using **Ash events** or **manage_relationship**, the tenant context doesn’t propagate correctly.

For example:

* `BlogPost` → works fine
* `Tag` → returns `tenant: nil` (without Ash events, it correctly receives the tenant from `BlogPost`)
* `BlogTag` → cannot access the tenant defined in `BlogPost`, so it performs no action

#### Example

In the `BlogPost` resource, we have an update action:

```elixir
update :update do
  primary? true
  require_atomic? false
  transaction? true
  accept @admin_fields |> List.delete(:site_id)

  argument :tag_ids, {:array, :uuid}, description: "List of tag IDs to assign to this section"

  change slugify(:slug, into: :slug, ignore: [".", "!", "?"])
  change manage_relationship(:tag_ids, :tags,
            type: :append_and_remove,
            on_no_match: :error,
            on_match: :ignore
          )

  change fn changeset, context ->
    Ash.Changeset.put_context(changeset, :ash_events_metadata, %{
      site_id: context.tenant || changeset.data.site_id,
      title: Ash.Changeset.get_attribute(changeset, :title) || changeset.data.title
    })
  end
end
```

Now, we want to define a **generic action** for master users (who have no `site_id` and use a `nil` tenant):

```elixir
action :master_update, :struct do
  description "Updates section for master users - requires nil tenant context"
  constraints instance_of: MishkaDocument.Section

  argument :id, :uuid, allow_nil?: false
  argument :tag_ids, {:array, :uuid}

  run fn input, _context ->
    id = input.arguments.id

    case Ash.get(MishkaDocument.Section, id, action: :master_get, authorize?: false) do
      {:ok, record} ->
        tenant = record.site_id

        record
        |> Ash.Changeset.for_update(:update, input.arguments, tenant: tenant, authorize?: false)
        |> Ash.update()

      _ ->
        {:error, Ash.Error.Query.NotFound.exception(resource: MishkaDocument.Section)}
    end
  end
end
```

Here, the tenant is manually set via:

```elixir
Ash.Changeset.for_update(:update, input.arguments, tenant: tenant, authorize?: false)
```

However, when the `Tag` resource triggers its `read` action, it receives `tenant: nil`, resulting in the following warning:

```
[warning] AshJsonApi.Error not implemented for error:
(Ash.Error.Invalid.TenantRequired)
> Error returned from: MishkaDocument.Tag.public_list
> Error returned from: MishkaDocument.Section.read
> Error returned from: MishkaDocument.Section.update

Queries against the MishkaDocument.Tag resource require a tenant to be specified
```

### Solution

With this small update, we ensure that when `engine_opts[:tenant]` is not set, the system falls back to `changeset.tenant`.
Since this happens at the final stage of processing, it won’t be overridden later (or at least, that’s the intended behavior).

> Consider it happens when we set `update` action  in `only_actions` for `AshEevents`  and it uses 
```elixir
  data_layer = Ash.Resource.Info.data_layer(changeset.resource)
  data_layer.update(changeset.resource, changeset)
```

For more discussion, see the reference thread on Discord:
🔗 [https://discord.com/channels/711271361523351632/1433938883040772279](https://discord.com/channels/711271361523351632/1433938883040772279)


---

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
