### PR TITLE
feat: Allow dumping and casting instance_of union types

### DIFF
--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -160,7 +160,13 @@ defmodule Ash.Type.Struct do
         fields
 
       :error ->
-        nil
+        instance_of = constraints[:instance_of]
+
+        if instance_of && Ash.Resource.Info.resource?(instance_of) do
+          instance_of
+          |> Ash.Resource.Info.attributes()
+          |> Map.new(&{&1.name, [type: &1.type, constraints: &1.constraints]})
+        end
     end
   end
 


### PR DESCRIPTION
Previously, it was not possible to use `cast_stored` to cast a union type using struct instances. It meant that it was impossible (as far as I could tell) to cast a union types directly in e.g. an `expression` calculation. It happened because the `fields/1` helper only looked at the `:fields` key in the constraints, which a instance_of union type doesn't have. However, the necessary information is available under the `:instance_of` key.

The `fields/1` helper now falls back to deriving field definitions from `Ash.Resource.Info.attributes/1` when `:instance_of` is an Ash resource. This mirrors what `handle_instance_of` already does for `cast_input`.

This commit was created in collaboration with Claude Code. It did the initial root-cause analysis and wrote the initial tests, but I have manually modified it to suit my tastes. I stand by the code as I would if I had written all of it myself.

That said, it is entirely possible that this is not the correct fix for the issue I was experiencing, or even that this new behavior isn't desired. If so, pleaes let me know.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
