### PR TITLE
fix: add [] as fallback for modules = Application.spec(app, :modules)

### DIFF
--- a/lib/ash/info.ex
+++ b/lib/ash/info.ex
@@ -77,7 +77,7 @@ defmodule Ash.Info do
   """
   @spec defined_extensions(app :: Application.app()) :: [module()]
   def defined_extensions(app) do
-    modules = Application.spec(app, :modules)
+    modules = Application.spec(app, :modules) || []
     # Preload the modules to improve performance.
     Code.ensure_all_loaded(modules)
     Enum.filter(modules, &Spark.implements_behaviour?(&1, Spark.Dsl.Extension))


### PR DESCRIPTION
Code.ensure_loaded(nil) crashes on Elixir 1.20.0-rc.1.

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
