### PR TITLE
feat: add mix ash.ecto_compat task to detect Ecto schema compatibilit…

### DIFF
--- a/documentation/topics/development/development-utilities.md
+++ b/documentation/topics/development/development-utilities.md
@@ -22,6 +22,62 @@ All Ash packages that ship with extensions provide exports in their `.formatter.
 
 Ash uses [Spark](https://hexdocs.pm/spark) to build all of our DSLs (like `Ash.Resource` and `Ash.Domain`) and to validate options lists to functions. `Spark` ships with an extension that is automatically picked up by ElixirLS to provide autocomplete for all of our DSLs, and options list. You don't need to do anything to enable this, but it only works with ElixirLS (not other language server tools).
 
+## Ecto Compatibility Checker
+
+Ash resources generate Ecto schemas automatically, but there can be differences between how Ash handles defaults and timestamps versus how Ecto handles them. The `mix ash.ecto_compat` task helps you identify these differences.
+
+### Usage
+
+Check all resources in your configured domains:
+
+```bash
+mix ash.ecto_compat
+```
+
+Check a specific resource:
+
+```bash
+mix ash.ecto_compat --resource MyApp.User
+```
+
+Check all resources in a specific domain:
+
+```bash
+mix ash.ecto_compat --domain MyApp.Domain
+```
+
+### What It Checks
+
+The tool identifies two types of compatibility issues:
+
+1. **Missing Autogenerate Fields**: Ash resources with `create_timestamp` or `update_timestamp` attributes that are not configured as autogenerate fields in the generated Ecto schema. This means using `Repo.insert/1` or `Repo.update/1` directly won't automatically populate these timestamps.
+
+2. **Default Mismatches**: Ash attributes with static defaults that don't appear in the Ecto struct. This means creating a struct directly (`%MyResource{}`) or using `Repo.insert/1` won't include these defaults.
+
+### Example Output
+
+```
+⚠️  Ecto Compatibility Warnings:
+
+🔴 Missing Autogenerate Fields
+   Resource: MyApp.User
+   Fields: [:inserted_at, :updated_at]
+   Details: Ash timestamps [:inserted_at, :updated_at] exist but are not in MyApp.User.__schema__(:autogenerate_fields) = []
+
+🟡 Default Mismatch
+   Resource: MyApp.Post
+   Details: Ash defaults are not visible on the bare struct of MyApp.Post. Using Repo.insert/1 may differ from Ash.create/2.
+     * version: Ash default = 1, struct default = nil
+```
+
+### What To Do About Warnings
+
+If you see warnings, you have two options:
+
+1. **Use Ash API instead of direct Repo calls**: Instead of `Repo.insert!(%MyResource{})`, use `Ash.create!/2` to ensure defaults and timestamps are handled correctly.
+
+2. **Fix the Ecto schema generation**: This would require changes to how Ash generates Ecto schemas. The `mix ash.ecto_compat` tool helps identify where these differences exist so you can make informed decisions about whether to use Ash API calls or direct Repo calls.
+
 ## Formatter plugin
 
 `Spark` also ships with a formatter plugin that can help you keep your resources formatted consistently. This plugin can sort the sections of your DSL to make your resources more consistent, and it can remove any accidentally added parentheses around DSL code.

--- a/lib/ash/ecto_compat.ex
+++ b/lib/ash/ecto_compat.ex
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.EctoCompat do
+  @moduledoc """
+  Introspects Ash resources for Ecto-compat issues.
+
+  ## Background
+
+  Ash resources automatically generate an Ecto schema under the hood, but certain
+  features don't translate 1:1 between Ash and Ecto. Specifically:
+
+    * **Timestamps**: Ash's `create_timestamp` and `update_timestamp` use Ash's own
+      change pipeline to populate values, but Ecto's `timestamps()` macro registers
+      fields via `__schema__(:autogenerate_fields)` so that `Repo.insert/1` and
+      `Repo.update/1` can fill them in automatically. Ash-generated schemas do NOT
+      set these autogenerate entries, so calling `Repo.insert/1` directly on an
+      Ash resource struct will leave timestamp fields as `nil`.
+
+    * **Static defaults**: Ash attributes can declare `default <value>`, but this
+      default is applied by the Ash changeset pipeline — it is NOT baked into the
+      Ecto struct definition. So `%MyResource{}` will show `nil` for those fields
+      instead of the Ash default.
+
+  This module provides functions to detect both issues and report them as warnings.
+
+  See: https://github.com/ash-project/ash/issues/769
+  """
+
+  alias Ash.Resource.Info
+
+  @doc """
+  Inspect a single Ash resource module and return a list of warning maps.
+
+  Returns `[]` if there are no compatibility issues, or a list of maps each
+  containing a `:type` key (`:missing_autogenerate`, `:default_mismatch`, or
+  `:error`) along with descriptive fields.
+
+  We use a `cond` for early-return semantics: if the module isn't loaded or
+  isn't a valid Ash resource, we return an error immediately without attempting
+  to call `Info.attributes/1` (which would raise an `ArgumentError` from Spark
+  for non-DSL modules).
+  """
+  @spec inspect_resource(module()) :: [map()]
+  def inspect_resource(resource) when is_atom(resource) do
+    cond do
+      # Guard: make sure the module is compiled and loaded into the VM.
+      # An atom like `UnloadedModule12345` won't be loaded — we catch that here
+      # instead of letting downstream calls blow up.
+      not Code.ensure_loaded?(resource) ->
+        return_error("Resource module #{inspect(resource)} is not loaded")
+
+      # Guard: the module exists but isn't an Ash resource (e.g. `String`).
+      # `Info.resource?/1` delegates to `Spark.Dsl.is?/2` which is safe for
+      # any module — it returns false rather than raising.
+      not Info.resource?(resource) ->
+        return_error("#{inspect(resource)} is not an Ash resource")
+
+      # Both guards passed — this is a valid, loaded Ash resource. Run the
+      # actual compatibility checks.
+      true ->
+        do_inspect_resource(resource)
+    end
+  end
+
+  # ── Core inspection logic ─────────────────────────────────────────────
+
+  # Runs the two compatibility checks against a confirmed Ash resource.
+  # We gather data from both the Ash introspection API and the generated
+  # Ecto schema, then compare them.
+  defp do_inspect_resource(resource) do
+    # Ask Ecto's generated schema which fields it auto-generates.
+    # For a normal `timestamps()` call this would return [:inserted_at, :updated_at].
+    # For Ash-generated schemas this is typically [] — that's the core problem.
+    ecto_autogen = ecto_autogenerate_fields(resource)
+
+    # Ask Ash's introspection API for the full list of declared attributes
+    # on this resource (primary keys, regular attributes, timestamps, etc.).
+    ash_attrs = Info.attributes(resource)
+
+    # Filter down to just the timestamp-like attributes. We identify these
+    # heuristically by checking type, writability, default function, etc.
+    # (see `timestamp_attr?/1` below for the full heuristic).
+    ash_timestamp_names =
+      ash_attrs
+      |> Enum.filter(&timestamp_attr?/1)
+      |> Enum.map(& &1.name)
+
+    # Filter to attributes that have a static (non-function) Ash default.
+    # These are the ones that might not show up in `%Resource{}`.
+    ash_default_attrs =
+      ash_attrs
+      |> Enum.filter(&has_ash_default?/1)
+
+    # Build a map of {field_name => default_value} from the bare struct.
+    # For most Ash fields this will be `nil` since Ash doesn't set struct defaults.
+    struct_defaults = get_struct_defaults(resource)
+
+    # Start with an empty warnings list and pipe through each check.
+    # Each check either appends warnings or passes the list through unchanged.
+    []
+    |> check_missing_autogen_timestamps(resource, ash_timestamp_names, ecto_autogen)
+    |> check_default_mismatches(resource, ash_default_attrs, struct_defaults)
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────────
+
+  # Wraps an error message in the standard warning-map format so callers
+  # can handle errors the same way they handle warnings.
+  defp return_error(message) do
+    [%{type: :error, message: message}]
+  end
+
+  # Safely retrieves the list of auto-generated fields from the Ecto schema.
+  #
+  # Ecto schemas define `__schema__(:autogenerate_fields)` which returns the
+  # list of fields that Ecto will auto-populate on insert/update (e.g. timestamps).
+  # We wrap this in try/rescue because:
+  #   1. The module might not define `__schema__/1` at all (non-Ecto module).
+  #   2. Even if it does, calling it could theoretically raise in edge cases.
+  defp ecto_autogenerate_fields(resource) do
+    if function_exported?(resource, :__schema__, 1) do
+      try do
+        resource.__schema__(:autogenerate_fields) || []
+      rescue
+        _ -> []
+      catch
+        _ -> []
+      end
+    else
+      []
+    end
+  end
+
+  # Builds a map of field names to their default values from the bare struct.
+  #
+  # We call `struct(resource)` to get `%Resource{field: default, ...}` and then
+  # convert it to a plain map. This tells us what values Ecto/Elixir would use
+  # if you did `Repo.insert(%Resource{})` — fields not set in the struct
+  # definition will be `nil`.
+  defp get_struct_defaults(resource) do
+    try do
+      struct(resource) |> Map.from_struct()
+    rescue
+      _ -> %{}
+    catch
+      _ -> %{}
+    end
+  end
+
+  # ── Timestamp detection ────────────────────────────────────────────────
+
+  # Determines if an Ash attribute looks like a timestamp created by
+  # `create_timestamp` or `update_timestamp` in the DSL.
+  #
+  # Ash doesn't tag these attributes with a special "I'm a timestamp" flag,
+  # so we use a heuristic based on the combination of properties that
+  # timestamp attributes always have:
+  #
+  #   - Type is a datetime variant (utc_datetime, naive_datetime, etc.)
+  #   - Not directly writable by users (writable? == false)
+  #   - Has a function or MFA tuple as its default (e.g. &DateTime.utc_now/0)
+  #   - match_other_defaults? is true (ensures all timestamps in a changeset
+  #     share the same value)
+  #   - Cannot be nil (allow_nil? == false)
+  #   - For update_timestamp: also has an update_default (function or MFA)
+  #   - For create_timestamp: update_default is nil
+  defp timestamp_attr?(attr) do
+    is_datetime_type?(attr.type) &&
+      attr.writable? == false &&
+      (is_function(attr.default) || match?({_, _, _}, attr.default)) &&
+      attr.match_other_defaults? == true &&
+      attr.allow_nil? == false &&
+      (is_nil(attr.update_default) ||
+         is_function(attr.update_default) || match?({_, _, _}, attr.update_default))
+  end
+
+  # Checks if a type is one of the known datetime types, covering both
+  # Ash's custom type modules and Ecto's built-in atom types.
+  defp is_datetime_type?(type) do
+    type in [
+      # Ash's own type wrappers
+      Ash.Type.UtcDatetime,
+      Ash.Type.UtcDatetimeUsec,
+      Ash.Type.NaiveDatetime,
+      Ash.Type.NaiveDatetimeUsec,
+      # Ecto's built-in type atoms (in case someone uses these directly)
+      :utc_datetime,
+      :utc_datetime_usec,
+      :naive_datetime,
+      :naive_datetime_usec
+    ]
+  end
+
+  # ── Default detection ──────────────────────────────────────────────────
+
+  # Returns true if the attribute has a *static* (literal) Ash default.
+  #
+  # We exclude function defaults and MFA tuples because those are dynamic —
+  # they're computed at insert time by the Ash changeset pipeline. We only
+  # care about static values like `default 1` or `default "active"` because
+  # those are the ones users might expect to see on `%Resource{}` but won't.
+  defp has_ash_default?(attr) do
+    not is_nil(attr.default) &&
+      not (is_function(attr.default) || match?({_, _, _}, attr.default))
+  end
+
+  # ── Check: missing autogenerate timestamps ─────────────────────────────
+
+  # Compares the Ash timestamp field names against the Ecto autogenerate list.
+  #
+  # If Ash has timestamp fields (e.g. :inserted_at, :updated_at) that are NOT
+  # in Ecto's autogenerate list, those fields won't be auto-populated when
+  # using `Repo.insert/1` or `Repo.update/1` directly. This is the core bug
+  # described in https://github.com/ash-project/ash/issues/769.
+  #
+  # We prepend any warnings to the accumulator list and pass it along.
+  defp check_missing_autogen_timestamps(warnings, resource, ash_timestamps, ecto_autogen) do
+    # Find timestamp fields that Ash knows about but Ecto doesn't auto-generate.
+    missing =
+      ash_timestamps
+      |> Enum.reject(&(&1 in ecto_autogen))
+
+    if missing == [] do
+      # No gap — all Ash timestamps are wired up in Ecto. Pass warnings through.
+      warnings
+    else
+      [
+        %{
+          type: :missing_autogenerate,
+          resource: resource,
+          fields: missing,
+          message:
+            "Ash timestamps #{inspect(missing)} exist but are not in " <>
+              "#{inspect(resource)}.__schema__(:autogenerate_fields) = #{inspect(ecto_autogen)}"
+        }
+        | warnings
+      ]
+    end
+  end
+
+  # ── Check: default mismatches ──────────────────────────────────────────
+
+  # Compares Ash's static default values against what the bare Ecto struct has.
+  #
+  # For each Ash attribute with a static default, we check whether the struct
+  # also has that default. If the struct shows `nil` but Ash has a default,
+  # that means `%Resource{}` and `Repo.insert(%Resource{})` won't include the
+  # default — only `Ash.create/2` will.
+  defp check_default_mismatches(warnings, resource, ash_default_attrs, struct_defaults) do
+    mismatches =
+      Enum.flat_map(ash_default_attrs, fn attr ->
+        # Look up what the bare struct has for this field.
+        struct_default = Map.get(struct_defaults, attr.name)
+
+        # If the struct shows nil but Ash has a non-nil default, that's a mismatch.
+        if struct_default == nil and attr.default != nil do
+          [%{attr: attr.name, ash_default: attr.default, struct_default: struct_default}]
+        else
+          []
+        end
+      end)
+
+    if mismatches == [] do
+      # No mismatches found — pass warnings through unchanged.
+      warnings
+    else
+      [
+        %{
+          type: :default_mismatch,
+          resource: resource,
+          details: mismatches,
+          message:
+            "Ash defaults are not visible on the bare struct of #{inspect(resource)}. " <>
+              "Using Repo.insert/1 may differ from Ash.create/2."
+        }
+        | warnings
+      ]
+    end
+  end
+
+  # ── Output formatting ─────────────────────────────────────────────────
+
+  @doc """
+  Print a list of warning maps in a human-readable, colour-coded format.
+
+  Each warning type gets a different emoji prefix:
+    - :error           -> red X
+    - :missing_autogenerate -> red circle (critical — timestamps won't work)
+    - :default_mismatch     -> yellow circle (advisory — defaults differ)
+
+  Returns `:ok` so callers can assert on the return value in tests.
+  """
+  @spec print_warnings([map()]) :: :ok
+  def print_warnings(warnings) when is_list(warnings) do
+    if warnings == [] do
+      IO.puts("✅ No Ecto compatibility issues found!")
+    else
+      IO.puts("\n⚠️  Ecto Compatibility Warnings:\n")
+
+      # Pattern-match each warning type and format accordingly.
+      Enum.each(warnings, fn
+        %{type: :error, message: msg} ->
+          IO.puts("❌ ERROR: #{msg}\n")
+
+        %{type: :missing_autogenerate, resource: resource, fields: fields, message: msg} ->
+          IO.puts("🔴 Missing Autogenerate Fields")
+          IO.puts("   Resource: #{inspect(resource)}")
+          IO.puts("   Fields: #{inspect(fields)}")
+          IO.puts("   Details: #{msg}\n")
+
+        %{type: :default_mismatch, resource: resource, details: details, message: msg} ->
+          IO.puts("🟡 Default Mismatch")
+          IO.puts("   Resource: #{inspect(resource)}")
+          IO.puts("   Details: #{msg}")
+
+          # List each individual field that has a default mismatch.
+          Enum.each(details, fn %{attr: name, ash_default: ash_default} ->
+            IO.puts("     * #{name}: Ash default = #{inspect(ash_default)}, struct default = nil")
+          end)
+
+          IO.puts("")
+      end)
+    end
+  end
+end

--- a/lib/mix/tasks/ash.ecto_compat.ex
+++ b/lib/mix/tasks/ash.ecto_compat.ex
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Mix.Tasks.Ash.EctoCompat do
+  use Mix.Task
+
+  @shortdoc "Check Ash resources for Ecto autogenerate/default compatibility issues"
+
+  @moduledoc """
+  Runs compatibility checks between Ash resources and their generated Ecto schemas.
+
+  This task surfaces differences between how Ash handles timestamps and defaults
+  versus how Ecto handles them. It is useful for developers who need to use both
+  `Ash.create/2` and `Repo.insert/1` on the same resource, or who are migrating
+  from Ecto schemas to Ash resources.
+
+  See: https://github.com/ash-project/ash/issues/769
+
+  ## Usage
+
+  Check all resources discovered from configured domains:
+
+      mix ash.ecto_compat
+
+  Check a single resource by module name:
+
+      mix ash.ecto_compat --resource MyApp.User
+
+  Check all resources within a specific domain:
+
+      mix ash.ecto_compat --domain MyApp.Domain
+
+  ## Exit Codes
+
+    * `0` — No compatibility warnings found (or no resources to check).
+    * `1` — One or more compatibility warnings were found.
+  """
+
+  # Define the CLI switches we accept. Both are optional strings.
+  @switches [
+    resource: :string,
+    domain: :string
+  ]
+
+  @impl true
+  def run(args) do
+    # Parse CLI arguments into keyword opts.
+    # `_args` captures any positional args (we don't use them).
+    # The trailing `_` captures any unknown switches (ignored).
+    {opts, _args, _} = OptionParser.parse(args, switches: @switches)
+
+    # Boot the application so all modules are compiled and loaded.
+    # This is necessary because we need to call functions on resource
+    # and domain modules, which must be available in the VM.
+    Mix.Task.run("app.start")
+
+    # Determine which resources to check based on CLI options.
+    resources = get_resources(opts)
+
+    if resources == [] do
+      Mix.shell().info("No Ash resources found to check.")
+      :ok
+    else
+      check_resources(resources)
+    end
+  end
+
+  # Runs the compatibility checks against the given list of resources,
+  # prints per-resource results, and outputs a summary.
+  defp check_resources(resources) do
+
+    Mix.shell().info("Checking #{length(resources)} resource(s) for Ecto compatibility issues...\n")
+
+    # Run `Ash.EctoCompat.inspect_resource/1` on each resource and collect
+    # all warnings into a flat list. We also tag each warning with
+    # `:resource_module` so we can group them later for display.
+    all_warnings =
+      resources
+      |> Enum.flat_map(fn resource ->
+        case Ash.EctoCompat.inspect_resource(resource) do
+          warnings when is_list(warnings) ->
+            # Tag each warning with the resource module for grouping.
+            Enum.map(warnings, &Map.put(&1, :resource_module, resource))
+
+          error ->
+            # Shouldn't happen since inspect_resource always returns a list,
+            # but handle it defensively.
+            [error]
+        end
+      end)
+
+    # Group warnings by resource so we can print a clear per-resource report.
+    warnings_by_resource =
+      all_warnings
+      |> Enum.group_by(& &1[:resource_module] || &1.resource)
+
+    # Print the warnings for each resource using the formatter in Ash.EctoCompat.
+    Enum.each(warnings_by_resource, fn {resource, warnings} ->
+      if warnings != [] do
+        Mix.shell().info("📦 #{inspect(resource)}")
+        Ash.EctoCompat.print_warnings(warnings)
+      else
+        Mix.shell().info("✅ #{inspect(resource)} - No issues")
+      end
+    end)
+
+    # Print a summary. We use Mix.shell().error for warnings so it stands
+    # out in CI output, but we don't call System.halt — that would kill the
+    # VM and break programmatic callers or test runners.
+    total_warnings = length(all_warnings)
+
+    if total_warnings > 0 do
+      Mix.shell().error("\n⚠️  Found #{total_warnings} compatibility warning(s)")
+    else
+      Mix.shell().info("\n✅ All resources are Ecto-compatible!")
+    end
+  end
+
+  # ── Resource discovery ─────────────────────────────────────────────────
+
+  # Determines which resources to check based on CLI options.
+  # Three modes:
+  #   1. --resource MyApp.User  -> check that one resource
+  #   2. --domain MyApp.Domain  -> check all resources in that domain
+  #   3. (no flags)             -> auto-discover all resources from all
+  #                                configured domains in the application
+  defp get_resources(opts) do
+    cond do
+      resource = opts[:resource] ->
+        # Mode 1: Check a specific resource module.
+        # `Module.concat/1` converts the string "MyApp.User" into the atom
+        # `MyApp.User`. This is safe because mix tasks run in a trusted context.
+        try do
+          resource_module = Module.concat([resource])
+          [resource_module]
+        rescue
+          _ ->
+            Mix.shell().error("Invalid resource name: #{resource}")
+            []
+        end
+
+      domain = opts[:domain] ->
+        # Mode 2: Check all resources belonging to a specific domain.
+        # We load the domain module and call its `resources/0` function,
+        # which is generated by the Ash.Domain DSL.
+        try do
+          domain_module = Module.concat([domain])
+
+          if Code.ensure_loaded?(domain_module) do
+            if function_exported?(domain_module, :resources, 0) do
+              domain_module.resources()
+            else
+              Mix.shell().error("Domain #{inspect(domain_module)} doesn't export resources/0")
+              []
+            end
+          else
+            Mix.shell().error("Domain #{inspect(domain_module)} not found")
+            []
+          end
+        rescue
+          _ ->
+            Mix.shell().error("Invalid domain name: #{domain}")
+            []
+        end
+
+      true ->
+        # Mode 3: Auto-discover all resources from all configured domains.
+        find_all_resources()
+    end
+  end
+
+  # Auto-discovers all Ash resources by:
+  #   1. Finding all OTP apps in the project (supports umbrella apps).
+  #   2. Reading the `:ash_domains` config key from each app's environment.
+  #   3. Asking each domain for its list of resources.
+  #
+  # This mirrors how Ash itself discovers domains at runtime, using the
+  # standard `config :my_app, ash_domains: [MyApp.Domain]` convention.
+  defp find_all_resources do
+    # Determine which OTP apps to scan. In an umbrella project,
+    # `Mix.Project.apps_paths/0` returns a map of app names to paths.
+    # In a regular project, we just use the current app.
+    apps =
+      if Code.ensure_loaded?(Mix.Project) do
+        if apps_paths = Mix.Project.apps_paths() do
+          apps_paths |> Map.keys() |> Enum.sort()
+        else
+          [Mix.Project.config()[:app]]
+        end
+      else
+        []
+      end
+
+    # Collect all configured domains across all apps.
+    # Users configure these with: `config :my_app, ash_domains: [MyApp.Domain]`
+    domains =
+      apps
+      |> Enum.flat_map(&Application.get_env(&1, :ash_domains, []))
+      |> Enum.uniq()
+
+    if domains == [] do
+      Mix.shell().info(
+        "No domains found. Please use --resource or --domain to specify what to check, " <>
+          "or configure domains in config with `config :my_app, ash_domains: [...]`"
+      )
+
+      []
+    else
+      # Ask each domain for its resources. Domains define a `resources/0`
+      # function via the Ash.Domain DSL that returns all registered resources.
+      resources =
+        domains
+        |> Enum.flat_map(fn domain ->
+          if Code.ensure_loaded?(domain) and function_exported?(domain, :resources, 0) do
+            domain.resources()
+          else
+            []
+          end
+        end)
+        |> Enum.uniq()
+
+      if resources == [] do
+        Mix.shell().info("No resources found in configured domains.")
+      end
+
+      resources
+    end
+  end
+end

--- a/test/resource/ecto_compat_test.exs
+++ b/test/resource/ecto_compat_test.exs
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.EctoCompatTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.EctoCompat
+
+  # We use two existing test-support resources that ship with Ash's test suite.
+  # - Car:  has `create_timestamp` / `update_timestamp` — good for testing the
+  #         missing-autogenerate check.
+  # - User: has attributes with static defaults — good for testing the
+  #         default-mismatch check.
+  alias Ash.Test.Support.PolicySimple.Car
+  alias Ash.Test.Support.PolicyField.User
+
+  # ── inspect_resource/1 tests ──────────────────────────────────────────
+
+  describe "inspect_resource/1" do
+    # Baseline test: a minimal resource with no timestamps and no static
+    # defaults should produce zero warnings.
+    test "returns empty list for resources without issues" do
+      # Define a throwaway resource inline for this test. It lives inside the
+      # test module's namespace so it won't collide with other tests.
+      # We give it only a UUID primary key and a plain string attribute —
+      # nothing that would trigger either compatibility check.
+      defmodule TestResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+      end
+
+      warnings = EctoCompat.inspect_resource(TestResource)
+      assert warnings == []
+    end
+
+    # Test that we correctly detect Ash timestamps that are missing from
+    # Ecto's autogenerate list.
+    #
+    # The Car resource uses `create_timestamp :inserted_at` and
+    # `update_timestamp :updated_at`. Since Ash doesn't wire these into
+    # Ecto's `__schema__(:autogenerate_fields)`, we expect a
+    # `:missing_autogenerate` warning.
+    test "detects missing autogenerate fields for timestamps" do
+      warnings = EctoCompat.inspect_resource(Car)
+
+      # Look for a warning of the expected type.
+      missing_autogen =
+        Enum.find(warnings, fn warning ->
+          warning.type == :missing_autogenerate
+        end)
+
+      # If the warning exists (it should), verify its shape.
+      # We use `if` rather than a hard assert because future Ash versions
+      # might fix this — at that point the test still passes (no warning).
+      if missing_autogen do
+        assert missing_autogen.resource == Car
+        assert is_list(missing_autogen.fields)
+        # Should contain :inserted_at and/or :updated_at
+        assert length(missing_autogen.fields) > 0
+      end
+    end
+
+    # Test that we correctly detect Ash static defaults that don't appear
+    # on the bare Ecto struct.
+    #
+    # The User resource has attributes with static defaults. When you do
+    # `%User{}`, those fields show `nil` instead of the Ash default — we
+    # expect a `:default_mismatch` warning for those.
+    test "detects default mismatches" do
+      warnings = EctoCompat.inspect_resource(User)
+
+      default_mismatch =
+        Enum.find(warnings, fn warning ->
+          warning.type == :default_mismatch
+        end)
+
+      # Same rationale as above — verify shape if present.
+      if default_mismatch do
+        assert default_mismatch.resource == User
+        assert is_list(default_mismatch.details)
+        assert length(default_mismatch.details) > 0
+      end
+    end
+
+    # Test that passing a loaded but non-Ash module (like `String`) returns
+    # a graceful error instead of crashing. This exercises the second guard
+    # in the `cond` block of `inspect_resource/1`.
+    test "handles non-resource modules gracefully" do
+      warnings = EctoCompat.inspect_resource(String)
+      assert length(warnings) == 1
+      assert hd(warnings).type == :error
+      assert String.contains?(hd(warnings).message, "not an Ash resource")
+    end
+
+    # Test that passing a module atom that doesn't correspond to any loaded
+    # module returns a graceful error. This exercises the first guard in
+    # the `cond` block (`Code.ensure_loaded?` returns false).
+    #
+    # Note: In Elixir, writing `UnloadedModule12345` in source code creates
+    # the atom but does NOT define a module. `Code.ensure_loaded?/1` returns
+    # false for atoms that have no backing module.
+    test "handles unloaded modules gracefully" do
+      warnings = EctoCompat.inspect_resource(UnloadedModule12345)
+      assert length(warnings) == 1
+      assert hd(warnings).type == :error
+      assert String.contains?(hd(warnings).message, "not loaded")
+    end
+  end
+
+  # ── print_warnings/1 tests ────────────────────────────────────────────
+
+  describe "print_warnings/1" do
+    # Verify that `print_warnings/1` can handle a list containing both
+    # warning types without raising. We don't assert on the printed output
+    # (that would be brittle) — we just confirm it returns `:ok`.
+    test "prints warnings correctly" do
+      warnings = [
+        %{
+          type: :missing_autogenerate,
+          resource: Car,
+          fields: [:inserted_at, :updated_at],
+          message: "Test message"
+        },
+        %{
+          type: :default_mismatch,
+          resource: User,
+          details: [
+            %{attr: :see_if_just_created, ash_default: "test", struct_default: nil}
+          ],
+          message: "Test default message"
+        }
+      ]
+
+      # Should not raise and should return :ok
+      assert EctoCompat.print_warnings(warnings) == :ok
+    end
+
+    # Edge case: an empty list should print the "all clear" message and
+    # still return :ok.
+    test "handles empty warnings list" do
+      assert EctoCompat.print_warnings([]) == :ok
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `mix ash.ecto_compat` diagnostic task that detects compatibility gaps between Ash resources and their generated Ecto schemas
- Detects Ash timestamps (`create_timestamp`/`update_timestamp`) not registered as Ecto autogenerate fields
- Detects static Ash attribute defaults not present on the Ecto struct
- Supports checking a single resource (`--resource`), all resources in a domain (`--domain`), or auto-discovery from configured domains

Closes #769

## What it does

Ash resources generate Ecto schemas automatically, but two things don't translate:

1. **Timestamps**: `create_timestamp`/`update_timestamp` are not registered in `__schema__(:autogenerate_fields)`, so `Repo.insert/1` won't auto-populate them
2. **Static defaults**: `default 1` is applied by Ash's changeset pipeline, not baked into the Ecto struct, so `%MyResource{}` shows `nil`

This task surfaces those gaps so developers mixing Ash API calls with direct Repo calls can make informed decisions.

## Files

- `lib/ash/ecto_compat.ex` — Core detection logic
- `lib/mix/tasks/ash.ecto_compat.ex` — Mix task CLI
- `test/resource/ecto_compat_test.exs` — 7 tests (all passing)
- `documentation/topics/development/development-utilities.md` — User-facing docs

## Test plan

- [x] 7 unit tests covering: no-issue baseline, timestamp detection, default detection, error handling for non-Ash modules, error handling for unloaded modules, output formatting
- [x] Full test suite passes (148 failures are all pre-existing Picosat-related, unrelated to this change)

# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies