### PR TITLE
fix: remove incorrect stream calls

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -1004,7 +1004,7 @@ defmodule Ash.Generator do
   def mixed_map(map, keys) do
     map = to_generators(map)
     {optional, required} = Map.split(map, keys)
-    do_mixed_map({StreamData.fixed_map(required), StreamData.optional_map(optional)})
+    do_mixed_map({required, optional})
   end
 
   defp do_changeset_or_query(resource, resource_or_record, action, input, changeset_options) do


### PR DESCRIPTION
Seems like generators of maps are broken right now because of this. The call to `do_mixed_map` was converting those maps to `StreamData` streams ahead of time, and then the body of `do_mixed_map` does that again, and things just bork. This was my stacktrace:

```
 ** (FunctionClauseError) no function clause matching in anonymous fn/1 in StreamData.fixed_map/1

     The following arguments were given to anonymous fn/1 in StreamData.fixed_map/1:

         # 1
         %{}

     stacktrace:
       (stream_data 1.2.0) lib/stream_data.ex:1362: anonymous fn/1 in StreamData.fixed_map/1
       (elixir 1.19.5) lib/enum.ex:1696: anonymous fn/3 in Enum.map/2
       (elixir 1.19.5) lib/enum.ex:4570: anonymous fn/3 in Enum.map/2
       (stream_data 1.2.0) lib/stream_data.ex:2492: StreamData.reduce/6
       (elixir 1.19.5) lib/enum.ex:4570: Enum.map/2
       (stream_data 1.2.0) lib/stream_data.ex:1362: StreamData.fixed_map/1
       (ash 3.13.2) lib/ash/generator/generator.ex:1121: Ash.Generator.do_mixed_map/1
       (ash 3.13.2) lib/ash/type/struct.ex:270: Ash.Type.Struct.generator/1
       (ash 3.13.2) lib/ash/type/union.ex:563: anonymous fn/1 in Ash.Type.Union.generator/1
       (elixir 1.19.5) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
       (ash 3.13.2) lib/ash/type/union.ex:561: Ash.Type.Union.generator/1
       (ash 3.13.2) lib/ash/generator/generator.ex:1102: Ash.Generator.attribute_generator/2
       (ash 3.13.2) lib/ash/generator/generator.ex:1084: anonymous fn/5 in Ash.Generator.generate_attributes/5
       (elixir 1.19.5) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ash 3.13.2) lib/ash/generator/generator.ex:1036: Ash.Generator.generate_attributes/5
       (ash 3.13.2) lib/ash/generator/generator.ex:508: Ash.Generator.seed_generator/2
       ... my codebase call stack
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
