### PR TITLE
feat: add load and loading? functions to ActionInput

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -852,6 +852,10 @@ defmodule Ash do
       type: {:wrap_list, {:or, [:atom, :string]}},
       doc:
         "A list of inputs that, if provided, will be ignored if they are not recognized by the action. Use `:*` to indicate all unknown keys."
+    ],
+    load: [
+      type: :any,
+      doc: "A load statement to apply on the resulting records after the action is invoked."
     ]
   ]
 

--- a/lib/ash/actions/helpers.ex
+++ b/lib/ash/actions/helpers.ex
@@ -732,6 +732,14 @@ defmodule Ash.Actions.Helpers do
     end
   end
 
+  def apply_opts_load(%Ash.ActionInput{} = input, opts) do
+    if opts[:load] do
+      Ash.ActionInput.load(input, opts[:load])
+    else
+      input
+    end
+  end
+
   def load({:ok, result, instructions}, changeset, domain, opts) do
     if changeset.load in [nil, []] do
       {:ok, result, instructions}

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -676,6 +676,7 @@ defmodule Ash.Changeset do
   - `select/3` for controlling which attributes are returned
   - `loading?/2` for checking if something is being loaded
   - `Ash.Query.load/2` for loading in queries
+  - `Ash.ActionInput.load/2` for loading in generic actions
   """
   @spec load(t(), term()) :: t()
   def load(changeset, load) do


### PR DESCRIPTION
Add support for loading attributes/calculations in generic actions similarly to non-generic actions.

- Add Ash.ActionInput.load/2
- Add :load option to Ash.run_action/2
- Add :load option to Ash.ActionInput.for_action/4
- Add Ash.ActionInput.loading?/2

The actual load occurs after the action runs (after the transaction if one was used), and it assumes that the result of the action is compatible with the given load statement.

Fixes #2316


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
