### PR TITLE
fix: use Enum.member? instead of in-macro to mitigate 1.20-rc.2 compiler warnings

### DIFF
--- a/lib/ash/resource.ex
+++ b/lib/ash/resource.ex
@@ -376,7 +376,7 @@ defmodule Ash.Resource do
       @spec input(values :: map | Keyword.t()) :: map | no_return
       def input(opts) do
         Map.new(opts, fn {key, value} ->
-          if key in @all_arguments || key in @all_attributes do
+          if Enum.member?(@all_arguments, key) || Enum.member?(@all_attributes, key) do
             {key, value}
           else
             raise KeyError, key: key


### PR DESCRIPTION
The compiler in Elixir 1.20-rc.2 infers that `@all_attributes` is an empty list when doing some inference checks, and concludes that it must always be false, and as a consequence gives a compile warning.

I suspect this is due to the in macro expanding before Spark has had the opportunity to hydrate the module attribute, but I'm far from sure.

Using `Enum.member?` instead however, stops the compiler warnings.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.

