### PR TITLE
fix: prevent lateral join handling for manual relationships

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -1503,6 +1503,11 @@ defmodule Ash.Actions.Read.Relationships do
         Map.get(relationship, :from_many?) ->
           true
 
+        Map.get(relationship, :manual) ->
+          # Manual relationships handle their own data fetching and return a map,
+          # not records with __lateral_join_source__ fields
+          false
+
         limit == 1 && is_nil(relationship.context) && is_nil(relationship.filter) &&
           is_nil(relationship.sort) && relationship.cardinality != :many ->
           has_parent_expr?(relationship, query.context, query.domain)


### PR DESCRIPTION
  Fix crash when loading manual relationships that have parent() or parent_expr() filters.

  Problem

  When a manual relationship has a parent() expression in its filter, has_parent_expr? returns true, causing lateral_join? to return true. This sets lateral_join_source context on the query.

  However, manual relationships handle their own data fetching via load/3 and return a map of {primary_key => [related_records]}, not records with __lateral_join_source__ fields. When do_attach_related_records tries to process this map using lateral join handling, it crashes with a KeyError.

  Proposed Fix

  Short-circuit lateral_join? to return false for manual relationships.

  **Discussion**

  This PR is a basis for discussion. An alternative approach might be better:

  - Should we instead add a compile-time verifier that warns when a manual relationship has a filter option? Filters don't make sense for manual relationships since they handle their own data fetching.
  - Is there a legitimate use case for filters on manual relationships that we need to support (e.g., for ash_postgres_subquery callbacks)?
  - If not, catching this at compile time would be more explicit than silently ignoring the filter at runtime.

  Interested in feedback on the preferred approach.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
