### PR TITLE
fix: remove unreachable is_list guard in soft destroy path

### DIFF
--- a/lib/ash/actions/destroy/destroy.ex
+++ b/lib/ash/actions/destroy/destroy.ex
@@ -31,9 +31,6 @@ defmodule Ash.Actions.Destroy do
       end
 
     case Ash.Actions.Update.run(domain, changeset, action, opts) do
-      {:ok, notifications} when is_list(notifications) ->
-        {:ok, notifications}
-
       {:ok, record} ->
         if opts[:return_destroyed?] do
           {:ok, record}


### PR DESCRIPTION
Dialyzer flagged that `is_list(notifications)` in the `{:ok, notifications}` branch can never succeed because `Update.run` always returns a struct (record) in its 2-tuple form, never a list. The remaining branches already handle all return type conversions correctly.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
