### PR TITLE
feat: manual relationship via list

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -505,12 +505,14 @@ defmodule Ash.Actions.Read.Relationships do
             tenant: related_query.tenant
           })
           |> case do
-            {:ok, records} ->
-              records
-              |> Enum.flat_map(fn {key, value} ->
+            {:ok, result_records} ->
+              result_records
+              |> normalize_manual_results(records, relationship)
+              |> Enum.with_index()
+              |> Enum.flat_map(fn {value, index} ->
                 value
                 |> List.wrap()
-                |> Enum.map(&Ash.Resource.put_metadata(&1, :manual_key, key))
+                |> Enum.map(&Ash.Resource.put_metadata(&1, :manual_key, index))
               end)
               |> Ash.load(related_query,
                 domain: related_query.domain,
@@ -520,7 +522,7 @@ defmodule Ash.Actions.Read.Relationships do
               )
               |> case do
                 {:ok, results} ->
-                  {:ok, regroup_manual_results(results, relationship)}
+                  {:ok, regroup_manual_results(results, relationship, Enum.count(records))}
 
                 {:error, error} ->
                   {:error, error}
@@ -870,16 +872,124 @@ defmodule Ash.Actions.Read.Relationships do
     end)
   end
 
-  defp regroup_manual_results(records, %{cardinality: :many}) do
-    Enum.group_by(records, & &1.__metadata__.manual_key, &delete_manual_key/1)
+  defp regroup_manual_results(records, %{cardinality: :many}, count) do
+    indexed_records =
+      Enum.group_by(records, & &1.__metadata__.manual_key, &delete_manual_key/1)
+
+    Enum.map(0..max(count - 1, 0), fn index ->
+      Map.get(indexed_records, index, [])
+    end)
   end
 
-  defp regroup_manual_results(records, %{cardinality: :one}) do
-    Map.new(records, &{&1.__metadata__.manual_key, delete_manual_key(&1)})
+  defp regroup_manual_results(records, %{cardinality: :one}, count) do
+    indexed_records =
+      Map.new(records, fn record ->
+        {record.__metadata__.manual_key, delete_manual_key(record)}
+      end)
+
+    Enum.map(0..max(count - 1, 0), fn index ->
+      Map.get(indexed_records, index)
+    end)
   end
 
   defp delete_manual_key(record) do
     Map.update!(record, :__metadata__, &Map.delete(&1, :manual_key))
+  end
+
+  defp normalize_manual_results(result_records, [%resource{} | _] = records, relationship)
+       when is_map(result_records) do
+    default =
+      case relationship.cardinality do
+        :one ->
+          nil
+
+        :many ->
+          []
+      end
+
+    if Ash.Resource.Info.primary_key_simple_equality?(resource) do
+      pkey = Ash.Resource.Info.primary_key(resource)
+
+      single_match? =
+        case pkey do
+          [_] -> true
+          _ -> false
+        end
+
+      Enum.map(records, fn record ->
+        value =
+          if single_match? do
+            case Map.fetch(result_records, Map.get(record, Enum.at(pkey, 0))) do
+              {:ok, value} -> {:ok, value}
+              :error -> Map.fetch(result_records, Map.take(record, pkey))
+            end
+          else
+            Map.fetch(result_records, Map.take(record, pkey))
+          end
+
+        case value do
+          {:ok, result} ->
+            result
+
+          :error ->
+            default
+        end
+      end)
+    else
+      pkey = Ash.Resource.Info.primary_key(resource)
+
+      case pkey do
+        [pkey_key] ->
+          Enum.map(records, fn record ->
+            pkey_values = Map.take(record, pkey)
+
+            value =
+              Enum.find_value(result_records, fn {key, value} ->
+                if is_map(key) do
+                  if resource.primary_key_matches?(key, pkey_values) do
+                    {:ok, value}
+                  end
+                else
+                  if resource.primary_key_matches?(%{pkey_key => key}, pkey_values) do
+                    {:ok, value}
+                  end
+                end
+              end) || :error
+
+            case value do
+              {:ok, result} ->
+                result
+
+              :error ->
+                default
+            end
+          end)
+
+        _pkeys ->
+          Enum.map(records, fn record ->
+            pkey_values = Map.take(record, pkey)
+
+            value =
+              Enum.find_value(result_records, fn {key, value} ->
+                if resource.primary_key_matches?(key, pkey_values) do
+                  {:ok, value}
+                end
+              end) || :error
+
+            case value do
+              {:ok, result} ->
+                result
+
+              :error ->
+                default
+            end
+          end)
+      end
+    end
+  end
+
+  defp normalize_manual_results(result_records, _records, _relationship) do
+    result_records
   end
 
   defp select_destination_attribute(related_query, relationship) do
@@ -1082,99 +1192,25 @@ defmodule Ash.Actions.Read.Relationships do
   end
 
   defp do_attach_related_records(
-         [%resource{} | _] = records,
+         records,
          %{manual: {_module, _opts}} = relationship,
-         map,
+         values,
          _related_query
        ) do
     default =
       case relationship.cardinality do
-        :one ->
-          nil
-
-        :many ->
-          []
+        :one -> nil
+        :many -> []
       end
 
-    if Ash.Resource.Info.primary_key_simple_equality?(resource) do
-      pkey = Ash.Resource.Info.primary_key(resource)
+    records
+    |> Enum.zip_with(values, fn
+      record, nil ->
+        Map.put(record, relationship.name, default)
 
-      single_match? =
-        case pkey do
-          [_] -> true
-          _ -> false
-        end
-
-      Enum.map(records, fn record ->
-        value =
-          if single_match? do
-            case Map.fetch(map, Map.get(record, Enum.at(pkey, 0))) do
-              {:ok, value} -> {:ok, value}
-              :error -> Map.fetch(map, Map.take(record, pkey))
-            end
-          else
-            Map.fetch(map, Map.take(record, pkey))
-          end
-
-        case value do
-          {:ok, result} ->
-            Map.put(record, relationship.name, result)
-
-          :error ->
-            Map.put(record, relationship.name, default)
-        end
-      end)
-    else
-      pkey = Ash.Resource.Info.primary_key(resource)
-
-      case pkey do
-        [pkey_key] ->
-          Enum.map(records, fn record ->
-            pkey_values = Map.take(record, pkey)
-
-            value =
-              Enum.find_value(map, fn {key, value} ->
-                if is_map(key) do
-                  if resource.primary_key_matches?(key, pkey_values) do
-                    {:ok, value}
-                  end
-                else
-                  if resource.primary_key_matches?(%{pkey_key => key}, pkey_values) do
-                    {:ok, value}
-                  end
-                end
-              end) || :error
-
-            case value do
-              {:ok, result} ->
-                Map.put(record, relationship.name, result)
-
-              :error ->
-                Map.put(record, relationship.name, default)
-            end
-          end)
-
-        _pkeys ->
-          Enum.map(records, fn record ->
-            pkey_values = Map.take(record, pkey)
-
-            value =
-              Enum.find_value(map, fn {key, value} ->
-                if resource.primary_key_matches?(key, pkey_values) do
-                  {:ok, value}
-                end
-              end) || :error
-
-            case value do
-              {:ok, result} ->
-                Map.put(record, relationship.name, result)
-
-              :error ->
-                Map.put(record, relationship.name, default)
-            end
-          end)
-      end
-    end
+      record, value ->
+        Map.put(record, relationship.name, value)
+    end)
   end
 
   defp do_attach_related_records(

--- a/lib/ash/resource/manual_relationship/manual_relationship.ex
+++ b/lib/ash/resource/manual_relationship/manual_relationship.ex
@@ -39,7 +39,7 @@ defmodule Ash.Resource.ManualRelationship do
               opts :: Keyword.t(),
               context :: Context.t()
             ) ::
-              {:ok, map} | {:error, term}
+              {:ok, [term] | map} | {:error, term}
 
   defmacro __using__(_) do
     quote do

--- a/test/resource/relationships/manual_test.exs
+++ b/test/resource/relationships/manual_test.exs
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.Relationships.ManualTestMacros do
+  defmacro defresources(
+             simple?,
+             multi?,
+             many?,
+             do: body
+           ) do
+    post_attributes =
+      quote do
+        case {unquote(simple?), unquote(multi?)} do
+          {true, true} ->
+            [%{name: :number, type: :string}, %{name: :number2, type: :string}]
+
+          {true, false} ->
+            [%{name: :number, type: :string}]
+
+          {false, true} ->
+            [
+              %{name: :number, type: :ci_string},
+              %{name: :number2, type: :ci_string}
+            ]
+
+          {false, false} ->
+            [%{name: :number, type: :ci_string}]
+        end
+      end
+
+    quote do
+      module_pfx = "rand#{System.unique_integer([:positive])}"
+      comment_module = Module.concat([module_pfx, Comment])
+      use_context_rel_module = Module.concat([module_pfx, UseContextRelationship])
+      post_module = Module.concat([module_pfx, Post])
+
+      defmodule comment_module do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        ets do
+          private?(true)
+        end
+
+        actions do
+          default_accept :*
+          defaults [:read, :destroy, create: :*, update: :*]
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :number, :string, allow_nil?: false, public?: true
+        end
+      end
+
+      @comment_module comment_module
+
+      defmodule use_context_rel_module do
+        @moduledoc false
+        use Ash.Resource.ManualRelationship
+
+        @impl true
+        def load(_posts, _opts, %{source_context: %{private: %{load_result: load_result}}}) do
+          {:ok, load_result}
+        end
+      end
+
+      defmodule post_module do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        actions do
+          default_accept :*
+          defaults [:read, :destroy, create: :*, update: :*]
+        end
+
+        attributes do
+          for config <- unquote(post_attributes) do
+            attribute config.name, config.type do
+              allow_nil? false
+              public? true
+              primary_key? true
+            end
+          end
+        end
+
+        relationships do
+          if unquote(many?) do
+            has_many :use_ctx_comment, comment_module do
+              public? true
+              manual use_context_rel_module
+              no_attributes? true
+            end
+          else
+            has_one :use_ctx_comment, comment_module do
+              public? true
+              allow_nil? true
+              manual use_context_rel_module
+              no_attributes? true
+            end
+          end
+        end
+      end
+
+      @post_module post_module
+
+      unquote(body)
+    end
+  end
+
+  defmacro run_test(
+             post_module,
+             comment_module,
+             post_inputs,
+             load_result,
+             expected,
+             multi?,
+             many?
+           ) do
+    post_inputs =
+      Macro.escape(
+        Enum.map(post_inputs, fn number ->
+          if multi? do
+            %{number: number, number2: number}
+          else
+            %{number: number}
+          end
+        end)
+      )
+
+    load_result =
+      Macro.escape(
+        if is_map(load_result) do
+          Map.new(load_result, fn {post_number, comment_number} ->
+            post_number =
+              if multi? do
+                %{number: post_number, number2: post_number}
+              else
+                post_number
+              end
+
+            {post_number, comment_number}
+          end)
+        else
+          load_result
+        end
+      )
+
+    create_comment_fn =
+      quote do
+        fn num ->
+          num =
+            case num do
+              nil -> nil
+              num -> Ash.create!(unquote(comment_module), %{number: num})
+            end
+
+          unquote(
+            if many? do
+              quote do
+                List.wrap(num)
+              end
+            else
+              quote(do: num)
+            end
+          )
+        end
+      end
+
+    expected =
+      Macro.escape(
+        Enum.map(expected, fn
+          nil ->
+            %{use_ctx_comment: if(many?, do: [], else: nil)}
+
+          num ->
+            %{use_ctx_comment: if(many?, do: [%{number: num}], else: %{number: num})}
+        end)
+      )
+
+    quote do
+      posts =
+        Enum.map(unquote(post_inputs), fn post_input ->
+          if post_input == nil do
+            nil
+          else
+            Ash.create!(unquote(post_module), post_input)
+          end
+        end)
+
+      create_comment = unquote(create_comment_fn)
+
+      load_result =
+        case unquote(load_result) do
+          res when is_map(res) ->
+            Map.new(res, fn {post_number, comment_number} ->
+              {post_number, create_comment.(comment_number)}
+            end)
+
+          res when is_list(res) ->
+            Enum.map(res, create_comment)
+        end
+
+      posts =
+        Ash.load!(posts, [:use_ctx_comment], context: %{private: %{load_result: load_result}})
+
+      assert unquote(expected) = posts
+    end
+  end
+end
+
+defmodule Ash.Test.Resource.Relationships.ManualTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  import Ash.Test.Resource.Relationships.ManualTestMacros
+
+  @test_cases [
+    %{
+      tag: "1>1",
+      name: "it associates a single record -> single record",
+      posts: ["0"],
+      load_results: %{map: %{"0" => "0"}, list: ["0"]},
+      expected: ["0"]
+    },
+    %{
+      tag: "1>nil",
+      name: "it associates a single record -> nil",
+      posts: ["0"],
+      load_results: %{map: %{"0" => nil}, list: [nil]},
+      expected: [nil]
+    },
+    %{
+      tag: "1>none",
+      name: "it associates a single record -> no match",
+      posts: ["0"],
+      load_results: %{map: %{}, list: []},
+      expected: [nil]
+    },
+    %{
+      tag: "3>3",
+      name: "it associates three records -> three records",
+      posts: ["0", "1", "2"],
+      load_results: %{map: %{"0" => "0", "1" => "1", "2" => "2"}, list: ["0", "1", "2"]},
+      expected: ["0", "1", "2"]
+    },
+    %{
+      tag: "3>nils",
+      name: "it associates three records -> three nils",
+      posts: ["0", "1", "2"],
+      load_results: %{map: %{"0" => nil, "1" => nil, "2" => nil}, list: [nil, nil, nil]},
+      expected: [nil, nil, nil]
+    },
+    %{
+      tag: "3>none",
+      name: "it associates three records -> no matches",
+      posts: ["0", "1", "2"],
+      load_results: %{map: %{}, list: []},
+      expected: [nil, nil, nil]
+    },
+    %{
+      tag: "3>mixed",
+      name: "it associates three records -> mixed records/nils",
+      posts: ["0", "1", "2"],
+      load_results: %{map: %{"0" => "0", "1" => nil, "2" => "2"}, list: ["0", nil, "2"]},
+      expected: ["0", nil, "2"]
+    },
+    %{
+      tag: "3>none+nil",
+      name: "it associates three records -> mixed records/nils (with one missing)",
+      posts: ["0", "1", "2"],
+      load_results: %{map: %{"0" => "0", "2" => nil}},
+      expected: ["0", nil, nil]
+    },
+    %{
+      tag: "1>2",
+      name: "it associates a single record -> single record (even with >1 returned)",
+      posts: ["0"],
+      load_results: %{list: ["0", "1"]},
+      expected: ["0"]
+    },
+    %{
+      tag: "3>2",
+      name: "it associates three records -> two records, using nil for last",
+      posts: ["0", "1", "2"],
+      load_results: %{list: ["0", "1"]},
+      expected: ["0", "1", nil]
+    }
+  ]
+
+  @strategies_to_test [:map, :list]
+
+  for simple? <- [true, false],
+      multi? <- [true, false],
+      many? <- [true, false] do
+    defresources simple?, multi?, many? do
+      for test_case <- @test_cases,
+          valid_load_results =
+            test_case.load_results
+            |> Map.take(@strategies_to_test),
+          {strategy, load_result} <- valid_load_results do
+        tag_str =
+          "#{test_case.tag} strategy=#{strategy} simple?=#{simple?} multi?=#{multi?} many?=#{many?}"
+
+        @tag actions_has_one: tag_str
+        @name "#{test_case.name} #{tag_str}"
+        test @name do
+          run_test(
+            unquote(@post_module),
+            unquote(@comment_module),
+            unquote(test_case.posts),
+            unquote(load_result),
+            unquote(test_case.expected),
+            unquote(multi?),
+            unquote(many?)
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces the ability to return a list from the `Ash.Resource.ManualRelationship.load/3` callback.

It works similarly to the `Ash.Resource.Calculation.calculate/3` callback: Each result in the returned list is related to the record from the same position in the input records list.

The ability to return a map is maintained for backwards compatibility (Though it perhaps should be deprecated at some point?).

The main reason for this is to improve performance for cases where the loading resource uses a non-simple-equality primary key (See below issue).

Closes #2505

## Notes

### Tests
The test cases included here are probably way too much, but they are very thorough in their coverage of the affected code to ensure full backwards compatibility. If you want to check the tests that pass on main, just remove `:list` from `@strategies_to_test` and run against main branch.

At least they prove correctness, but if they are too much I understand, and I can put together some simpler tests.

### Documentation
Also, this change should be documented - but I wasn't sure how exactly it should be communicated. Should we replace any mention of returning a map with instead returning a list? Should returning a map be mentioned as a legacy option with performance drawbacks? Either way it should definitely touch the "Manual Relationships" section of `documentation/topics/resources/relationships.md`. Just let me know any thoughts and I can draft the documentation.

### Implementation
The implementation works by first normalizing the result from the user's `load/3` callback:
- If it is a map, it is converted to a list in the "new format" which will end up having the same performance drawbacks as before this commit (O(n^2) for non-simple pkeys). Users can switch to returning a list instead for performance gains.
- If it is a list, it is untouched.

Then the related records are flattened, and loaded with the given query. Then they are regrouped back into a list efficiently by their index (:manual_key).

Finally, this list is passed into `do_attach_related_records`, which simply zips them together with the loading records.

Since the O(n^2) part is only happening in cases where a map is returned, users that instead use a list will not hit this bottleneck.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes (TODO)
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
