### PR TITLE
fix: limit struct field inference to embedded resources

### DIFF
--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -160,13 +160,27 @@ defmodule Ash.Type.Struct do
         fields
 
       :error ->
-        instance_of = constraints[:instance_of]
+        inferred_fields(constraints)
+    end
+  end
 
-        if instance_of && Ash.Resource.Info.resource?(instance_of) do
-          instance_of
-          |> Ash.Resource.Info.attributes()
-          |> Map.new(&{&1.name, [type: &1.type, constraints: &1.constraints]})
-        end
+  defp inferred_fields(constraints) do
+    with {:ok, instance_of} <- Keyword.fetch(constraints, :instance_of),
+         true <- Ash.Resource.Info.resource?(instance_of),
+         true <- Ash.Resource.Info.embedded?(instance_of) do
+      instance_of
+      |> Ash.Resource.Info.public_attributes()
+      |> Enum.map(fn attribute ->
+        {attribute.name,
+         [
+           type: attribute.type,
+           allow_nil?: attribute.allow_nil?,
+           description: attribute.description,
+           constraints: attribute.constraints || []
+         ]}
+      end)
+    else
+      _ -> nil
     end
   end
 

--- a/test/type/struct_inference_test.exs
+++ b/test/type/struct_inference_test.exs
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Type.StructInferenceTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule EmbeddedResource do
+    use Ash.Resource, data_layer: :embedded
+
+    attributes do
+      attribute(:name, :string, allow_nil?: false, public?: true)
+      attribute(:title, :string, allow_nil?: false, public?: true)
+    end
+  end
+
+  defmodule NonEmbeddedResource do
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, allow_nil?: false, public?: true)
+    end
+  end
+
+  test "cast_stored infers fields for embedded resources" do
+    assert {:ok, %EmbeddedResource{name: "fred", title: "Engineer"}} =
+             Ash.Type.cast_stored(Ash.Type.Struct, %{"name" => "fred", "title" => "Engineer"},
+               instance_of: EmbeddedResource
+             )
+  end
+
+  test "cast_stored does not infer fields for non-embedded resources" do
+    assert :error =
+             Ash.Type.cast_stored(Ash.Type.Struct, %{"id" => Ecto.UUID.generate()},
+               instance_of: NonEmbeddedResource
+             )
+  end
+end


### PR DESCRIPTION
## Summary
- Restrict `Ash.Type.Struct` field inference to `instance_of` values that are Ash embedded resources.
- Keep non-embedded resources on explicit field definitions instead of inferring from resource attributes.
- Add regression tests for both embedded inference and non-embedded non-inference behavior.

## Verification
- `mix test test/type/struct_test.exs test/type/struct_inference_test.exs`
- `mix test`