### PR TITLE
chore: add failing test for sum on count

### DIFF
--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -64,12 +64,28 @@ defmodule Ash.Test.Actions.AggregateTest do
       belongs_to :post, Ash.Test.Actions.AggregateTest.Post do
         public?(true)
       end
+
+      belongs_to :parent, Ash.Test.Actions.AggregateTest.Comment do
+        public? true
+      end
+
+      has_many :children, Ash.Test.Actions.AggregateTest.Comment do
+        destination_attribute :parent_id
+      end
     end
 
     policies do
       policy do
         condition(always())
         authorize_if expr(public == true)
+      end
+    end
+
+    aggregates do
+      count :count_of_children_relationship_based, :children
+
+      count :count_of_children_resource_based, Comment do
+        filter expr(parent_id == parent(id))
       end
     end
   end
@@ -211,6 +227,12 @@ defmodule Ash.Test.Actions.AggregateTest do
         public? true
         authorize? false
       end
+
+      sum :sum_of_count_of_children_relationship_based,
+          :comments,
+          :count_of_children_relationship_based
+
+      sum :sum_of_count_of_children_resource_based, :comments, :count_of_children_resource_based
     end
 
     relationships do
@@ -590,6 +612,27 @@ defmodule Ash.Test.Actions.AggregateTest do
       # Previously this returned {:ok, nil} because attribute/2 was used instead of field/2.
       assert {:ok, Ash.Type.Integer} =
                Ash.Resource.Info.aggregate_type(Post, :sum_of_doubled_thing3)
+    end
+
+    test "aggregates can sum on counts" do
+      post = Post |> Ash.create!(%{public: true}, authorize?: false)
+
+      comment =
+        Comment
+        |> Ash.create!(%{post_id: post.id, public: true}, authorize?: false)
+
+      Comment
+      |> Ash.create!(%{post_id: post.id, public: false, parent_id: comment.id}, authorize?: false)
+
+      post =
+        Ash.load!(post, [
+          :sum_of_count_of_children_relationship_based,
+          :sum_of_count_of_children_resource_based,
+          comments: :count_of_children_relationship_based
+        ])
+
+      assert post.sum_of_count_of_children_relationship_based == 0
+      assert post.sum_of_count_of_children_resource_based == 0
     end
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Description

An aggregate of an aggregate bypasses authorization as shown in failing tests. Aggregates of aggregates work correctly when using the new resource based approach, but they are broken when using relationships. 

This isn't such a strange use-case if you imagine something like this:

```ex
defmodule Document do
  relationships do
    belongs_to :category, Category
  end

  policies do
    policy action(:read) do 
      # imagine a filter policy here where I can only see 2 of 4 documents in a given category or child category
    end
  end
end

defmodule Category do
  relationships do
    belongs_to :parent_category, Category
    has_many :child_categories, Category
    has_many :documents, Document
  end

  aggregates do
    count :count_of_documents, :documents

    # This aggregate fails because it skips policies
    count :sum_of_count_of_documents_of_child_categories, :child_categories, :count_of_documents # I know the naming is a bit weird
  end
end
```

I added tests that re-use the existing fixtures in the `aggregate_tests.exs` file.