### PR TITLE
Document :ash_domains configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ bar to find relevant reference information. Place the text `dsl` before your sea
 - [Reactor](documentation/topics/advanced/reactor.md)
 - [Combination Queries](documentation/topics/advanced/combination-queries.md)
 - [Timeouts](documentation/topics/advanced/timeouts.md)
+- [Manual Installation](documentation/topics/advanced/manual-installation.md)
 - [Writing Extensions](documentation/topics/advanced/writing-extensions.md)
 
 ---

--- a/documentation/topics/advanced/manual-installation.md
+++ b/documentation/topics/advanced/manual-installation.md
@@ -49,7 +49,7 @@ Update `.formatter.exs`:
 
 ## Skip protocol consolidation
 To avoid warnings about protocol consolidation when recompiling in dev, we
-set protocolc onsolidation to happen only in non-dev environments.
+set protocol consolidation to happen only in non-dev environments.
 
 ## Setup The Formatter
 Configure the DSL auto-formatter. This tells the formatter to remove excess parentheses
@@ -153,3 +153,19 @@ Update `config/config.exs`:
     formatter: [
 ...
 ```
+
+## Register Your Domains
+Ash relies on your application's `:ash_domains` configuration to find domain modules for
+mix tasks (diagrams, livebooks, policy charts) and to validate that domains/resources are
+registered at compile time.
+
+Add your domain modules to `config/config.exs`:
+
+```elixir
+config :my_app, :ash_domains, [
+  MyApp.Accounts,
+  MyApp.Helpdesk
+]
+```
+
+For more detail, see the [Domains guide](/documentation/topics/resources/domains.md#application-configuration-ash_domains).

--- a/documentation/topics/resources/domains.md
+++ b/documentation/topics/resources/domains.md
@@ -14,6 +14,23 @@ Domains serve three primary purposes:
 
 If you are familiar with a [Phoenix Context](https://hexdocs.pm/phoenix/contexts.html), you can think of a domain as the Ash equivalent.
 
+## Application Configuration (`:ash_domains`)
+
+Ash expects you to list your domain modules in your application config:
+
+```elixir
+config :my_app, :ash_domains, [MyApp.Tweets, MyApp.Billing]
+```
+
+This configuration is used for:
+
+- Mix tasks and tooling that need to load all domains (e.g. diagrams, livebooks, policy charts)
+- Compile-time validation that domains and resources are registered (the warnings shown by `use Ash.Domain` and `use Ash.Resource`)
+
+If you see warnings about missing domains or resources, it usually means this list is incomplete.
+You can add your domain modules here to resolve those warnings, or disable the validations if you
+prefer to manage it manually.
+
 ## Grouping Resources
 
 In an `Ash.Domain`, you will typically see something like this:


### PR DESCRIPTION
## Summary
Adds missing documentation for the `:ash_domains` application config option.

## Changes
- Add "Register Your Domains" section to Manual Installation guide
- Add `:ash_domains` explanation to Domains guide  
- Link Manual Installation from README Advanced section

Fixes #2351

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
