### PR TITLE
fix: merge scope with actor when doing can? check

### DIFF
--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -76,6 +76,8 @@ defmodule Ash.Can do
     opts = Keyword.put_new(opts, :filter_with, :filter)
     pre_flight? = Keyword.get(opts, :pre_flight?, true)
 
+    actor_or_scope = Ash.Helpers.deep_merge_maps(actor_or_scope, opts[:scope])
+
     context =
       Ash.Helpers.deep_merge_maps(opts[:context] || %{}, %{
         private: %{pre_flight_authorization?: pre_flight?}

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -3,6 +3,18 @@
 # SPDX-License-Identifier: MIT
 
 defmodule Ash.Test.CodeInterfaceTest do
+  defmodule Scope do
+    defstruct [:actor, :tenant, :context]
+
+    defimpl Ash.Scope.ToOpts do
+      def get_actor(%{actor: actor}), do: {:ok, actor}
+      def get_tenant(%{tenant: tenant}), do: {:ok, tenant}
+      def get_context(%{context: context}), do: {:ok, context}
+      def get_tracer(_), do: :error
+      def get_authorize?(_), do: :error
+    end
+  end
+
   @moduledoc false
   use ExUnit.Case, async: true
 
@@ -680,6 +692,10 @@ defmodule Ash.Test.CodeInterfaceTest do
 
     assert User.can_update_by_id?(user, user.id, %{})
     assert User.can_destroy_by_id?(user, user.id, %{})
+
+    assert User.can_destroy_by_id?(user, %{},
+             scope: %Ash.Test.CodeInterfaceTest.Scope{actor: user}
+           )
   end
 
   test "optional arguments are optional" do
@@ -735,18 +751,6 @@ defmodule Ash.Test.CodeInterfaceTest do
     # Test that function-based defaults can still be overridden
     assert "Hello, Override Actor." =
              User.hello_actor_with_function_default!(actor: %{name: "Override Actor"})
-  end
-
-  defmodule Scope do
-    defstruct [:actor, :tenant, :context]
-
-    defimpl Ash.Scope.ToOpts do
-      def get_actor(%{actor: actor}), do: {:ok, actor}
-      def get_tenant(%{tenant: tenant}), do: {:ok, tenant}
-      def get_context(%{context: context}), do: {:ok, context}
-      def get_tracer(_), do: :error
-      def get_authorize?(_), do: :error
-    end
   end
 
   defmodule ContextScope do

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -478,6 +478,7 @@ defmodule Ash.Test.Policy.SimpleTest do
   test "Ash.can? honors a provided scope", %{admin: admin, user: user} do
     tweet = Ash.create!(Ash.Changeset.for_create(Tweet, :create), authorize?: false)
     assert Ash.can?({tweet, :read}, %Scope{actor: admin})
+    assert Ash.can?({tweet, :read}, %{}, scope: %Scope{actor: admin})
     refute Ash.can?({tweet, :read}, %Scope{actor: user})
   end
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes https://github.com/ash-project/ash/issues/2619

I added tests, but I'm not sure if this is how you are supposed to fix it this, to be honest.