### PR TITLE
feat: add pre_flight_authorization() builtin validation for conditional checks during Ash.can?

### DIFF
--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -404,4 +404,22 @@ defmodule Ash.Resource.Validation.Builtins do
   def argument_in(argument, list) do
     {Validation.ArgumentIn, argument: argument, list: list}
   end
+
+  @doc """
+  Validates that the action is being run in a pre-flight authorization context (i.e. `Ash.can?/3`).
+
+  Primarily meant for use in `where` to skip or enable validations during authorization checks.
+
+  ## Examples
+
+      # Skip an expensive validation during can/can? checks
+      validate expensive_check(), where: [negate(pre_flight_authorization())]
+
+      # Only run a validation during can/can? checks
+      validate some_check(), where: [pre_flight_authorization()]
+  """
+  @spec pre_flight_authorization() :: Validation.ref()
+  def pre_flight_authorization do
+    {Validation.PreFlightAuthorization, []}
+  end
 end

--- a/lib/ash/resource/validation/pre_flight_authorization.ex
+++ b/lib/ash/resource/validation/pre_flight_authorization.ex
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Resource.Validation.PreFlightAuthorization do
+  @moduledoc "Validates that the action is being run in a pre-flight authorization context (i.e. `Ash.can?/3`)."
+  use Ash.Resource.Validation
+
+  @impl true
+  def init(opts) do
+    {:ok, opts}
+  end
+
+  @impl true
+  def supports(_opts), do: [Ash.Changeset, Ash.Query, Ash.ActionInput]
+
+  @impl true
+  def validate(subject, _opts, _context) do
+    if subject.context[:private][:pre_flight_authorization?] do
+      :ok
+    else
+      {:error,
+       Ash.Error.Unknown.UnknownError.exception(
+         error: "action is not being run in a pre-flight authorization context"
+       )}
+    end
+  end
+
+  @impl true
+  def atomic(subject, opts, context) do
+    validate(subject, opts, context)
+  end
+
+  @impl true
+  def describe(_opts) do
+    [message: "must be in a pre-flight authorization context", vars: %{}]
+  end
+end

--- a/test/resource/validation/pre_flight_test.exs
+++ b/test/resource/validation/pre_flight_test.exs
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.Validation.PreFlightTest do
+  use ExUnit.Case, async: true
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule AlwaysRaises do
+    use Ash.Resource.Validation
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+
+    @impl true
+    def validate(_changeset, _opts, _context) do
+      raise "validation was not skipped"
+    end
+
+    @impl true
+    def atomic(_changeset, _opts, _context), do: raise("validation was not skipped")
+
+    @impl true
+    def describe(_opts), do: [message: "always raises", vars: %{}]
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      authorizers: [Ash.Policy.Authorizer]
+
+    actions do
+      default_accept :*
+      defaults [:read, :create]
+
+      update :skip_during_pre_flight_authorization do
+        validate AlwaysRaises do
+          where [negate(pre_flight_authorization())]
+        end
+      end
+
+      update :only_during_pre_flight_authorization do
+        validate AlwaysRaises do
+          where [pre_flight_authorization()]
+        end
+      end
+    end
+
+    policies do
+      policy always() do
+        authorize_if always()
+      end
+    end
+
+    attributes do
+      uuid_v7_primary_key :id
+      attribute :title, :string, allow_nil?: true, public?: true
+    end
+  end
+
+  describe "negate(pre_flight_authorization())" do
+    test "skips validation during Ash.can? (pre_flight?: true)" do
+      post = Ash.create!(Post, %{title: "hello"})
+      assert Ash.can?({post, :skip_during_pre_flight_authorization}, nil, pre_flight?: true)
+    end
+
+    test "runs validation during Ash.can? with pre_flight?: false" do
+      post = Ash.create!(Post, %{title: "hello"})
+
+      assert_raise Ash.Error.Unknown, ~r/validation was not skipped/, fn ->
+        Ash.can?({post, :skip_during_pre_flight_authorization}, nil, pre_flight?: false)
+      end
+    end
+
+    test "runs validation during normal action execution" do
+      post = Ash.create!(Post, %{title: "hello"})
+
+      assert_raise Ash.Error.Unknown, ~r/validation was not skipped/, fn ->
+        Ash.update(post, %{}, action: :skip_during_pre_flight_authorization)
+      end
+    end
+  end
+
+  describe "pre_flight_authorization()" do
+    test "runs validation during Ash.can? (pre_flight?: true)" do
+      post = Ash.create!(Post, %{title: "hello"})
+
+      assert_raise Ash.Error.Unknown, ~r/validation was not skipped/, fn ->
+        Ash.can?({post, :only_during_pre_flight_authorization}, nil, pre_flight?: true)
+      end
+    end
+
+    test "skips validation during Ash.can? with pre_flight?: false" do
+      post = Ash.create!(Post, %{title: "hello"})
+      assert Ash.can?({post, :only_during_pre_flight_authorization}, nil, pre_flight?: false)
+    end
+
+    test "skips validation during normal action execution" do
+      post = Ash.create!(Post, %{title: "hello"})
+      assert {:ok, _} = Ash.update(post, %{}, action: :only_during_pre_flight_authorization)
+    end
+  end
+end


### PR DESCRIPTION
-  Set pre_flight_authorization? in context earlier so it's available during validation, rather than setting it after subject construction.
- Use that private context to implement pre_flight_authorization()

Btw is there a reason context is ignored here? 

```elixir
%Ash.Changeset{} = changeset ->
    changeset
    |> Ash.Changeset.set_tenant(opts[:tenant] || changeset.tenant)
    |> Ash.Changeset.set_context(%{private: %{actor: actor}})
```

Also for %Ash.ActionInput{} and %Ash.Query{}

I know the caller can add whatever context they want in the subject itself when they call Ash.can like this:

```elixir
Ash.can?(changeset |> Ash.Changeset.set_context(...), actor)
```

But the context is ignored if sent like this, which isn't what I expected since context almost always get merged in other places.
```elixir 
Ash.can?(changeset, actor, context: ...)
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
