### PR TITLE
feat: add generate/1 and bingenerate/1 accepting a DateTime to Ash.UUIDv7

### DIFF
--- a/lib/ash/uuid_v7.ex
+++ b/lib/ash/uuid_v7.ex
@@ -39,27 +39,41 @@ defmodule Ash.UUIDv7 do
   @doc """
   Generates a version 7 UUID using submilliseconds for increased clock precision.
 
-  ## Example
+  Optionally accepts a `DateTime` to embed a specific timestamp, which is useful
+  when migrating existing records and you need to preserve their original creation order.
+
+  ## Examples
 
       iex> UUIDv7.generate()
       "018e90d8-06e8-7f9f-bfd7-6730ba98a51b"
 
+      iex> UUIDv7.generate(~U[2024-01-01 00:00:00Z])
+      "018cfa9b-b400-7e72-a400-000398daddd9"
+
   """
   @spec generate() :: t
+  @spec generate(DateTime.t()) :: t
   def generate, do: bingenerate() |> encode()
+  def generate(%DateTime{} = dt), do: bingenerate(dt) |> encode()
 
   @doc """
   Generates a version 7 UUID in the binary format.
 
-  ## Example
+  Optionally accepts a `DateTime` to embed a specific timestamp, which is useful
+  when migrating existing records and you need to preserve their original creation order.
+
+  ## Examples
 
       iex> UUIDv7.bingenerate()
       <<1, 142, 144, 216, 6, 232, 127, 159, 191, 215, 103, 48, 186, 152, 165, 27>>
 
   """
   @spec bingenerate() :: raw
-  def bingenerate do
-    timestamp_nanoseconds = System.system_time(:nanosecond)
+  @spec bingenerate(DateTime.t()) :: raw
+  def bingenerate, do: do_bingenerate(System.system_time(:nanosecond))
+  def bingenerate(%DateTime{} = dt), do: do_bingenerate(DateTime.to_unix(dt, :nanosecond))
+
+  defp do_bingenerate(timestamp_nanoseconds) do
     timestamp_milliseconds = trunc(timestamp_nanoseconds / 1_000_000)
 
     nanoseconds = timestamp_nanoseconds - timestamp_milliseconds * 1_000_000

--- a/test/uuid_v7_test.exs
+++ b/test/uuid_v7_test.exs
@@ -54,6 +54,31 @@ defmodule Ash.Test.UUIDv7Test do
     assert :error = Ash.UUIDv7.encode("error")
   end
 
+  test "generate/1 with a DateTime embeds the correct timestamp" do
+    dt = ~U[2024-04-11 00:00:00Z]
+    expected_ms = DateTime.to_unix(dt, :millisecond)
+
+    uuid = Ash.UUIDv7.generate(dt)
+    assert Ash.UUIDv7.extract_timestamp(uuid) == expected_ms
+  end
+
+  test "generate/1 with different DateTimes produces correctly ordered UUIDs" do
+    dt1 = ~U[2023-01-01 00:00:00Z]
+    dt2 = ~U[2024-01-01 00:00:00Z]
+    dt3 = ~U[2025-01-01 00:00:00Z]
+
+    uuids = [Ash.UUIDv7.generate(dt1), Ash.UUIDv7.generate(dt2), Ash.UUIDv7.generate(dt3)]
+    assert uuids == Enum.sort(uuids)
+  end
+
+  test "bingenerate/1 with a DateTime embeds the correct timestamp" do
+    dt = ~U[2024-04-11 00:00:00Z]
+    expected_ms = DateTime.to_unix(dt, :millisecond)
+
+    raw = Ash.UUIDv7.bingenerate(dt)
+    assert Ash.UUIDv7.extract_timestamp(raw) == expected_ms
+  end
+
   test "decode/1 is working" do
     hex_uuid = Ash.UUIDv7.generate()
     raw_uuid = Ash.UUIDv7.bingenerate()


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

- Extracts `bingenerate/0` body into `defp do_bingenerate(timestamp_nanoseconds)`
- Adds `generate/1` and `bingenerate/1` accepting a `DateTime` — both delegate to the same private function, so no logic is duplicated

Closes #1303