### PR TITLE
improvement: warn if manual relationship has missing source_attribute

### DIFF
--- a/test/resource/validate_relationship_attributes_test.exs
+++ b/test/resource/validate_relationship_attributes_test.exs
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.ValidateRelationshipAttributesTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule Comment do
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule ManualCommentRelationship do
+    def load(_records, _opts, _context) do
+      raise "Should not get here"
+    end
+  end
+
+  defmodule Tag do
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule MissingDestJoinResource do
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+      attribute :post_id, :uuid, primary_key?: true, allow_nil?: false
+    end
+  end
+
+  test "relationship with missing destination_attribute raises error" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule PostMissingDestAttribute do
+          @moduledoc false
+          use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+          attributes do
+            uuid_primary_key :id
+          end
+
+          relationships do
+            has_many :comments, Comment
+          end
+        end
+      end)
+
+    assert String.contains?(
+             output,
+             "Relationship `comments` expects destination field `post_missing_dest_attribute_id` to be defined on Ash.Test.Resource.ValidateRelationshipAttributesTest.Comment"
+           )
+
+    assert String.contains?(
+             output,
+             "relationships -> comments"
+           )
+  end
+
+  test "manual relationship with mismatched source_attribute raises error" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule PostMissingSourceAttributeManual do
+          @moduledoc false
+          use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+          attributes do
+            uuid_primary_key :not_id
+          end
+
+          relationships do
+            has_many :comments, Comment do
+              manual ManualCommentRelationship
+            end
+          end
+        end
+      end)
+
+    assert String.contains?(
+             output,
+             "Relationship `comments` expects source attribute `id` to be defined."
+           )
+
+    assert String.contains?(
+             output,
+             "relationships -> comments"
+           )
+  end
+
+  test "many_to_many with missing source_attribute_on_join_resource raises error" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule PostMissingJoinDestinationAttribute do
+          @moduledoc false
+          use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+          attributes do
+            uuid_primary_key :id
+          end
+
+          relationships do
+            many_to_many :tags, Tag do
+              through MissingDestJoinResource
+              source_attribute_on_join_resource :post_id
+              destination_attribute_on_join_resource :tag_id
+            end
+          end
+        end
+      end)
+
+    assert String.contains?(
+             output,
+             "Relationship `tags` expects destination attribute on join resource `tag_id` to be defined on Ash.Test.Resource.ValidateRelationshipAttributesTest.MissingDestJoinResource"
+           )
+
+    assert String.contains?(
+             output,
+             "relationships -> tags"
+           )
+  end
+
+  test "relationship with no_attributes and missing destination_attribute does not raise error" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule PostMissingDestAttributeNoAttributes do
+          @moduledoc false
+          use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+          attributes do
+            uuid_primary_key :id
+          end
+
+          relationships do
+            has_many :comments, Comment do
+              no_attributes? true
+            end
+          end
+        end
+      end)
+
+    assert not String.contains?(
+             output,
+             "Relationship `comments` expects destination field `post_missing_dest_attribute_no_attributes_id` to be defined on Ash.Test.Resource.ValidateRelationshipAttributesTest.Comment"
+           )
+  end
+
+  test "relationship with validate_destination_attribute? false and missing destination_attribute does not raise error" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule PostMissingDestAttributeNoValidateDestAttr do
+          @moduledoc false
+          use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+          attributes do
+            uuid_primary_key :id
+          end
+
+          relationships do
+            has_many :comments, Comment do
+              validate_destination_attribute? false
+            end
+          end
+        end
+      end)
+
+    assert not String.contains?(
+             output,
+             "Relationship `comments` expects destination field `post_missing_dest_attribute_no_validate_dest_attr_id` to be defined on Ash.Test.Resource.ValidateRelationshipAttributesTest.Comment"
+           )
+  end
+end


### PR DESCRIPTION
Reworks the ValidateRelationshipAttributes verifier so that it also warns of missing source attributes for manual relationships instead of ignoring them.

For manual, only do this specific type of verification, Don't do the rest of the verifications since they aren't applicable

### Notes

Reason I made this is because I spent longer than I'd like debugging an error when defining a manual relationship on a resource without an :id primary key.

Specifically if you do this and then try to load the relationship you will get an error like this (See the NoSuchAttribute :id error):
```
     ** (Ash.Error.Unknown) 
     Bread Crumbs:
       > Exception raised in: Ash.Test.Actions.LoadTest.PostSecret.read

     Unknown Error

     * ** (WithClauseError) no with clause matching:

         #Ash.Query<
           resource: Ash.Test.Actions.LoadTest.PostSecret,
           action: :read,
           filter: #Ash.Filter<secret == "4">,
           load: [
             posts_with_secret: #Ash.Query<resource: Ash.Test.Actions.LoadTest.Post>
           ],
           errors: [
             %Ash.Error.Query.NoSuchAttribute{
               resource: Ash.Test.Actions.LoadTest.PostSecret,
               attribute: :id,
               splode: Ash.Error,
               bread_crumbs: [],
               vars: [],
               path: [],
               stacktrace: #Splode.Stacktrace<>,
               class: :invalid
             }
           ],
           select: [:secret]
         >

       (ash 3.15.0) lib/ash/actions/read/read.ex:88: Ash.Actions.Read.run/3
       (ash 3.15.0) lib/ash.ex:2535: Ash.load/3
       (ash 3.15.0) lib/ash.ex:2489: Ash.load/3
       (ash 3.15.0) lib/ash.ex:2391: Ash.load!/3
       test/actions/load_test.exs:1457: Ash.Test.Actions.LoadTest."test loads it allows loading manual relationships with non :id pkey, regardless of source_attribute"/1
       (ex_unit 1.19.0) lib/ex_unit/runner.ex:528: ExUnit.Runner.exec_test/2
       (stdlib 7.1) timer.erl:599: :timer.tc/2
       (ex_unit 1.19.0) lib/ex_unit/runner.ex:450: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
     code: |> Ash.load!([:posts_with_secret])
     stacktrace:
       (ash 3.15.0) lib/ash/actions/read/read.ex:459: anonymous fn/3 in Ash.Actions.Read.do_run/3
       (ash 3.15.0) lib/ash/actions/read/read.ex:459: Ash.Actions.Read.do_run/3
       (ash 3.15.0) lib/ash/actions/read/read.ex:89: anonymous fn/3 in Ash.Actions.Read.run/3
       (ash 3.15.0) lib/ash/actions/read/read.ex:88: Ash.Actions.Read.run/3
       (ash 3.15.0) lib/ash.ex:2535: Ash.load/3
       (ash 3.15.0) lib/ash.ex:2489: Ash.load/3
       (ash 3.15.0) lib/ash.ex:2391: Ash.load!/3
       test/actions/load_test.exs:1457: (test)
```

This is because source_attribute (:id by default) is selected for manual actions [here](https://github.com/ash-project/ash/blob/f97e621c013c1dcfa58244fa59770fce885b3ed8/lib/ash/actions/read/read.ex#L1509) 

It might seem obvious, but it was confusing to me, and I hope that emitting this warning can help save people some time debugging this if they make this mistake.

If you want to reproduce the error yourself you can check out [this branch](https://github.com/zackattackz/ash/tree/manual-rel-no-source-attr) and run the test `it allows loading manual relationships with non :id pkey, regardless of source_attribute` via `mix test test/actions/load_test.exs:1443`

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
