### PR TITLE
Include usage-rules directory in package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -358,7 +358,7 @@ defmodule Ash.MixProject do
       ],
       licenses: ["MIT"],
       files: ~w(lib .formatter.exs mix.exs README* LICENSE*
-      CHANGELOG* usage-rules.md),
+      CHANGELOG* usage-rules.md usage-rules),
       links: %{
         "GitHub" => "https://github.com/ash-project/ash",
         "Changelog" => "https://github.com/ash-project/ash/blob/main/CHANGELOG.md",


### PR DESCRIPTION
Currently it's not being included so `mix usage_rules.sync` is now missing the rules (since most of them were removed from usage-rules.md in the last release)


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
