### PR TITLE
fix: respect `read_action` option in cascade_update/cascade_destroy fallback path

### DIFF
--- a/lib/ash/resource/change/cascade_update.ex
+++ b/lib/ash/resource/change/cascade_update.ex
@@ -238,16 +238,28 @@ defmodule Ash.Resource.Change.CascadeUpdate do
         )
 
       :error ->
+        read_action_name =
+          opts.read_action || opts.relationship.read_action || opts.action.atomic_upgrade_with
+
+        load_query =
+          if read_action_name do
+            opts.relationship.destination
+            |> Ash.Query.for_read(read_action_name)
+            |> Ash.Query.set_context(%{
+              cascade_update: true,
+              accessing_from: %{source: relationship.source, name: relationship.name}
+            })
+          else
+            Ash.Query.set_context(relationship.destination, %{
+              cascade_update: true,
+              accessing_from: %{source: relationship.source, name: relationship.name}
+            })
+          end
+
         data
         |> List.wrap()
         |> Ash.load!(
-          [
-            {relationship.name,
-             Ash.Query.set_context(relationship.destination, %{
-               cascade_update: true,
-               accessing_from: %{source: relationship.source, name: relationship.name}
-             })}
-          ],
+          [{relationship.name, load_query}],
           tenant: tenant
         )
         |> Enum.flat_map(fn record ->

--- a/test/resource/changes/cascade_destroy_test.exs
+++ b/test/resource/changes/cascade_destroy_test.exs
@@ -54,10 +54,26 @@ defmodule Ash.Test.Resource.Change.CascadeDestroy do
                  action: :no_notification_destroy
                )
       end
+
+      destroy :destroy_tags_with_read_action do
+        require_atomic? false
+
+        change cascade_destroy(:tags,
+                 read_action: :custom_read,
+                 after_action?: false
+               )
+      end
     end
 
     relationships do
       has_many :posts, Test.Post, public?: true
+
+      many_to_many :tags, Test.Tag do
+        through Test.AuthorTag
+        source_attribute_on_join_resource :author_id
+        destination_attribute_on_join_resource :tag_id
+        public? true
+      end
     end
 
     code_interface do
@@ -65,6 +81,7 @@ defmodule Ash.Test.Resource.Change.CascadeDestroy do
       define :destroy
       define :destroy_with_atomic_upgrade
       define :no_notification_destroy
+      define :destroy_tags_with_read_action
       define :read
     end
   end
@@ -127,6 +144,64 @@ defmodule Ash.Test.Resource.Change.CascadeDestroy do
 
     relationships do
       belongs_to :author, Test.Author, public?: true, attribute_writable?: true
+    end
+
+    code_interface do
+      define :create
+      define :read
+    end
+  end
+
+  defmodule Tag do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    actions do
+      default_accept :*
+      defaults [:read, create: :*]
+
+      read :custom_read do
+        prepare fn query, _ ->
+          Agent.update(
+            Test.Agent,
+            &%{&1 | custom_read_used: true}
+          )
+
+          query
+        end
+      end
+
+      destroy :destroy do
+        primary? true
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+
+    code_interface do
+      define :create
+      define :read
+    end
+  end
+
+  defmodule AuthorTag do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    actions do
+      default_accept :*
+      defaults [:read, create: :*]
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+
+    relationships do
+      belongs_to :author, Test.Author, public?: true, attribute_writable?: true
+      belongs_to :tag, Test.Tag, public?: true, attribute_writable?: true
     end
 
     code_interface do
@@ -233,5 +308,20 @@ defmodule Ash.Test.Resource.Change.CascadeDestroy do
 
     assert [] = Post.read!()
     assert [] = Author.read!()
+  end
+
+  test "uses read_action option in fallback path for many_to_many relationships" do
+    author = Author.create!(%{})
+    tag1 = Tag.create!(%{})
+    tag2 = Tag.create!(%{})
+
+    AuthorTag.create!(%{author_id: author.id, tag_id: tag1.id})
+    AuthorTag.create!(%{author_id: author.id, tag_id: tag2.id})
+
+    Author.destroy_tags_with_read_action!(author)
+
+    assert Agent.get(Test.Agent, & &1.custom_read_used) == true
+
+    assert [] = Tag.read!()
   end
 end


### PR DESCRIPTION
## Summary

- Fixes `cascade_update` to use the `read_action` option in the fallback path when `related_query` returns `:error`
- Fixes `cascade_destroy` to use the `read_action` option in the fallback path when `related_query` returns `:error`

## Problem

When using `cascade_update` or `cascade_destroy` with the `read_action` option, the specified read action was ignored when `related_query/3` returns `:error`. This happens for:

1. `many_to_many` relationships
2. Relationships where the query contains a `parent_expr`

In these cases, the fallback path used `Ash.load!` with just the relationship name, ignoring any user-specified `read_action`.

## Solution

Modified both `CascadeUpdate` and `CascadeDestroy` to construct a query with the specified `read_action` when falling back to `Ash.load!`.

Closes #2473