### PR TITLE
fix: Update typespec for deprecated `can/3` on domain

### DIFF
--- a/lib/ash/domain/interface.ex
+++ b/lib/ash/domain/interface.ex
@@ -46,7 +46,11 @@ defmodule Ash.Domain.Interface do
               actor :: term,
               opts :: Keyword.t()
             ) ::
-              {:ok, boolean | :maybe} | {:error, term}
+              {:ok, boolean | :maybe}
+              | {:ok, true, Ash.Changeset.t() | Ash.Query.t()}
+              | {:ok, true, Ash.Changeset.t(), Ash.Query.t()}
+              | {:ok, false, Exception.t()}
+              | {:error, term}
       def can(action_or_query_or_changeset, actor, opts \\ []) do
         opts = Keyword.put(opts, :domain, __MODULE__)
         Ash.can(action_or_query_or_changeset, actor, opts)


### PR DESCRIPTION
I seems like 2f5fefa92109ec1000ac661bb67bd6523e46ef05 added this typespec to `Ash.can/3`, but this function wasn't updated.

Fixes: #2442


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
