### PR TITLE
fix: dont validate constraints in union_types

### DIFF
--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -149,10 +149,7 @@ defmodule Ash.Type.Union do
          """
        end
 
-       schema = Ash.Type.constraints(type)
-       constraints = Spark.Options.validate!(config[:constraints] || [], schema)
-
-       {key, config |> Keyword.put(:constraints, constraints) |> Keyword.put(:type, type)}
+       {key, config |> Keyword.put(:type, type)}
      end)}
   end
 


### PR DESCRIPTION
Remove call to `Spark.Options.validate!/2` inside `Ash.Type.Union.union_types/1`. It is unnecessary and it causes an issue when attempting to define unions using NewTypes whose parents have `required: true` in their constraints.

Add in two test cases in the union type's tests:

1. Checks that we can define and use a union with the mentioned definition.
2. Ensures that nothing was lost when we removed the call to `Spark.Options.validate!/2` by demonstrating that the constraints are still checked when defining a resource using a union with the mentioned definition.

These tests fail to compile/run without the fix.

Fixes https://github.com/ash-project/ash/issues/2468

--------

### Extra notes

I believe removing this call to `validate!` is fine. However it did used to modify the constraints by adding in default values, e.g if `type` was `Ash.Type.String`, the call to `validate!` would return constraints with `[trim?: true, allow_empty?: false]` before adding them to the final result from `union_types`. But this seems to not be necessary as when the type is fully initialized it will include those constraints anyways. (I could add a test case to show this if wanted)

The problem with keeping the `validate!` call, is that with NewTypes `validate!` is expecting to receive their applied constraints as well. I think we could do this by calling `Ash.Type.init/2` like so:

```elixir
schema = Ash.Type.constraints(type)

{:ok, constraints} = Ash.Type.init(type, config[:constraints] || [])
constraints = Spark.Options.validate!(constraints, schema)

{key, config |> Keyword.put(:constraints, constraints) |> Keyword.put(:type, type)}
```

But I think it'd just be more preferable to remove the `validate!` call altogether since it seems unnecessary.

I may be missing some considerations there though, so please scrutinize this!

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
