### PR TITLE
fix: use individually overridden callbacks within array callbacks

### DIFF
--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -214,15 +214,48 @@ defmodule Ash.Type.NewType do
       end
 
       @impl Ash.Type
-      def cast_input_array(value, constraints) do
-        subtype_constraints = subtype_constraints(constraints)
+      def cast_input_array(nil, _), do: {:ok, nil}
 
-        with {:ok, value} <- unquote(subtype_of).cast_input_array(value, subtype_constraints) do
-          Ash.Type.apply_constraints(
-            {:array, unquote(subtype_of)},
-            value,
-            items: subtype_constraints
-          )
+      def cast_input_array(term, constraints) do
+        term
+        |> Stream.with_index()
+        |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, casted} ->
+          case cast_input(item, constraints) do
+            :error ->
+              {:halt, {:error, message: "invalid value at %{index}", index: index, path: [index]}}
+
+            {:error, keyword} ->
+              errors =
+                keyword
+                |> List.wrap()
+                |> Ash.Helpers.flatten_preserving_keywords()
+                |> Enum.map(fn
+                  message when is_binary(message) ->
+                    [message: message, index: index, path: [index]]
+
+                  error when is_exception(error) ->
+                    error
+                    |> Ash.Error.to_ash_error()
+                    |> Ash.Error.set_path([index])
+
+                  keyword ->
+                    keyword
+                    |> Keyword.put(:index, index)
+                    |> Keyword.update(:path, [index], &[index | &1])
+                end)
+
+              {:halt, {:error, errors}}
+
+            {:ok, value} ->
+              {:cont, {:ok, [value | casted]}}
+          end
+        end)
+        |> case do
+          {:ok, result} ->
+            {:ok, Enum.reverse(result)}
+
+          {:error, error} ->
+            {:error, error}
         end
       end
 
@@ -276,9 +309,38 @@ defmodule Ash.Type.NewType do
       end
 
       @impl Ash.Type
-      def cast_stored_array(value, constraints) do
-        constraints = subtype_constraints(constraints)
-        Ash.Type.cast_stored({:array, unquote(subtype_of)}, value, items: constraints)
+      def cast_stored_array(term, constraints) do
+        if is_nil(term) do
+          {:ok, nil}
+        else
+          term
+          |> Enum.with_index()
+          |> Enum.reverse()
+          |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, casted} ->
+            case cast_stored(item, constraints) do
+              :error ->
+                {:halt, {:error, index: index}}
+
+              {:error, keyword} ->
+                errors =
+                  keyword
+                  |> List.wrap()
+                  |> Ash.Helpers.flatten_preserving_keywords()
+                  |> Enum.map(fn
+                    string when is_binary(string) ->
+                      [message: string, index: index]
+
+                    vars ->
+                      Keyword.put(vars, :index, index)
+                  end)
+
+                {:halt, {:error, errors}}
+
+              {:ok, value} ->
+                {:cont, {:ok, [value | casted]}}
+            end
+          end)
+        end
       end
 
       @impl Ash.Type
@@ -307,9 +369,23 @@ defmodule Ash.Type.NewType do
       end
 
       @impl Ash.Type
-      def dump_to_embedded_array(value, constraints) do
-        constraints = subtype_constraints(constraints)
-        Ash.Type.dump_to_embedded({:array, unquote(subtype_of)}, value, items: constraints)
+      def dump_to_embedded_array(term, constraints) do
+        if is_nil(term) do
+          {:ok, nil}
+        else
+          term
+          |> Enum.with_index()
+          |> Enum.reverse()
+          |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, dumped} ->
+            case dump_to_embedded(item, constraints) do
+              {:ok, value} ->
+                {:cont, {:ok, [value | dumped]}}
+
+              error ->
+                {:halt, Ash.Helpers.error_with_context(error, index: index)}
+            end
+          end)
+        end
       end
 
       @impl Ash.Type
@@ -319,9 +395,23 @@ defmodule Ash.Type.NewType do
       end
 
       @impl Ash.Type
-      def dump_to_native_array(value, constraints) do
-        constraints = subtype_constraints(constraints)
-        Ash.Type.dump_to_native({:array, unquote(subtype_of)}, value, items: constraints)
+      def dump_to_native_array(term, constraints) do
+        if is_nil(term) do
+          {:ok, nil}
+        else
+          term
+          |> Enum.with_index()
+          |> Enum.reverse()
+          |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, dumped} ->
+            case dump_to_native(item, constraints) do
+              {:ok, value} ->
+                {:cont, {:ok, [value | dumped]}}
+
+              error ->
+                {:halt, Ash.Helpers.error_with_context(error, index: index)}
+            end
+          end)
+        end
       end
 
       @impl Ash.Type

--- a/test/type/new_type_test.exs
+++ b/test/type/new_type_test.exs
@@ -464,4 +464,82 @@ defmodule Ash.Test.Type.NewTypeTest do
       assert :match in keys
     end
   end
+
+  describe "array callbacks respect single-item overrides" do
+    defmodule TaggedString do
+      @moduledoc """
+      A Ash.Type.NewType that overrides all four single-item callbacks to add a
+      transformation, so we can verify the array variants route through them.
+      """
+      use Ash.Type.NewType, subtype_of: :string
+
+      @impl Ash.Type
+      def cast_input(value, constraints) do
+        case super(value, constraints) do
+          {:ok, str} -> {:ok, "cast:" <> str}
+          other -> other
+        end
+      end
+
+      @impl Ash.Type
+      def cast_stored(value, constraints) do
+        case super(value, constraints) do
+          {:ok, str} -> {:ok, "stored:" <> str}
+          other -> other
+        end
+      end
+
+      @impl Ash.Type
+      def dump_to_native(value, constraints) do
+        case super(value, constraints) do
+          {:ok, str} -> {:ok, "dumped:" <> str}
+          other -> other
+        end
+      end
+
+      @impl Ash.Type
+      def dump_to_embedded(value, constraints) do
+        case super(value, constraints) do
+          {:ok, str} -> {:ok, "embedded:" <> str}
+          other -> other
+        end
+      end
+    end
+
+    test "cast_input_array calls overridden cast_input for each element" do
+      assert {:ok, ["cast:hello", "cast:world"]} =
+               Ash.Type.cast_input({:array, TaggedString}, ["hello", "world"])
+    end
+
+    test "cast_input_array handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_input({:array, TaggedString}, nil)
+    end
+
+    test "cast_stored_array calls overridden cast_stored for each element" do
+      assert {:ok, ["stored:hello", "stored:world"]} =
+               TaggedString.cast_stored_array(["hello", "world"], [])
+    end
+
+    test "cast_stored_array handles nil" do
+      assert {:ok, nil} = TaggedString.cast_stored_array(nil, [])
+    end
+
+    test "dump_to_native_array calls overridden dump_to_native for each element" do
+      assert {:ok, ["dumped:hello", "dumped:world"]} =
+               Ash.Type.dump_to_native({:array, TaggedString}, ["hello", "world"])
+    end
+
+    test "dump_to_native_array handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_native({:array, TaggedString}, nil)
+    end
+
+    test "dump_to_embedded_array calls overridden dump_to_embedded for each element" do
+      assert {:ok, ["embedded:hello", "embedded:world"]} =
+               Ash.Type.dump_to_embedded({:array, TaggedString}, ["hello", "world"])
+    end
+
+    test "dump_to_embedded_array handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_embedded({:array, TaggedString}, nil)
+    end
+  end
 end


### PR DESCRIPTION
I have a few types that override `cast_stored` and `dump_to_native` to override how things are stored in my DB layer (for backwards compatibility reasons, I need some things to exist in the DB one way while being a bit different in elixir/API layer).

For individual records, this works great. But, when serializing an array of records (like in an attribute that is type `{:array, MyTypeWithOverriddenCallbacks}`), the records in the arrays weren't being dumped right, they were being dumped/loaded the default way.

It turns out that the default `*_array` callback implementations for `NewType`s use the `subtype_of` value for the individual callbacks, which is why things aren't being dumped right in this case.

I wrote this up with Claude's help, which I say not to abdicate responsibility for the code, but rather just to be transparent + point out that, while I'm fairly sure this does fix the problem, I'm not 100% sure this is the best way to fix the problem—this essentially replicates the entire body of the Ash.Type functions, which definitely feels a bit janky. Very open to feedback on better ways to accomplish this.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
