### PR TITLE
perf: Re-enables regex as mfa to improve regex speed

### DIFF
--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -207,6 +207,17 @@ defmodule Ash.Resource.Validation do
 
   @doc false
   def transform(%{validation: {module, opts}} = validation) do
+    opts =
+      Enum.map(opts, fn
+        {key, %Regex{} = value} when module == Ash.Resource.Validation.Match ->
+          source = Regex.source(value)
+          opts = Regex.opts(value)
+          {key, {Spark.Regex, :cache, [source, opts]}}
+
+        {key, value} ->
+          {key, value}
+      end)
+
     {:ok,
      %{
        validation

--- a/lib/ash/resource/validation/match.ex
+++ b/lib/ash/resource/validation/match.ex
@@ -17,7 +17,7 @@ defmodule Ash.Resource.Validation.Match do
       hide: true
     ],
     match: [
-      type: :regex,
+      type: :regex_as_mfa,
       required: true,
       doc: "The value that the attribute should match against"
     ],

--- a/lib/ash/type/ci_string.ex
+++ b/lib/ash/type/ci_string.ex
@@ -13,7 +13,7 @@ defmodule Ash.Type.CiString do
       doc: "Enforces a minimum length on the value"
     ],
     match: [
-      type: :regex,
+      type: :regex_as_mfa,
       doc: "Enforces that the string matches a passed in regex"
     ],
     trim?: [

--- a/lib/ash/type/string.ex
+++ b/lib/ash/type/string.ex
@@ -13,7 +13,7 @@ defmodule Ash.Type.String do
       doc: "Enforces a minimum length on the value"
     ],
     match: [
-      type: :regex,
+      type: :regex_as_mfa,
       doc: "Enforces that the string matches a passed in regex"
     ],
     trim?: [

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -167,7 +167,7 @@ defmodule Ash.Type do
       doc: "Enforces a minimum length on the value"
     ],
     match: [
-      type: :regex,
+      type: :regex_as_mfa,
       doc: "Enforces that the string matches a passed in regex"
     ],
     trim?: [type: :boolean, doc: "Trims the value.", default: true],


### PR DESCRIPTION
This PR basically partially reverts (partially because some of the old code doesn't make sense to move to the new one) this commit: https://github.com/ash-project/ash/commit/d77537dd03f7e31dc7a127a415a0a935be15043c

The reason is so that spark will cache the regex (even if you don't use mfa and just use regex directly). Without this cache, `:re.import` will be called multiple times during a cast of a resource with regexes matches in its attributes, resulting in a very expressive performance loss.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
