### PR TITLE
fix: Trim triple newlines instead of double newlines

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -465,7 +465,7 @@ defmodule Ash.CodeInterface do
 
              #{interface_options.docs()}
              """
-             |> Ash.CodeInterface.trim_double_newlines()
+             |> Ash.CodeInterface.trim_triple_newlines()
         @doc spark_opts: [
                {opts_location, interface_options.schema()}
              ]
@@ -531,7 +531,7 @@ defmodule Ash.CodeInterface do
 
              #{interface_options.docs()}
              """
-             |> Ash.CodeInterface.trim_double_newlines()
+             |> Ash.CodeInterface.trim_triple_newlines()
         @doc spark_opts: [
                {opts_location, interface_options.schema()}
              ]
@@ -1651,7 +1651,7 @@ defmodule Ash.CodeInterface do
 
              #{interface_options.docs()}
              """
-             |> Ash.CodeInterface.trim_double_newlines()
+             |> Ash.CodeInterface.trim_triple_newlines()
 
         @doc spark_opts: [
                {first_opts_location, interface_options.schema()},
@@ -1683,7 +1683,7 @@ defmodule Ash.CodeInterface do
 
              #{interface_options.docs()}
              """
-             |> Ash.CodeInterface.trim_double_newlines()
+             |> Ash.CodeInterface.trim_triple_newlines()
 
         @doc spark_opts: [
                {first_opts_location, interface_options.schema()},
@@ -1728,7 +1728,7 @@ defmodule Ash.CodeInterface do
 
                #{Spark.Options.docs(subject_opts)}
                """
-               |> Ash.CodeInterface.trim_double_newlines()
+               |> Ash.CodeInterface.trim_triple_newlines()
           @doc spark_opts: [
                  {first_opts_location, subject_opts},
                  {first_opts_location + 1, subject_opts}
@@ -1754,7 +1754,7 @@ defmodule Ash.CodeInterface do
 
              #{Ash.Resource.Interface.CanOpts.docs()}
              """
-             |> Ash.CodeInterface.trim_double_newlines()
+             |> Ash.CodeInterface.trim_triple_newlines()
         @dialyzer {:nowarn_function, {:"can_#{interface.name}", length(common_args) + 3}}
         @doc spark_opts: [
                {first_opts_location + 1, Ash.Resource.Interface.CanOpts.schema()},
@@ -1842,7 +1842,7 @@ defmodule Ash.CodeInterface do
 
              #{Ash.Resource.Interface.CanQuestionMarkOpts.docs()}
              """
-             |> Ash.CodeInterface.trim_double_newlines()
+             |> Ash.CodeInterface.trim_triple_newlines()
         def unquote(:"can_#{interface.name}?")(
               actor,
               unquote_splicing(common_args),
@@ -2303,6 +2303,12 @@ defmodule Ash.CodeInterface do
   def trim_double_newlines(str) do
     str
     |> String.replace(~r/\n{2,}/, "\n")
+    |> String.trim_trailing()
+  end
+
+  def trim_triple_newlines(str) do
+    str
+    |> String.replace(~r/\n{3,}/, "\n\n")
     |> String.trim_trailing()
   end
 


### PR DESCRIPTION
Removing double newlines breaks formatting in e.g. the generated browser docs,
and breaks doctests, since they expect the example code sections to be separated
by the rest of the comments by double newlines.

Instead, we should focus on collapsing triple newlines, which can occur for
legitimate reasons, e.g. a section of the generated documentation doesn't return
any text, but which shouldn't be showed in the resulting documentation.

Fixes: #2433

I tried adding a regression test to `code_interface_test.exs` by adding the following, but it didn't work because `Code.fetch_docs` returned `{:error, :module_not_found}`:

```
  defmodule CalculationDocumentation do
    use Ash.Resource,
      data_layer: Ash.DataLayer.Ets,
      domain: Ash.Test.Domain

    attributes do
      attribute :foo, :string do
        public? true
      end
    end

    actions do
      defaults create: :*
    end

    calculations do
      calculate :foo_calculation, :boolean, expr(true) do
        description """
        Calculate a foo.

        This is hard to do.
        """
      end
    end

    code_interface do
      define_calculation :foo_calculation
    end
  end

  describe "documentation" do
    test "calculation code interface doc string doesn't strip double newlines" do
      generated_doc =
        Code.fetch_docs(CalculationDocumentation)
        |> dbg
        |> elem(6)
        |> Enum.find(&(elem(&1, 0) == {:function, :foo, 1}))
        |> elem(3)
        |> Map.fetch!("en")
        |> dbg

      assert String.contains?(generated_doc, """
             Calculate a foo.

             This is hard to do.
             """)
    end
  end
```

Any suggestions for a better way to test this would be greatly appreciated.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Edit: Updated to reflect this comment: https://github.com/ash-project/ash/issues/2433#issuecomment-3535480094