### PR TITLE
fix: rollback transaction when manage_relationships fails in bulk actions

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -1514,6 +1514,15 @@ defmodule Ash.Actions.Create.Bulk do
             end
 
           {:error, error} ->
+            if opts[:transaction] && opts[:rollback_on_error?] do
+              if Ash.DataLayer.in_transaction?(changeset.resource) do
+                Ash.DataLayer.rollback(
+                  changeset.resource,
+                  error
+                )
+              end
+            end
+
             [{:error, error, changeset}]
         end
 

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -2197,6 +2197,15 @@ defmodule Ash.Actions.Destroy.Bulk do
             end
 
           {:error, error} ->
+            if opts[:transaction] && opts[:rollback_on_error?] do
+              if Ash.DataLayer.in_transaction?(changeset.resource) do
+                Ash.DataLayer.rollback(
+                  changeset.resource,
+                  error
+                )
+              end
+            end
+
             [{:error, error, changeset}]
         end
 

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -2799,6 +2799,15 @@ defmodule Ash.Actions.Update.Bulk do
             end
 
           {:error, error} ->
+            if opts[:transaction] && opts[:rollback_on_error?] do
+              if Ash.DataLayer.in_transaction?(changeset.resource) do
+                Ash.DataLayer.rollback(
+                  changeset.resource,
+                  error
+                )
+              end
+            end
+
             [{:error, error, changeset}]
         end
 


### PR DESCRIPTION
## Summary

- In `run_after_action_hooks`, when `manage_relationships` returns `{:error, error}`, the code returned the error tuple without calling `Ash.DataLayer.rollback`
- The `run_after_actions` error path directly above already had the rollback call — this was simply missing from the `manage_relationships` error path
- With `transaction: :batch`, this caused parent records to be committed despite child validation failures, because `process_results` runs outside the batch transaction and its `maybe_rollback` safety net can no longer help
- The fix adds the same rollback logic to `create/bulk.ex`, `update/bulk.ex`, and `destroy/bulk.ex`

## Related

- Regression tests: ash-project/ash_postgres#(pending — see test PR)

## Test plan

- [ ] Regression tests in ash_postgres pass with `ASH_VERSION=local`: 19 tests, 0 failures
- [ ] Without fix: 7 failures across bulk_create, bulk_update, and bulk_destroy with `transaction: :batch`
- [ ] Existing ash test suite passes