### PR TITLE
bugfix: Fix aggregate type resolution when aggregate references a calculation

### DIFF
--- a/lib/ash/domain/info/diagram.ex
+++ b/lib/ash/domain/info/diagram.ex
@@ -77,7 +77,7 @@ defmodule Ash.Domain.Info.Diagram do
     attribute =
       if aggregate.field do
         related = Ash.Resource.Info.related(resource, aggregate.relationship_path)
-        Ash.Resource.Info.attribute(related, aggregate.field)
+        Ash.Resource.Info.field(related, aggregate.field)
       end
 
     attribute_type =

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -532,7 +532,7 @@ defmodule Ash.Resource.Info do
     attribute =
       if aggregate.field do
         related = Ash.Resource.Info.related(resource, aggregate.relationship_path)
-        Ash.Resource.Info.attribute(related, aggregate.field)
+        Ash.Resource.Info.field(related, aggregate.field)
       end
 
     attribute_type =

--- a/lib/ash/sort/sort.ex
+++ b/lib/ash/sort/sort.ex
@@ -432,7 +432,7 @@ defmodule Ash.Sort do
     attribute =
       if aggregate.field do
         related = Ash.Resource.Info.related(resource, aggregate.relationship_path)
-        Ash.Resource.Info.attribute(related, aggregate.field)
+        Ash.Resource.Info.field(related, aggregate.field)
       end
 
     attribute_type =

--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -535,5 +535,12 @@ defmodule Ash.Test.Actions.AggregateTest do
 
       assert post.sum_of_doubled_thing3 == 36
     end
+
+    test "Info.aggregate_type returns correct type for aggregate referencing a calculation" do
+      # sum_of_doubled_thing3 references the doubled_thing3 calculation on Comment.
+      # Previously this returned {:ok, nil} because attribute/2 was used instead of field/2.
+      assert {:ok, Ash.Type.Integer} =
+               Ash.Resource.Info.aggregate_type(Post, :sum_of_doubled_thing3)
+    end
   end
 end


### PR DESCRIPTION
Came across this one while debugging a Cinder issue!

When an aggregate references a calculation (e.g., `first(:name, :rel, :calc_field)`), the type resolution was failing because `Ash.Resource.Info.attribute/2` was used instead of `Ash.Resource.Info.field/2`.

Since `attribute/2` only finds attributes (not calculations), it returned nil, causing crashes like `nil.embedded?/0` when sorting through a relationship path to such an aggregate.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
