### PR TITLE
fix: preserve __meta__ state in Ash.Type.Struct.apply_constraints

### DIFF
--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -285,7 +285,7 @@ defmodule Ash.Type.Struct do
   def apply_constraints(value, constraints) do
     instance_of = constraints[:instance_of]
 
-    if instance_of && is_struct(value, instance_of) do
+    if instance_of && !constraints[:fields] && is_struct(value, instance_of) do
       {:ok, value}
     else
       with {:ok, value} <- handle_fields(value, constraints) do

--- a/test/type/struct_test.exs
+++ b/test/type/struct_test.exs
@@ -449,9 +449,7 @@ defmodule Type.StructTest do
     assert loaded_struct.__meta__.state == :loaded
 
     assert {:ok, result} =
-             Ash.Type.apply_constraints(Ash.Type.Struct, loaded_struct,
-               instance_of: Embedded
-             )
+             Ash.Type.apply_constraints(Ash.Type.Struct, loaded_struct, instance_of: Embedded)
 
     assert result.__meta__.state == :loaded
     assert result.name == "fred"


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

- Fix `Ash.Type.Struct.apply_constraints` destroying `__meta__.state` (`:loaded` → `:built`) when validating an already-valid struct instance
- When `instance_of` is an Ash resource without explicit `fields`, `check_fields` was converting the struct to a plain map (losing `__meta__`, `__struct__`), then `handle_instance_of` reconstructed it via `struct()` with default `:built` state
- Add early return: if the value is already an instance of the target struct, skip `check_fields`/`handle_instance_of` entirely
- 
## Root cause

Introduced in `4e549bf66` (v3.19.0, 2026-02-28) — "feat: Allow dumping and casting instance_of union types (#2597)".

This commit added a fallback in `fields/1` to derive field definitions from `Ash.Resource.Info.attributes/1` when `instance_of` is an Ash resource. This is useful for `cast_stored`/`dump_to_native`, but caused `apply_constraints` to run `check_fields` on already-valid struct instances, converting them to plain maps and losing `__meta__` metadata.

### Impact

Any `:struct` type argument with `constraints: [instance_of: SomeAshResource]` will corrupt `__meta__.state` on loaded structs. Downstream code (e.g. `Ash.Generator.generate/1`) then treats them as new records, causing `Ash.Seed.seed!` → INSERT → unique constraint violations:

```
** (Ash.Error.Invalid) Invalid Error: Invalid value provided for id: has already been taken.
```