### PR TITLE
Document uniqueness constraints for one-to-one relationships

### DIFF
--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -407,7 +407,7 @@ has_one name, destination
 
 Declares a `has_one` relationship. In a relational database, the foreign key would be on the *other* table.
 
-Generally speaking, a `has_one` also implies that the destination table is unique on that foreign key.
+Generally speaking, a `has_one` also implies that the destination table is unique on that foreign key. To add a uniqueness constraint, you will need to add an identity for the foreign key column on the resource which defines the `belongs_to` side of the relationship. See the [identities guide](/documentation/topics/resources/identities.md) to learn more.
 
 See the [relationships guide](/documentation/topics/resources/relationships.md) for more.
 

--- a/documentation/topics/resources/relationships.md
+++ b/documentation/topics/resources/relationships.md
@@ -164,6 +164,25 @@ iex> Ash.get!(User, 1, load: [:latest_tweet])
 
 ```
 
+#### Enforcing Uniqueness
+
+If you are modelling a true one-to-one relationship, you will need to use an identity to create the constraint.
+
+```elixir
+# on MyApp.User
+has_one :profile, MyApp.Profile
+
+# on MyApp.Profile
+belongs_to :user, MyApp.User
+
+identities do
+  # Creates a unique constraint on the `user_id` foreign key
+  identity :user_id, [:user_id]
+end
+```
+
+See the [identities guide](/documentation/topics/resources/identities.md) for more.
+
 #### Attribute Defaults
 
 By default, the `source_attribute` is assumed to be `:id`, and


### PR DESCRIPTION
This documents how to enforce uniqueness constraints when modelling one-to-one relationships.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
