### PR TITLE
fix: many-to-many relationships should inherit the sort/limit from their join relationship

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -651,6 +651,15 @@ defmodule Ash.Actions.Read.Relationships do
             related_query.domain
           )
       )
+      |> Ash.Query.sort(join_relationship.sort)
+      |> Ash.Query.set_context(join_relationship.context)
+      |> then(fn q ->
+        if join_relationship.limit do
+          Ash.Query.limit(q, join_relationship.limit)
+        else
+          q
+        end
+      end)
 
     parent_stack = [
       query.resource | Ash.Actions.Read.parent_stack_from_context(query.context)


### PR DESCRIPTION
This fixes an issue where a has_many relationship could have a limit applied, but the many-to-many relationship would ignore that limit and instead load the full set of related records

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
