### PR TITLE
fix: manage_relationship in atomics

### DIFF
--- a/lib/ash/resource/change/manage_relationship.ex
+++ b/lib/ash/resource/change/manage_relationship.ex
@@ -36,7 +36,12 @@ defmodule Ash.Resource.Change.ManageRelationship do
   end
 
   def atomic(changeset, opts, context) do
-    {:ok, change(changeset, opts, context)}
+    if opts[:opts][:ignore?] do
+      {:ok, change(changeset, opts, context)}
+    else
+      {:not_atomic,
+       "manage_relationship changes require the non-atomic path to execute relationship management"}
+    end
   end
 
   defp from_structs(argument_value, destination) when is_list(argument_value) do


### PR DESCRIPTION
  Summary

  Fixes a regression introduced in commit 02b260a39 ("make ignored managed relationships not break atomicity") where
  manage_relationship changes were silently skipped during atomic bulk updates.

  Problem

  The atomic/3 callback was added unconditionally to ManageRelationship, making all manage_relationship changes claim
  to be atomic. However, the atomic bulk update path doesn't call manage_relationships() - only the stream path does.
  This caused relationship changes to be silently ignored.

  Solution

  Return {:not_atomic, reason} for non-ignored relationships, forcing the stream-based fallback path which properly
  executes relationship management. The ignore?: true optimization from the original commit is preserved.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
