### PR TITLE
Update Ash.Gen.Resource, validate relationship type

### DIFF
--- a/lib/mix/tasks/gen/ash.gen.resource.ex
+++ b/lib/mix/tasks/gen/ash.gen.resource.ex
@@ -211,6 +211,10 @@ if Code.ensure_loaded?(Igniter) do
       Regex.match?(~r/^[a-zA-Z][a-zA-Z0-9_]*[!?]?$/, name)
     end
 
+    defp valid_relationship_type(type) do
+      type in ["has_one", "has_many", "many_to_many", "belongs_to"]
+    end
+
     defp attribute_modifier_string(modifiers) do
       modifiers
       |> Enum.uniq()
@@ -463,6 +467,10 @@ if Code.ensure_loaded?(Igniter) do
             )
 
           [type, name, destination | modifiers] ->
+            if !valid_relationship_type(type) do
+              raise "Invalid relationship type provided: #{type}"
+            end
+
             if !valid_attribute_name?(name) do
               raise "Invalid relationship name provided: #{name}"
             end

--- a/test/mix/tasks/ash.gen.resource_test.exs
+++ b/test/mix/tasks/ash.gen.resource_test.exs
@@ -333,6 +333,19 @@ defmodule Mix.Tasks.Ash.Gen.ResourceTest do
       end
       """)
     end
+
+    test "rejects invalid relationship type" do
+      assert_raise RuntimeError, fn ->
+        test_project()
+        |> Igniter.compose_task("ash.gen.resource", [
+          "MyApp.Blog.Post",
+          "--relationship",
+          # belongs-to is not valid
+          "belongs-to:author:MyApp.Accounts.User,has_many:comments:MyApp.Blog.Comment"
+        ])
+        |> refute_creates("lib/my_app/blog/post.ex")
+      end
+    end
   end
 
   describe "default actions" do


### PR DESCRIPTION
## Description

Recently found that this `ash.gen.resource` will let you create something with an invalid relationship. 

### Example

```sh
mix ash.gen.resource MyApp.Blog.Post \
    -r belongs-to:author:MyApp.Accounts.User,has_any:comments:MyApp.Blog.Comment
```
This has two problems:
-  `belongs-to` (kebab-case) instead of `belongs_to` (snake_case)
- `has_any` instead of `has_many`

I would expect this to fail so I can fix the typos, but instead it creates a resource with a `relationships` block that looks like this:
```
       relationships do
         belongs - to(:author, MyApp.Accounts.User)
         has_any(:comments, MyApp.Blog.Comment)
       end
```

## Changes

- Update `Ash.Gen.Resource`, add `valid_relationship_type/1` and call in `add_relationships_to_resource`.  

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
