### PR TITLE
Ensure generated users are not admins for the policy test

### DIFF
--- a/documentation/how-to/test-resources.livemd
+++ b/documentation/how-to/test-resources.livemd
@@ -242,7 +242,7 @@ defmodule ActionInvocationTest do
     end
 
     test "does not allow a user to update someone elses tweet" do
-      [user, user2] = generate_many(user(), 2)
+      [user, user2] = generate_many(user(admin?: false), 2)
       tweet = Domain.create_tweet!("Hello world!", actor: user)
 
       refute Domain.can_update_tweet?(user2, tweet, "Goodbye world!")


### PR DESCRIPTION
Occasionally the second user in this test will be an admin causing the test to fail, so we ensure both users are not admins when generating.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
