### PR TITLE
fix: handle struct context in atomic_condition

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1512,15 +1512,18 @@ defmodule Ash.Changeset do
   # to a `where` condition, the opposite is desired. The end result is kinda
   # ugly because it can end up reading like "not is not equal to" but
   # ultimately produces the correct results.
-  @spec atomic_condition([{module(), keyword()}], Ash.Changeset.t(), map()) ::
+  @spec atomic_condition([{module(), keyword()}], Ash.Changeset.t(), map() | struct()) ::
           {:atomic, Ash.Expr.t() | boolean()} | {:not_atomic, String.t()}
   def atomic_condition(where, changeset, context) do
+    # Handle both map and struct contexts (e.g., Ash.Resource.Change.Context)
+    context_map = if is_struct(context), do: Map.from_struct(context), else: context
+
     Enum.reduce_while(where, {:atomic, true}, fn {module, validation_opts},
                                                  {:atomic, condition_expr} ->
       case module.atomic(
              changeset,
              validation_opts,
-             struct(Ash.Resource.Validation.Context, context)
+             struct(Ash.Resource.Validation.Context, context_map)
            ) do
         :ok ->
           {:cont, {:atomic, condition_expr}}


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ✔️ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ✔️ ] Refactoring
- [ ] Update dependencies



- When `atomic_condition/3` is called from `hooks_and_calcs_for_update_query`
in `bulk.ex`, it receives an `Ash.Resource.Change.Context` struct rather than
a `map`. The `struct/2` function expects an `enumerable ` (`map` or keyword list),
but `structs` don't implement the `Enumerable` protocol, causing:

   ``` Protocol Enumerable not implemented for Ash.Resource.Change.Context ```

- This fix converts struct contexts to maps before passing them to `struct/2`,
allowing `atomic_condition` to work correctly with both map and struct
contexts.