### PR TITLE
Allow Ash.Type.NewType to apply its own constraints

### DIFF
--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -488,8 +488,7 @@ defmodule Ash.Type.NewType do
 
                 case field_keys -- [:type, :constraints, :allow_nil?, :description] do
                   [] ->
-                    {:cont,
-                     validate_type_constraints(key, field[:type], field[:constraints])}
+                    {:cont, validate_type_constraints(key, field[:type], field[:constraints])}
 
                   keys ->
                     {:halt, {:error, "Unknown options given to #{key}: #{inspect(keys)}"}}

--- a/test/type/new_type_test.exs
+++ b/test/type/new_type_test.exs
@@ -232,12 +232,12 @@ defmodule Ash.Test.Type.NewTypeTest do
 
     @impl Ash.Type
     def constraints do
-      Keyword.merge(super(), [
+      Keyword.merge(super(),
         allowed_domains: [
           type: {:list, :string},
           doc: "If set, only addresses at these domains are accepted"
         ]
-      ])
+      )
     end
 
     @impl Ash.Type
@@ -252,7 +252,9 @@ defmodule Ash.Test.Type.NewTypeTest do
           if domain in domains do
             {:ok, value}
           else
-            {:error, message: "must be an address at one of: %{domains}", domains: Enum.join(domains, ", ")}
+            {:error,
+             message: "must be an address at one of: %{domains}",
+             domains: Enum.join(domains, ", ")}
           end
       end
     end
@@ -268,7 +270,8 @@ defmodule Ash.Test.Type.NewTypeTest do
     end
 
     test "restricts to allowed_domains when set" do
-      {:ok, constraints} = Ash.Type.init(EmailAddress, allowed_domains: ["company.com", "corp.co"])
+      {:ok, constraints} =
+        Ash.Type.init(EmailAddress, allowed_domains: ["company.com", "corp.co"])
 
       assert {:ok, _} =
                Ash.Type.apply_constraints(EmailAddress, "user@company.com", constraints)


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Context

[As discussed in Discord](https://discord.com/channels/711271361523351632/1059965824691097670/1474100616862236724),  Ash.Type.NewType can currently only use constraints defined by the parent/subtype. There is no way to add custom constraint options to a NewType. constraints/0 and apply_constraints/2 are not in defoverridable

This PR adds support custom constraints on types defined using Ash.Type.NewType