### PR TITLE
Add failing test for ets-backed union types

### DIFF
--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -59,6 +59,25 @@ defmodule Ash.Test.Filter.UnionTest do
     end
   end
 
+  defmodule EtsResource do
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Domain
+
+    actions do
+      defaults [:read, :create]
+
+      default_accept [:count]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :count, :integer do
+        allow_nil? false
+        public? true
+      end
+    end
+  end
+
   defmodule FooBarUnion do
     use Ash.Type.NewType,
       subtype_of: :union,
@@ -286,6 +305,78 @@ defmodule Ash.Test.Filter.UnionTest do
               type: Baz,
               tag: :type,
               tag_value: :baz
+            ]
+          ]
+        ]
+    end
+  end
+
+  defmodule TypeAndValueExample do
+    use Ash.Resource, data_layer: :embedded
+
+    actions do
+      defaults [:read, :create, :destroy, :update]
+      default_accept [:thing]
+    end
+
+    attributes do
+      attribute :thing, :union,
+        constraints: [
+          storage: :type_and_value,
+          types: [
+            foo: [
+              type: Baz,
+              tag: :type,
+              tag_value: :baz
+            ]
+          ]
+        ]
+    end
+  end
+
+  defmodule EtsUnionExample do
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Domain
+
+    actions do
+      defaults [:read, :create]
+      default_accept [:thing]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :thing, :union,
+        constraints: [
+          types: [
+            foo: [
+              type: EtsResource,
+              tag: :type,
+              tag_value: :foo
+            ]
+          ]
+        ]
+    end
+  end
+
+  defmodule EtsUnionExample2 do
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Domain
+
+    actions do
+      defaults [:read, :create]
+      default_accept [:thing]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :thing, :union,
+        constraints: [
+          types: [
+            foo: [
+              type: :struct,
+              constraints: [instance_of: EtsResource],
+              tag: :type,
+              tag_value: :foo
             ]
           ]
         ]


### PR DESCRIPTION
Upon running `mix test test/type/union_test.exs`, I get this error:

```
== Compilation error in file test/type/union_test.exs ==
** (RuntimeError) Unknown type in union type "foo": Ash.Test.Filter.UnionTest.EtsResource

    (ash 3.16.0) lib/ash/type/union.ex:147: anonymous fn/1 in Ash.Type.Union.union_types/1
    (elixir 1.18.4) lib/keyword.ex:205: anonymous fn/3 in Keyword.new/2
    (elixir 1.18.4) lib/keyword.ex:209: Keyword."-new/2-lists^foldl/2-0-"/3
    (ash 3.16.0) lib/ash/type/union.ex:142: Ash.Type.Union.union_types/1
    (spark 2.4.0) lib/spark/options/options.ex:1234: Spark.Options.validate_type/3
    (spark 2.4.0) lib/spark/options/options.ex:837: anonymous fn/4 in Spark.Options.validate_options/2
    (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
    (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
    (spark 2.4.0) lib/spark/options/options.ex:835: Spark.Options.validate_options/2
    (spark 2.4.0) lib/spark/options/options.ex:803: Spark.Options.validate_options_with_schema_and_path/3
    (ash 3.16.0) lib/ash/type/type.ex:2271: Ash.Type.validate_constraints/2
    (ash 3.16.0) lib/ash/type/type.ex:880: Ash.Type.init/2
    (ash 3.16.0) lib/ash/type/type.ex:2177: Ash.Type.set_type_transformation/1
    (spark 2.4.0) lib/spark/dsl/entity.ex:297: Spark.Dsl.Entity.build/5
    (ash 3.16.0) deps/spark/lib/spark/dsl/extension.ex:1360: Ash.Resource.Dsl.Attributes.Attribute.__build__/5
    (spark 2.4.0) lib/spark/dsl/extension/entity.ex:102: Spark.Dsl.Extension.Entity.handle/6
    test/type/union_test.exs:348: (module)
    test/type/union_test.exs:337: (module)
    (elixir 1.18.4) lib/kernel/parallel_compiler.ex:542: Kernel.ParallelCompiler.require_file/2
    (elixir 1.18.4) lib/kernel/parallel_compiler.ex:425: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```

Curiously, the same error doesn't happen when I just run `mix test`.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
