### PR TITLE
fix: aggregates to_tenant support

### DIFF
--- a/lib/ash/actions/aggregate.ex
+++ b/lib/ash/actions/aggregate.ex
@@ -93,18 +93,18 @@ defmodule Ash.Actions.Aggregate do
               results =
                 Enum.reduce_while(
                   [
-                    {bypass_aggs, query.tenant,
+                    {bypass_aggs,
                      Map.merge(query.context || %{}, %{
                        shared: %{private: %{multitenancy: :bypass_all}}
                      })},
-                    {tenant_aggs, query.tenant, query.context}
+                    {tenant_aggs, query.context}
                   ],
                   {:ok, %{}},
                   fn
-                    {[], _tenant, _context}, acc ->
+                    {[], _context}, acc ->
                       {:cont, acc}
 
-                    {aggs, tenant, context}, {:ok, results_acc} ->
+                    {aggs, context}, {:ok, results_acc} ->
                       with {:ok, data_layer_query} <-
                              Ash.Query.data_layer_query(%Ash.Query{
                                action: Ash.Resource.Info.action(query.resource, read_action),
@@ -115,9 +115,9 @@ defmodule Ash.Actions.Aggregate do
                                distinct_sort: query.distinct_sort,
                                sort: query.sort,
                                domain: query.domain,
-                               tenant: tenant,
+                               tenant: query.tenant,
                                filter: query.filter,
-                               to_tenant: tenant,
+                               to_tenant: query.to_tenant,
                                context: context
                              }),
                            {:ok, group_results} <-


### PR DESCRIPTION
In my project I was trying to do an `Ash.count!()` with a struct as `tenant` argument and it would fail with an error telling me the tenant struct doesn't implement `Strings.Chars` protocol, the issue being that `to_tenant` wasn't passed correctly, this fixes that.
I took the liberty to remove that `tenant` variable in the `reduce_while` as it seems it's always `query.tenant` and I couldn't understand why it exists.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
