### PR TITLE
feat(calculations): Add multitenancy bypass options to calculations

### DIFF
--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -3768,6 +3768,7 @@ end
 | [`allow_nil?`](#calculations-calculate-allow_nil?){: #calculations-calculate-allow_nil? } | `boolean` | `true` | Whether or not the calculation can return nil. |
 | [`filterable?`](#calculations-calculate-filterable?){: #calculations-calculate-filterable? } | `boolean \| :simple_equality` | `true` | Whether or not the calculation should be usable in filters. |
 | [`sortable?`](#calculations-calculate-sortable?){: #calculations-calculate-sortable? } | `boolean` | `true` | Whether or not the calculation can be referenced in sorts. |
+| [`multitenancy`](#calculations-calculate-multitenancy){: #calculations-calculate-multitenancy } | `:enforce \| :allow_global \| :bypass \| :bypass_all` |  | Configures multitenancy behavior for the calculation. `:enforce` requires a tenant to be set (the default behavior), `:allow_global` allows using this calculation both with and without a tenant, `:bypass` completely ignores the tenant even if it's set, `:bypass_all` like `:bypass` but also bypasses the tenancy requirement for nested resources. |
 
 
 ### calculations.calculate.argument

--- a/lib/ash/query/calculation.ex
+++ b/lib/ash/query/calculation.ex
@@ -13,6 +13,7 @@ defmodule Ash.Query.Calculation do
     :type,
     :constraints,
     :calc_name,
+    :multitenancy,
     context: %{},
     required_loads: [],
     select: [],
@@ -216,22 +217,24 @@ defmodule Ash.Query.Calculation do
 
     with {:ok, opts} <- FromResourceOpts.validate(opts),
          {:ok, args} <-
-           Ash.Query.validate_calculation_arguments(resource_calculation, opts.args) do
-      new(
-        name,
-        module,
-        calc_opts,
-        resource_calculation.type,
-        resource_calculation.constraints,
-        arguments: args,
-        async?: resource_calculation.async?,
-        filterable?: resource_calculation.filterable?,
-        sortable?: resource_calculation.sortable?,
-        sensitive?: resource_calculation.sensitive?,
-        load: resource_calculation.load,
-        source_context: opts.source_context,
-        calc_name: resource_calculation.name
-      )
+           Ash.Query.validate_calculation_arguments(resource_calculation, opts.args),
+         {:ok, calculation} <-
+           new(
+             name,
+             module,
+             calc_opts,
+             resource_calculation.type,
+             resource_calculation.constraints,
+             arguments: args,
+             async?: resource_calculation.async?,
+             filterable?: resource_calculation.filterable?,
+             sortable?: resource_calculation.sortable?,
+             sensitive?: resource_calculation.sensitive?,
+             load: resource_calculation.load,
+             source_context: opts.source_context,
+             calc_name: resource_calculation.name
+           ) do
+      {:ok, %{calculation | multitenancy: resource_calculation.multitenancy}}
     end
   end
 

--- a/lib/ash/resource/calculation/calculation.ex
+++ b/lib/ash/resource/calculation/calculation.ex
@@ -16,11 +16,12 @@ defmodule Ash.Resource.Calculation do
             description: nil,
             filterable?: true,
             sortable?: true,
+            sensitive?: false,
+            multitenancy: nil,
             load: [],
             name: nil,
             public?: false,
             async?: false,
-            sensitive?: false,
             type: nil,
             __spark_metadata__: nil
 
@@ -91,6 +92,16 @@ defmodule Ash.Resource.Calculation do
       doc: """
       Whether or not the calculation can be referenced in sorts.
       """
+    ],
+    multitenancy: [
+      type: {:in, [:enforce, :allow_global, :bypass, :bypass_all]},
+      doc: """
+      Configures multitenancy behavior for the calculation.
+      `:enforce` requires a tenant to be set (the default behavior),
+      `:allow_global` allows using this calculation both with and without a tenant,
+      `:bypass` completely ignores the tenant even if it's set,
+      `:bypass_all` like `:bypass` but also bypasses the tenancy requirement for nested resources.
+      """
     ]
   ]
 
@@ -136,6 +147,8 @@ defmodule Ash.Resource.Calculation do
           filterable?: boolean,
           load: keyword,
           sortable?: boolean,
+          sensitive?: boolean,
+          multitenancy: nil | :enforce | :allow_global | :bypass | :bypass_all,
           name: atom(),
           public?: boolean,
           type: nil | Ash.Type.t(),

--- a/test/actions/multitenancy_test.exs
+++ b/test/actions/multitenancy_test.exs
@@ -116,6 +116,24 @@ defmodule Ash.Actions.MultitenancyTest do
       end
     end
 
+    calculations do
+      calculate :name_lower, :string, expr(string_downcase(name)), public?: true
+
+      calculate :name_lower_bypass, :string, expr(string_downcase(name)),
+        public?: true,
+        multitenancy: :bypass
+
+      calculate :name_lower_allow_global, :string, expr(string_downcase(name)),
+        public?: true,
+        multitenancy: :allow_global
+
+      calculate :cross_tenant_post_count,
+                :integer,
+                Ash.Actions.MultitenancyTest.CrossTenantPostCount,
+                public?: true,
+                multitenancy: :bypass
+    end
+
     relationships do
       has_many :posts, Ash.Actions.MultitenancyTest.Post,
         destination_attribute: :author_id,
@@ -261,6 +279,12 @@ defmodule Ash.Actions.MultitenancyTest do
       end
     end
 
+    calculations do
+      calculate :name_lower_bypass, :string, expr(string_downcase(name)),
+        public?: true,
+        multitenancy: :bypass
+    end
+
     relationships do
       belongs_to :commenter, User do
         public?(true)
@@ -292,6 +316,20 @@ defmodule Ash.Actions.MultitenancyTest do
 
     defimpl Ash.ToTenant do
       def to_tenant(tenant, _resource), do: tenant.id
+    end
+  end
+
+  defmodule CrossTenantPostCount do
+    use Ash.Resource.Calculation
+
+    def load(_, _, _) do
+      [:posts]
+    end
+
+    def calculate(records, _, _) do
+      Enum.map(records, fn record ->
+        length(record.posts || [])
+      end)
     end
   end
 
@@ -1571,6 +1609,159 @@ defmodule Ash.Actions.MultitenancyTest do
 
       # All records deleted
       assert Enum.empty?(User |> Ash.Query.for_read(:bypass_tenant) |> Ash.read!())
+    end
+  end
+
+  describe "calculation multitenancy bypass" do
+    setup do
+      tenant1 = Ash.UUID.generate()
+      tenant2 = Ash.UUID.generate()
+
+      user1 =
+        User
+        |> Ash.Changeset.for_create(:create, %{name: "alice"}, tenant: tenant1)
+        |> Ash.create!()
+
+      user2 =
+        User
+        |> Ash.Changeset.for_create(:create, %{name: "bob"}, tenant: tenant2)
+        |> Ash.create!()
+
+      Post
+      |> Ash.Changeset.for_create(:create, %{author_id: user1.id}, tenant: tenant1)
+      |> Ash.create!()
+
+      %{tenant1: tenant1, tenant2: tenant2, user1: user1, user2: user2}
+    end
+
+    test "bypass calculation returns 2 records, no-bypass returns 1 for same data", %{
+      tenant1: tenant1
+    } do
+      # No bypass: tenant1 only sees its own record
+      no_bypass =
+        User
+        |> Ash.Query.set_tenant(tenant1)
+        |> Ash.Query.load(:name_lower)
+        |> Ash.read!()
+
+      assert length(no_bypass) == 1
+      assert hd(no_bypass).name_lower == "alice"
+
+      # Bypass: same data, sees both tenants
+      bypass =
+        User
+        |> Ash.Query.for_read(:bypass_tenant)
+        |> Ash.Query.load(:name_lower_bypass)
+        |> Ash.read!()
+
+      assert length(bypass) == 2
+      assert Enum.map(bypass, & &1.name_lower_bypass) |> Enum.sort() == ["alice", "bob"]
+    end
+
+    test "bypass module calculation loads across tenants, no-bypass only loads within tenant", %{
+      tenant1: tenant1
+    } do
+      # No bypass: tenant1 sees 1 user with 1 post
+      no_bypass =
+        User
+        |> Ash.Query.set_tenant(tenant1)
+        |> Ash.Query.load(:cross_tenant_post_count)
+        |> Ash.read!()
+
+      assert length(no_bypass) == 1
+      assert hd(no_bypass).cross_tenant_post_count == 1
+
+      # Bypass: sees 2 users — alice with 1 post, bob with 0
+      bypass =
+        User
+        |> Ash.Query.for_read(:bypass_tenant)
+        |> Ash.Query.load(:cross_tenant_post_count)
+        |> Ash.read!()
+
+      assert length(bypass) == 2
+
+      counts = bypass |> Enum.sort_by(& &1.name) |> Enum.map(& &1.cross_tenant_post_count)
+      assert counts == [1, 0]
+    end
+
+    test "allow_global with tenant returns 1, without tenant returns 2", %{
+      tenant1: tenant1
+    } do
+      # With tenant: scoped to tenant1 only
+      with_tenant =
+        User
+        |> Ash.Query.for_read(:allow_global)
+        |> Ash.Query.set_tenant(tenant1)
+        |> Ash.Query.load(:name_lower_allow_global)
+        |> Ash.read!()
+
+      assert length(with_tenant) == 1
+      assert hd(with_tenant).name_lower_allow_global == "alice"
+
+      # Without tenant: sees all
+      without_tenant =
+        User
+        |> Ash.Query.for_read(:allow_global)
+        |> Ash.Query.load(:name_lower_allow_global)
+        |> Ash.read!()
+
+      assert length(without_tenant) == 2
+    end
+
+    test "bypass and no-bypass calculations on same query return different visibility", %{
+      tenant1: tenant1
+    } do
+      # Load both bypass and no-bypass on a bypass read (sees 2 records)
+      bypass_read =
+        User
+        |> Ash.Query.for_read(:bypass_tenant)
+        |> Ash.Query.load([:name_lower_bypass, :name_lower])
+        |> Ash.read!()
+
+      assert length(bypass_read) == 2
+      bypass_values = bypass_read |> Enum.map(& &1.name_lower_bypass) |> Enum.sort()
+      no_bypass_values = bypass_read |> Enum.map(& &1.name_lower) |> Enum.sort()
+
+      # Both calculations computed for all 2 records
+      assert bypass_values == ["alice", "bob"]
+      assert no_bypass_values == ["alice", "bob"]
+
+      # Tenanted read: only 1 record, so both calculations only see 1
+      tenanted_read =
+        User
+        |> Ash.Query.set_tenant(tenant1)
+        |> Ash.Query.load([:name_lower_bypass, :name_lower])
+        |> Ash.read!()
+
+      assert length(tenanted_read) == 1
+      assert hd(tenanted_read).name_lower_bypass == "alice"
+      assert hd(tenanted_read).name_lower == "alice"
+    end
+
+    test "context strategy allows bypass calculation (unlike aggregates)", %{
+      tenant1: tenant1
+    } do
+      Comment
+      |> Ash.Changeset.for_create(:create, %{name: "hello"}, tenant: tenant1)
+      |> Ash.create!()
+
+      # No bypass: requires tenant, returns 1
+      with_tenant =
+        Comment
+        |> Ash.Query.set_tenant(tenant1)
+        |> Ash.Query.load(:name_lower_bypass)
+        |> Ash.read!()
+
+      assert length(with_tenant) == 1
+      assert hd(with_tenant).name_lower_bypass == "hello"
+
+      bypass =
+        Comment
+        |> Ash.Query.for_read(:bypass_tenant)
+        |> Ash.Query.load(:name_lower_bypass)
+        |> Ash.read!()
+
+      assert is_list(bypass)
     end
   end
 end


### PR DESCRIPTION
This was the final missing piece to support `multitenancy` bypass across most of Ash. It was submitted, please let me know if there are any issues.

Now you can easily have a Master user across the entire system; for example, one that doesn’t have a `site_id`, and there’s no longer any need to create generic actions or use raw queries in calculations.

Fixed #2372

### Now we support 
- calculations
- aggregates
- read
- update
- destroy (soft delete)
- destroy

----

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
