### PR TITLE
improvement: include context in inspect consistently

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -112,7 +112,7 @@ defmodule Ash.Changeset do
         if context == %{} do
           empty()
         else
-          concat("context: ", to_doc(context, opts))
+          concat("context: ", to_doc(Ash.Helpers.redact(context), opts))
         end
 
       tenant =

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -313,6 +313,8 @@ defmodule Ash.Query do
         | calculations: Ash.Actions.Read.Calculations.map_without_calc_deps(query.calculations)
       }
 
+      context = Map.delete(query.context, :private)
+
       sort? = query.sort != []
       distinct_sort? = query.distinct_sort != []
       load? = query.load != []
@@ -323,6 +325,7 @@ defmodule Ash.Query do
       filter? = not is_nil(query.filter)
       errors? = not Enum.empty?(query.errors)
       tenant? = not is_nil(query.tenant)
+      context? = query.context != %{}
       select? = query.select not in [[], nil]
       distinct? = query.distinct not in [[], nil]
       lock? = not is_nil(query.lock)
@@ -338,6 +341,7 @@ defmodule Ash.Query do
             not is_nil(query.action)
           ),
           or_empty(concat("tenant: ", to_doc(query.to_tenant, opts)), tenant?),
+          or_empty(concat("context: ", to_doc(Ash.Helpers.redact(context), opts)), context?),
           arguments(query, opts),
           # TODO: inspect these specially
           or_empty(

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -473,6 +473,26 @@ defmodule Ash.Test.Changeset.ChangesetTest do
     assert post.slug == "foo-bar"
   end
 
+  describe "inspect" do
+    test "empty map context is omitted" do
+      changeset =
+        Category
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.Changeset.set_context(%{})
+
+      refute inspect(changeset) =~ "context:"
+    end
+
+    test "nonempty map context is redacted" do
+      changeset =
+        Category
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.Changeset.set_context(%{secret: "value"})
+
+      assert inspect(changeset) =~ "context: \"**redacted**\""
+    end
+  end
+
   describe "new" do
     test "it wraps a new resource in a `create` changeset" do
       assert %Ash.Changeset{

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -66,6 +66,22 @@ defmodule Ash.Test.QueryTest do
       assert inspect(Ash.Query.new(User)) == "#Ash.Query<resource: Ash.Test.QueryTest.User>"
       assert inspect(Ash.Query.for_read(User, :by_id, %{id: "foobar"})) =~ "action: :by_id"
     end
+
+    test "empty map context is omitted" do
+      query = Ash.Query.new(User) |> Ash.Query.set_context(%{})
+
+      assert inspect(query) == "#Ash.Query<resource: Ash.Test.QueryTest.User>"
+    end
+
+    test "nonempty map context is redacted" do
+      query = Ash.Query.new(User) |> Ash.Query.set_context(%{secret: "value"})
+
+      # We show that there is a context present but redact its contents as it might be sensitive.
+      # During development the context can be inspected either by inspecting it directly or by
+      # enabling :show_sensitive? in the dev config.
+      assert inspect(query) ==
+               "#Ash.Query<resource: Ash.Test.QueryTest.User, context: \"**redacted**\">"
+    end
   end
 
   describe "read argument validation" do


### PR DESCRIPTION
# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Description

This came up when I was debugging (using `dbg()`) why my scope wasn't correctly propagated as `context` in my project. It took me a while to figure out that it was indeed correctly propagated but calling `dbg(query)` does not show whether or not there's a context or its contents.

My goal here is to save my future self and everyone else the time and frustration by putting the context into the `Inspect` implementation.

# Design Decisions

When I asked Zack if I could simply add it he was cautious and said it had been intentionally left out due to concerns about leaking sensitive data. A very valid concern given that `inspect` is often used for logging.

My primary goal is to show that there is a (non empty) context present, not necessarily what its contents are. If the content is important you can look at it by directly calling `dbg(query.context)` in any case.

There is already a config setting called `:show_sensitive?` which is used by the `Ash.Helpers.redact/1` function. I'm using this function if the context is non empty so it will show up as `context: "**redacted**"` by default, which gives enough of a clue that there is something present without potentially leaking something sensitive.

With the setting enabled it embeds the context as expected.

# Current Implementation and Consistency

While writing this PR I looked at other entities which are passed to callbacks and carry the context inside and how they handle inspect (mostly `Ash.Changeset` and `Ash.ActionInput`).

As far as I can tell there is no consistent logic being applied. For example one implementation removes the `:privat` key from context but embeds it without redacting anything. The one in `Ash.Query` omits it fully and in `Ash.ActionInput` there's no custom `Inspect` so it seems to just show everything as it is.

I don't want to stray too far from my original goal but if you think it's worthwhile to have a consistent logic behind all of these structs, then we can discuss what the "spec" looks like and I'll try to implement that.

What I've tried to implement so far is this:
Structs passed to callbacks which contain a `:context` map should
  - not include `context` in their `Inspect` output if the context is empty
  - include `context: "**redacted**"` if the context is non empty if `:show_sensitive?` is false (default)
  - include `context: ` with all keys except `:private` embedded if `:show_sensitive?` is true
  - use `Ash.Helpers.redact/1` where applicable for the above

Sorry for the wall of text and thanks for reading it anyway! 😄

# References

* [Related problem and Zack's response in Discord](https://discord.com/channels/711271361523351632/1437804402504372285)