### PR TITLE
feat: make enum label/description overridable

### DIFF
--- a/lib/ash/type/enum.ex
+++ b/lib/ash/type/enum.ex
@@ -111,6 +111,32 @@ defmodule Ash.Type.Enum do
   MyApp.TicketStatus.details(:closed)
   iex> %{description: "A closed ticket", label: "Closed"}
   ```
+
+  ### Overriding label and description
+
+  The `label/1` and `description/1` functions are overridable. This can be useful, for example,
+  to integrate with Gettext for internationalization. Use the Gettext macro in the `values` option
+  so that the keys are discovered at compile time, then override `label/1` to translate at runtime:
+
+  ```elixir
+  defmodule MyApp.TicketStatus do
+    use Gettext, backend: MyApp.Gettext
+
+    use Ash.Type.Enum,
+      values: [
+        open: [label: gettext("Open")],
+        closed: [label: gettext("Closed")],
+        escalated: [label: gettext("Escalated")]
+      ]
+
+    def label(nil), do: "N/A"
+
+    def label(value) do
+      with label when is_binary(label) <- super(value),
+        do: Gettext.gettext(MyApp.Gettext, label)
+    end
+  end
+  ```
   """
   @doc "The list of valid values (not all input types that match them)"
   @callback values() :: [atom | String.t()]
@@ -329,7 +355,12 @@ defmodule Ash.Type.Enum do
           :error
       end
 
-      defoverridable match: 1, storage_type: 0, cast_stored: 2, dump_to_native: 2
+      defoverridable match: 1,
+                     storage_type: 0,
+                     cast_stored: 2,
+                     dump_to_native: 2,
+                     label: 1,
+                     description: 1
     end
   end
 

--- a/test/support/enum.ex
+++ b/test/support/enum.ex
@@ -25,6 +25,23 @@ defmodule DescriptiveEnum do
     ]
 end
 
+defmodule OverriddenEnum do
+  @moduledoc false
+
+  use Ash.Type.Enum,
+    values: [
+      :active,
+      :inactive,
+      :archived
+    ]
+
+  def label(:active), do: "Currently Active"
+  def label(value), do: super(value)
+
+  def description(:active), do: "This item is currently active"
+  def description(value), do: super(value)
+end
+
 defmodule StringEnum do
   @moduledoc false
 

--- a/test/type/enum_test.exs
+++ b/test/type/enum_test.exs
@@ -100,6 +100,16 @@ defmodule Ash.Test.Type.EnumTest do
     assert DescriptiveEnum.label(:with_details) == "I have a label"
   end
 
+  test "label and description can be overridden" do
+    assert OverriddenEnum.label(:active) == "Currently Active"
+    assert OverriddenEnum.label(:inactive) == "Inactive"
+    assert OverriddenEnum.label(:archived) == "Archived"
+
+    assert OverriddenEnum.description(:active) == "This item is currently active"
+    assert OverriddenEnum.description(:inactive) == nil
+    assert OverriddenEnum.description(:archived) == nil
+  end
+
   describe "types are correctly generated" do
     test "simple atoms" do
       assert {:ok,


### PR DESCRIPTION
Make `label/1` and `description/1` overridable for `Ash.Type.Enum`.

Also added an example in the docs how to use this to translate labels using Gettext. Maybe this is a bit verbose and hacky (only works if the default locale `msgid` == `msgstr`), but this is what we use it for.

This is a follow-up for #2172 and #2222

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
