### PR TITLE
feat: add generate_rest? option to seed_generator

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -453,14 +453,7 @@ defmodule Ash.Generator do
           {resource, attributes} ->
             merged = Map.merge(attributes, Map.new(opts[:overrides] || %{}))
 
-            if opts[:generate_rest?] == false do
-              validate_required_attributes(resource, merged, :create)
-
-              merged
-              |> to_generators()
-              |> Map.put(:__will_be_struct__, resource)
-              |> StreamData.fixed_map()
-            else
+            if Keyword.get(opts, :generate_rest?, true) do
               resource
               |> Ash.Resource.Info.attributes()
               |> Enum.reject(&(!&1.writable? && &1.generated?))
@@ -472,6 +465,13 @@ defmodule Ash.Generator do
                 :create,
                 []
               )
+            else
+              validate_required_attributes(resource, merged, :create)
+
+              merged
+              |> to_generators()
+              |> Map.put(:__will_be_struct__, resource)
+              |> StreamData.fixed_map()
             end
         end
       end)
@@ -515,10 +515,7 @@ defmodule Ash.Generator do
         {_resource, attributes} ->
           merged = Map.merge(attributes, Map.new(opts[:overrides] || %{}))
 
-          if opts[:generate_rest?] == false do
-            validate_required_attributes(resource, merged, :create)
-            merged |> to_generators() |> StreamData.fixed_map()
-          else
+          if Keyword.get(opts, :generate_rest?, true) do
             resource
             |> Ash.Resource.Info.attributes()
             |> Enum.reject(&(!&1.writable? && &1.generated?))
@@ -528,6 +525,9 @@ defmodule Ash.Generator do
               :create,
               []
             )
+          else
+            validate_required_attributes(resource, merged, :create)
+            merged |> to_generators() |> StreamData.fixed_map()
           end
       end
       |> StreamData.map(fn keys ->

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -1142,6 +1142,10 @@ defmodule Ash.Generator do
   end
 
   defp validate_required_attributes(resource, generators, action_type) do
+    action = Ash.Resource.Info.primary_action(resource, action_type)
+    allow_nil_input = (action && Map.get(action, :allow_nil_input)) || []
+    require_attributes = (action && Map.get(action, :require_attributes)) || []
+
     resource
     |> Ash.Resource.Info.attributes()
     |> Enum.reject(&(!&1.writable? && &1.generated?))
@@ -1149,10 +1153,19 @@ defmodule Ash.Generator do
       default =
         if action_type == :create, do: attribute.default, else: attribute.update_default
 
-      if !attribute.allow_nil? && is_nil(default) && !Map.has_key?(generators, attribute.name) do
+      required? =
+        cond do
+          attribute.name in allow_nil_input -> false
+          attribute.name in require_attributes -> true
+          attribute.allow_nil? -> false
+          !is_nil(default) -> false
+          true -> true
+        end
+
+      if required? && !Map.has_key?(generators, attribute.name) do
         raise ArgumentError,
               "Attribute #{inspect(attribute.name)} on #{inspect(resource)} is required " <>
-                "(allow_nil?: false) and has no default, but no generator was provided. " <>
+                "and has no default, but no generator was provided. " <>
                 "Add a generator for this attribute or set generate_rest?: true."
       end
     end)

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -234,6 +234,46 @@ defmodule Ash.Test.GeneratorTest do
     end
   end
 
+  defmodule ActionOverrides do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+
+      create :create do
+        primary? true
+        allow_nil_input [:required_attr]
+        require_attributes [:defaulted_attr]
+      end
+
+      defaults [:read, :destroy, update: :*]
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :required_attr, :string do
+        public?(true)
+        allow_nil? false
+      end
+
+      attribute :defaulted_attr, :string do
+        public?(true)
+        default "default value"
+      end
+
+      attribute :regular_required, :string do
+        public?(true)
+        allow_nil? false
+      end
+    end
+  end
+
   defmodule Generator do
     use Ash.Generator
 
@@ -687,7 +727,6 @@ defmodule Ash.Test.GeneratorTest do
         |> Ash.Generator.generate()
 
       assert %Author{} = result
-      assert result.name != nil
     end
 
     test "generate_rest?: true generates all attributes" do
@@ -696,7 +735,6 @@ defmodule Ash.Test.GeneratorTest do
         |> Ash.Generator.generate()
 
       assert %Author{} = result
-      assert result.name != nil
     end
 
     test "generate_rest?: false only generates listed attributes" do
@@ -761,6 +799,42 @@ defmodule Ash.Test.GeneratorTest do
       assert %Author{} = result
       assert result.name == "Generated Name"
       assert result.metadata == nil
+    end
+
+    test "generate_rest?: false respects primary action's allow_nil_input" do
+      result =
+        Ash.Generator.seed_generator(
+          {ActionOverrides, %{defaulted_attr: "x", regular_required: "y"}},
+          generate_rest?: false
+        )
+        |> Ash.Generator.generate()
+
+      assert %ActionOverrides{} = result
+      assert result.required_attr == nil
+    end
+
+    test "generate_rest?: false respects primary action's require_attributes" do
+      assert_raise ArgumentError,
+                   ~r/Attribute :defaulted_attr .* is required/,
+                   fn ->
+                     Ash.Generator.seed_generator(
+                       {ActionOverrides, %{regular_required: "y"}},
+                       generate_rest?: false
+                     )
+                     |> Ash.Generator.generate()
+                   end
+    end
+
+    test "generate_rest?: false still raises for resource-level required attrs not in overrides" do
+      assert_raise ArgumentError,
+                   ~r/Attribute :regular_required .* is required/,
+                   fn ->
+                     Ash.Generator.seed_generator(
+                       {ActionOverrides, %{defaulted_attr: "x"}},
+                       generate_rest?: false
+                     )
+                     |> Ash.Generator.generate()
+                   end
     end
   end
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the AI Policy, or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Problem

`seed_generator` in its tuple form `{Resource, %{attrs}}` generates random values for all writable, non-generated attributes, even those not listed in the attributes map. This makes it easy to accidentally introduce nondeterminism into test generators — any attribute not explicitly pinned will receive a random value, which can cause flaky tests that are difficult to trace back to the generator.

## Solution

Adds a `generate_rest?` option to `seed_generator/2`. When `false`, only attributes explicitly listed in the attributes map (and overrides) receive generated values. Unlisted attributes receive their resource-level default or `nil` (if `allow_nil?`). Raises with a clear message if a required attribute (`allow_nil?: false`, no default) is not provided, catching missing generators early.

```elixir
seed_generator(
  {MyApp.Document, %{name: StreamData.string(:alphanumeric)}},
  generate_rest?: false
)
```

Defaults to `true` to preserve existing behavior.