### PR TITLE
fix: boolean expression not eq optimization

### DIFF
--- a/lib/ash/query/boolean_expression.ex
+++ b/lib/ash/query/boolean_expression.ex
@@ -147,7 +147,7 @@ defmodule Ash.Query.BooleanExpression do
         %NotEq{left: left, right: right_value} = right_expr
       ) do
     if can_optimize?(left_value) && can_optimize?(right_value) && left_value == right_value do
-      left_value
+      left_expr
     else
       do_new(:and, left_expr, right_expr)
     end

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -393,6 +393,16 @@ defmodule Ash.Test.Filter.FilterTest do
 
       assert stringified_query =~ ~S(title == "bar")
     end
+
+    test "duplicate not-equal filters are simplified correctly" do
+      stringified_query =
+        Post
+        |> Ash.Query.filter(title != "foo")
+        |> Ash.Query.filter(title != "foo")
+        |> inspect()
+
+      assert stringified_query =~ ~S(title != "foo")
+    end
   end
 
   describe "no such function errors" do


### PR DESCRIPTION
Before this fix a filter chain like this one

```elixir
MyResource
|> Ash.Query.filter(name != "Emad")
|> Ash.Query.filter(name != "Emad")
|> Ash.read!()
``` 
would fail with this exception

```
Unknown Error

* ** (ArgumentError) expected a keyword list or dynamic expression in `where`, got: `"Emad"`
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
