### PR TITLE
feat: keep tenant in query when using :bypass and :bypass_all

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -2653,12 +2653,12 @@ defmodule Ash.Actions.Read do
         {:ok, handle_attribute_multitenancy(query)}
 
       :bypass ->
-        {:ok, %{query | tenant: nil, to_tenant: nil}}
+        {:ok, query}
 
       :bypass_all ->
         query = Ash.Query.set_context(query, %{shared: %{multitenancy: :bypass_all}})
 
-        {:ok, %{query | tenant: nil, to_tenant: nil}}
+        {:ok, query}
     end
     |> case do
       {:ok, query} -> handle_aggregate_multitenancy(query)


### PR DESCRIPTION
With multitenancy the `:bypass` option does not apply the filter by tenant to the current query (and sub ressources with `:bypass_all`).

However, the options also set the tenant to `nil` in the query by overriding the given value (see https://github.com/ash-project/ash/blob/main/lib/ash/actions/read/read.ex#L2655-L2661)

I believe this behaviour confusing, as we might need the tenant anyway for other stuff like policies or to filter in a specific way. Here is two cases I have in mind:
- A policy that check the current actor has a membership to the tenant. With :bypass, or :bypass_all I do not have a tenant anymore in the query.
- A resource that might belongs to a tenant, or might be global (= no tenant). We would like to get ressource where the tenant equals the current tenant OR the tenant is nil. With :bypass, or :bypass_all we lost the tenant info, and we cannot filter. With :allow_global Ash adds an additionnal filter to scope by tenant, resulting in a (A or B) and A condition

This PR returns the query as is without defining the tenant to `nil`. All other tests stay green.

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Features include unit/acceptance tests
