### PR TITLE
fix: pass full context to `Ash.load!` in cascade changes

### DIFF
--- a/lib/ash/resource/change/cascade_destroy.ex
+++ b/lib/ash/resource/change/cascade_destroy.ex
@@ -346,8 +346,7 @@ defmodule Ash.Resource.Change.CascadeDestroy do
           |> List.wrap()
           |> Ash.load!(
             [{relationship.name, load_query}],
-            scope: context,
-            authorize?: false
+            scope: context
           )
           |> Enum.flat_map(fn record ->
             record

--- a/lib/ash/resource/change/cascade_update.ex
+++ b/lib/ash/resource/change/cascade_update.ex
@@ -260,8 +260,7 @@ defmodule Ash.Resource.Change.CascadeUpdate do
         |> List.wrap()
         |> Ash.load!(
           [{relationship.name, load_query}],
-          scope: context,
-          authorize?: false
+          scope: context
         )
         |> Enum.flat_map(fn record ->
           record


### PR DESCRIPTION
## Summary

- Fix `cascade_destroy` and `cascade_update` to pass full context (including actor) to `Ash.load!`
- Previously only `tenant: tenant` was passed, causing policy failures when policies require an actor

## Details

The `Ash.load!` calls in both cascade changes were missing the actor from the context. This was a regression introduced in #1948 when `authorize?: false` was removed but the actor wasn't added.

The fix uses `Ash.Context.to_opts(context)` to pass all relevant context options (actor, tenant, tracer, context, authorize?), consistent with how `context_opts` is already passed to `Ash.bulk_destroy!`/`Ash.bulk_update!` in the same code path.

Closes #2536