### PR TITLE
fix: Ensure that calculations used in preparations have access to argument values

### DIFF
--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -511,6 +511,21 @@ defmodule Ash.Expr do
     end
   end
 
+  def walk_template(%Ash.Query.Calculation{opts: opts} = calc, mapper) do
+    case mapper.(calc) do
+      ^calc ->
+        new_opts =
+          Keyword.update(opts, :expr, nil, fn expr ->
+            walk_template(expr, mapper)
+          end)
+
+        %{calc | opts: new_opts}
+
+      other ->
+        walk_template(other, mapper)
+    end
+  end
+
   def walk_template(filter, mapper) when is_map(filter) do
     if Map.has_key?(filter, :__struct__) do
       filter


### PR DESCRIPTION
As reported on Discord - https://discord.com/channels/711271361523351632/1451166635997003899

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
