### PR TITLE
fix: set accessing_from context when reading action during relationship creation

### DIFF
--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -929,7 +929,11 @@ defmodule Ash.Actions.ManagedRelationships do
                   )
                   |> Ash.Query.filter(^keys)
                   |> sort_and_filter(relationship)
-                  |> Ash.Query.set_context(relationship.context)
+                  |> Ash.Query.set_context(
+                    Map.merge(relationship.context || %{}, %{
+                      accessing_from: %{source: relationship.source, name: relationship.name}
+                    })
+                  )
                   |> Ash.Query.limit(1)
                   |> Ash.read_one()
                 end

--- a/test/policy/accessing_from_test.exs
+++ b/test/policy/accessing_from_test.exs
@@ -1,0 +1,19 @@
+defmodule Ash.Test.Policy.AccessingFromTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Support.PolicyComplex.{Team, User}
+
+  require Logger
+
+  describe "many_to_many relationship" do
+    test "creates record via accessing_from" do
+      team = Ash.create!(Team, %{name: "Sports"}, authorize?: false)
+      team_id = team.id
+
+      assert {:ok, %{teams: [%{id: ^team_id}]}} =
+               User
+               |> Ash.Changeset.for_create(:with_teams, %{name: "Name", teams: [team_id]})
+               |> Ash.create(load: [:teams])
+    end
+  end
+end

--- a/test/support/policy_complex/domain.ex
+++ b/test/support/policy_complex/domain.ex
@@ -13,6 +13,8 @@ defmodule Ash.Test.Support.PolicyComplex.Domain do
     resource(Ash.Test.Support.PolicyComplex.Post)
     resource(Ash.Test.Support.PolicyComplex.Comment)
     resource(Ash.Test.Support.PolicyComplex.Bio)
+    resource(Ash.Test.Support.PolicyComplex.Team)
+    resource(Ash.Test.Support.PolicyComplex.Membership)
   end
 
   policies do

--- a/test/support/policy_complex/resources/team/membership.ex
+++ b/test/support/policy_complex/resources/team/membership.ex
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Support.PolicyComplex.Membership do
+  @moduledoc false
+  use Ash.Resource,
+    domain: Ash.Test.Support.PolicyComplex.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [
+      Ash.Policy.Authorizer
+    ]
+
+  alias Ash.Test.Support.PolicyComplex.{Team, User}
+
+  ets do
+    private?(true)
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  policies do
+    policy always() do
+      access_type :strict
+
+      authorize_if accessing_from(Team, :membership)
+      authorize_if accessing_from(User, :membership)
+      authorize_if accessing_from(User, :teams_join_assoc)
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+
+  relationships do
+    belongs_to :team, Team
+    belongs_to :user, User
+  end
+end

--- a/test/support/policy_complex/resources/team/team.ex
+++ b/test/support/policy_complex/resources/team/team.ex
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Support.PolicyComplex.Team do
+  @moduledoc false
+  use Ash.Resource,
+    domain: Ash.Test.Support.PolicyComplex.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [
+      Ash.Policy.Authorizer
+    ]
+
+  alias Ash.Test.Support.PolicyComplex.{Membership, User}
+
+  policies do
+    policy always() do
+      access_type :strict
+
+      authorize_if accessing_from(Membership, :team)
+      authorize_if accessing_from(User, :teams)
+    end
+  end
+
+  ets do
+    private?(true)
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+
+  relationships do
+    has_many :memberships, Membership
+
+    many_to_many :users, User do
+      through Membership
+    end
+  end
+end

--- a/test/support/policy_complex/resources/user/user.ex
+++ b/test/support/policy_complex/resources/user/user.ex
@@ -11,6 +11,8 @@ defmodule Ash.Test.Support.PolicyComplex.User do
       Ash.Policy.Authorizer
     ]
 
+  alias Ash.Test.Support.PolicyComplex.{Membership, Team}
+
   policies do
     # For testing we need to be able to read/create/update users
     policy action_type(:read) do
@@ -72,6 +74,17 @@ defmodule Ash.Test.Support.PolicyComplex.User do
       change set_attribute(:private_email, arg(:email))
     end
 
+    create :with_teams do
+      accept [:name]
+
+      argument :teams, {:array, :uuid} do
+        allow_nil? false
+        constraints min_length: 1
+      end
+
+      change manage_relationship(:teams, :teams, type: :append_and_remove)
+    end
+
     update :add_friend do
       accept []
 
@@ -123,6 +136,12 @@ defmodule Ash.Test.Support.PolicyComplex.User do
 
     has_one :bio, Ash.Test.Support.PolicyComplex.Bio do
       public?(true)
+    end
+
+    has_many :memberships, Membership
+
+    many_to_many :teams, Team do
+      through Membership
     end
   end
 end


### PR DESCRIPTION
Fixes some missing `accessing_from` context when querying a relationship during a resource creation.

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
