### PR TITLE
improvement: raise error when authorizer/notifier is added to extensions instead of proper option

### DIFF
--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -1686,6 +1686,7 @@ defmodule Ash.Resource.Dsl do
     Ash.Resource.Verifiers.VerifyAcceptedByDomain,
     Ash.Resource.Verifiers.VerifyActionsAtomic,
     Ash.Resource.Verifiers.VerifyNotifiers,
+    Ash.Resource.Verifiers.VerifyExtensionsAreNotMisplaced,
     Ash.Resource.Verifiers.VerifyPrimaryKeyPresent,
     Ash.Resource.Verifiers.VerifyGenericActionReactorInputs,
     Ash.Resource.Verifiers.ValidateArgumentsToCodeInterface

--- a/lib/ash/resource/verifiers/verify_extensions_are_not_misplaced.ex
+++ b/lib/ash/resource/verifiers/verify_extensions_are_not_misplaced.ex
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Resource.Verifiers.VerifyExtensionsAreNotMisplaced do
+  @moduledoc false
+  use Spark.Dsl.Verifier
+
+  @extension_kinds [
+    {Ash.Authorizer, :authorizers, "authorizers"},
+    {Ash.Notifier, :notifiers, "notifiers"}
+  ]
+
+  def verify(dsl) do
+    module = Spark.Dsl.Verifier.get_persisted(dsl, :module)
+    extensions = Spark.Dsl.Verifier.get_persisted(dsl, :extensions, [])
+
+    for extension <- extensions,
+        {behaviour, kind, kind_name} <- @extension_kinds,
+        Spark.implements_behaviour?(extension, behaviour),
+        registered = Spark.Dsl.Verifier.get_persisted(dsl, kind, []),
+        extension not in registered do
+      raise Spark.Error.DslError,
+        module: module,
+        path: [:extensions],
+        message:
+          "#{inspect(extension)} implements the #{inspect(behaviour)} behaviour " <>
+            "but was added to `extensions` instead of `#{kind_name}`. " <>
+            "The DSL will be available but it won't be used for #{kind_name}. " <>
+            "Move it to the `#{kind_name}` option."
+    end
+
+    :ok
+  end
+end

--- a/test/resource/verify_extensions_are_not_misplaced_test.exs
+++ b/test/resource/verify_extensions_are_not_misplaced_test.exs
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.VerifyExtensionsAreNotMisplacedTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule PlainExtension do
+    @moduledoc false
+    use Spark.Dsl.Extension
+  end
+
+  test "raises error when an authorizer is added to extensions instead of authorizers" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule Module.concat(["rand#{System.unique_integer([:positive])}", Post]) do
+          @moduledoc false
+
+          use Ash.Resource,
+            domain: Ash.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [Ash.Policy.Authorizer]
+
+          attributes do
+            uuid_primary_key :id
+          end
+        end
+      end)
+
+    assert output =~
+             "implements the Ash.Authorizer behaviour but was added to `extensions` instead of `authorizers`"
+  end
+
+  test "raises error when a notifier is added to extensions instead of notifiers" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule Module.concat(["rand#{System.unique_integer([:positive])}", Post]) do
+          @moduledoc false
+
+          use Ash.Resource,
+            domain: Ash.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [Ash.Notifier.PubSub]
+
+          attributes do
+            uuid_primary_key :id
+          end
+        end
+      end)
+
+    assert output =~
+             "implements the Ash.Notifier behaviour but was added to `extensions` instead of `notifiers`"
+  end
+
+  test "does not raise when an authorizer is correctly added to authorizers" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule Module.concat(["rand#{System.unique_integer([:positive])}", Post]) do
+          @moduledoc false
+
+          use Ash.Resource,
+            domain: Ash.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            authorizers: [Ash.Policy.Authorizer]
+
+          attributes do
+            uuid_primary_key :id
+          end
+        end
+      end)
+
+    refute output =~ "instead of `authorizers`"
+  end
+
+  test "does not raise when a notifier is correctly added to notifiers" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule Module.concat(["rand#{System.unique_integer([:positive])}", Post]) do
+          @moduledoc false
+
+          use Ash.Resource,
+            domain: Ash.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            notifiers: [Ash.Notifier.PubSub]
+
+          attributes do
+            uuid_primary_key :id
+          end
+        end
+      end)
+
+    refute output =~ "instead of `notifiers`"
+  end
+
+  test "does not raise for extensions that do not implement authorizer or notifier" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule Module.concat(["rand#{System.unique_integer([:positive])}", Post]) do
+          @moduledoc false
+
+          use Ash.Resource,
+            domain: Ash.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [PlainExtension]
+
+          attributes do
+            uuid_primary_key :id
+          end
+        end
+      end)
+
+    refute output =~ "instead of"
+  end
+end


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Closes #716

- This catches a common mistake where the DSL becomes available (since it's a valid extension) but the actual authorization/notification logic silently doesn't run
- Adds a new verifier `VerifyExtensionsAreNotMisplaced` that raises a compile-time error when a module implementing `Ash.Authorizer` or `Ash.Notifier` is added to `extensions` instead of `authorizers`/`notifiers`