### PR TITLE
feat: add `not_found_error?` to `Ash.get` to bring it in-line with actions

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -230,7 +230,14 @@ defmodule Ash do
                     )
 
   @get_opts_schema [
+                     # This will be removed in 4.0. Use `not_found_error?` instead.
                      error?: [
+                       type: :boolean,
+                       default: true,
+                       doc:
+                         "Deprecated: Use not_found_error? instead. Whether or not an error should be returned or raised when the record is not found. If set to false, `nil` will be returned. Deprecated: This will be removed in 4.0."
+                     ],
+                     not_found_error?: [
                        type: :boolean,
                        default: true,
                        doc:
@@ -2124,7 +2131,8 @@ defmodule Ash do
         {:ok, single_result}
 
       {:ok, %{results: []}} ->
-        if opts[:error?] do
+        # deprecated: opts[:error?] will be removed in 4.0 and then opts[:not_found_error?] can be used directly here
+        if Enum.all?([opts[:error?], opts[:not_found_error?]]) do
           {:error,
            Ash.Error.Query.NotFound.exception(
              primary_key: filter,
@@ -2146,7 +2154,8 @@ defmodule Ash do
         {:ok, single_result}
 
       {:ok, []} ->
-        if opts[:error?] do
+        # deprecated: opts[:error?] will be removed in 4.0 and then opts[:not_found_error?] can be used directly here
+        if Enum.all?([opts[:error?], opts[:not_found_error?]]) do
           {:error,
            Ash.Error.Query.NotFound.exception(
              primary_key: filter,

--- a/test/ash_test.exs
+++ b/test/ash_test.exs
@@ -513,6 +513,21 @@ defmodule Ash.Test.AshTest do
     end
   end
 
+  describe "get/2" do
+    test "accepts error? and not_found_error? as options" do
+      # `error?` will be removed in 4.0 in order to bring get/2 inline with `get? true` in read actions
+      Ash.create!(User, %{name: "Alice"})
+
+      assert {:ok, nil} = Ash.get(User, "dcbbe7f0-0d77-4c38-923b-ab66a42cc817", error?: false)
+
+      assert {:ok, nil} =
+               Ash.get(User, "dcbbe7f0-0d77-4c38-923b-ab66a42cc817", not_found_error?: false)
+
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Query.NotFound{}]}} =
+               Ash.get(User, "dcbbe7f0-0d77-4c38-923b-ab66a42cc817")
+    end
+  end
+
   describe "transact/3" do
     setup do
       import ExUnit.CaptureLog


### PR DESCRIPTION
Addresses this issue: https://github.com/ash-project/ash/issues/2569

While I was implementing it I also realised that the tests in `ash_test` don't actually work with a real data layer, so I slightly changed them where necessary.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
