### PR TITLE
fix: handle empty list in Ash.Filter.parse_and_join/3

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -4708,6 +4708,8 @@ defmodule Ash.Filter do
 
   defp add_to_ref_path(other, _), do: other
 
+  defp parse_and_join([], _op, _context), do: {:ok, true}
+
   defp parse_and_join([statement | statements], op, context) do
     case parse_expression(statement, context) do
       {:ok, nested_expression} ->

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -1213,4 +1213,40 @@ defmodule Ash.Test.Filter.FilterTest do
              |> Ash.Query.filter_input(%{embedded_bio: %{at_path: [:title], eq: "Dr."}})
              |> Ash.read!()
   end
+
+  describe "empty filter lists" do
+    setup do
+      post1 =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "title1", contents: "contents1", points: 1})
+        |> Ash.create!()
+        |> strip_metadata()
+
+      post2 =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "title2", contents: "contents2", points: 2})
+        |> Ash.create!()
+        |> strip_metadata()
+
+      %{post1: post1, post2: post2}
+    end
+
+    test "filtering with an empty 'or' list does not crash", %{post1: post1, post2: post2} do
+      query =
+        Post
+        |> Ash.Query.filter(or: [])
+        |> Ash.read!()
+
+      assert [post1, post2] = query
+    end
+
+    test "filtering with an empty 'and' list does not crash", %{post1: post1, post2: post2} do
+      query =
+        Post
+        |> Ash.Query.filter(and: [])
+        |> Ash.read!()
+
+      assert [post1, post2] = query
+    end
+  end
 end


### PR DESCRIPTION
 ## Summary

  - Fix `FunctionClauseError` crash when using `Ash.Query.filter(or: [])` or `Ash.Query.filter(and: [])`
  - Add clause to handle empty lists by returning `{:ok, true}` (identity element for boolean operations)

  ## Root Cause

  `Ash.Filter.parse_and_join/3` didn't have a clause to handle empty lists, only:
  - Non-empty lists: `[statement | statements]`
  - Maps: `when is_map(statement) and not is_struct(statement)`

  ## Real-world Scenario

  This occurs when using `Ash.bulk_create/4` with AshPostgres data layer, `upsert?: true` and `return_skipped_upsert?: true`. When all
  records are successfully inserted (none are skipped due to upsert conditions), [`AshPostgres.DataLayer.bulk_create/3`](https://github.com/ash-project/ash_postgres/blob/cb2c8cbbeea32822c37f4ea7ba072ad081d48032/lib/data_layer.ex#L2065) builds a filter with `or: []` to fetch
   skipped records, which triggers the crash:

```
  ** (FunctionClauseError) no function clause matching in Ash.Filter.parse_and_join/3
      (ash 3.9.0) lib/ash/filter/filter.ex:4711: Ash.Filter.parse_and_join([], :or, %{...})
```


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
