### PR TITLE
chore: fix warning in union tests

### DIFF
--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -727,7 +727,7 @@ defmodule Ash.Test.Filter.UnionTest do
 
   test "it fails when attempting to define a resource using a union with invalid constraints" do
     assert_raise Spark.Error.DslError, ~r/required :second option not found/, fn ->
-      defmodule FailingExample do
+      defmodule FailingExampleMissingSecond do
         use Ash.Resource, data_layer: :embedded
 
         attributes do
@@ -743,7 +743,7 @@ defmodule Ash.Test.Filter.UnionTest do
     end
 
     assert_raise Spark.Error.DslError, ~r/message: "first is too high!"/, fn ->
-      defmodule FailingExample do
+      defmodule FailingExampleFirstTooHigh do
         use Ash.Resource, data_layer: :embedded
 
         attributes do


### PR DESCRIPTION
Renames some example in-memory modules defined in union tests to avoid name conflicts in order to avoid a warning while testing

Fixes #2512


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
