### PR TITLE
fix: register Ash timestamps with Ecto's autogenerate system

### DIFF
--- a/lib/ash/resource/schema.ex
+++ b/lib/ash/resource/schema.ex
@@ -61,6 +61,8 @@ defmodule Ash.Schema do
               )
             end
 
+            Ash.Schema.register_ecto_autogenerate(__MODULE__)
+
             field(:aggregates, :map, virtual: true, default: %{})
             field(:calculations, :map, virtual: true, default: %{})
             field(:__metadata__, :map, virtual: true, default: %{}, redact: true)
@@ -197,6 +199,8 @@ defmodule Ash.Schema do
                 )
               )
             end
+
+            Ash.Schema.register_ecto_autogenerate(__MODULE__)
 
             field(:aggregates, :map, virtual: true, default: %{})
             field(:calculations, :map, virtual: true, default: %{})
@@ -383,4 +387,92 @@ defmodule Ash.Schema do
   def attribute_default(fun) when is_function(fun), do: nil
   def attribute_default({_mod, _func, _args}), do: nil
   def attribute_default(value), do: value
+
+  @doc false
+  # Called at compile time from within the `schema do ... end` block to wire
+  # Ash's create_timestamp/update_timestamp attributes into Ecto's autogenerate
+  # system. This enables Repo.insert/1 and Repo.update/1 to auto-populate
+  # timestamp fields without going through Ash's changeset pipeline.
+  def register_ecto_autogenerate(module) do
+    autogen_timestamps =
+      Ash.Resource.Info.attributes(module)
+      |> Enum.filter(&timestamp_attribute?/1)
+
+    # Partition by match_other_defaults?: timestamps that share defaults are
+    # grouped into a single {[field1, field2], mfa} tuple so Ecto calls the MFA
+    # once and assigns the same value to all fields. Timestamps with
+    # match_other_defaults? == false each get their own entry.
+    {shared, individual} =
+      Enum.split_with(autogen_timestamps, & &1.match_other_defaults?)
+
+    shared
+    |> Enum.group_by(&Ash.Type.storage_type(&1.type, &1.constraints))
+    |> Enum.each(fn {storage_type, attrs} ->
+      field_names = Enum.map(attrs, & &1.name)
+
+      Module.put_attribute(
+        module,
+        :ecto_autogenerate,
+        {field_names, {Ecto.Schema, :__timestamps__, [storage_type]}}
+      )
+    end)
+
+    Enum.each(individual, fn attr ->
+      storage_type = Ash.Type.storage_type(attr.type, attr.constraints)
+
+      Module.put_attribute(
+        module,
+        :ecto_autogenerate,
+        {[attr.name], {Ecto.Schema, :__timestamps__, [storage_type]}}
+      )
+    end)
+
+    # Register update_timestamp fields in :ecto_autoupdate so Repo.update/1
+    # refreshes them automatically.
+    update_timestamps =
+      Enum.filter(autogen_timestamps, fn attr -> not is_nil(attr.update_default) end)
+
+    {shared_update, individual_update} =
+      Enum.split_with(update_timestamps, & &1.match_other_defaults?)
+
+    shared_update
+    |> Enum.group_by(&Ash.Type.storage_type(&1.type, &1.constraints))
+    |> Enum.each(fn {storage_type, attrs} ->
+      field_names = Enum.map(attrs, & &1.name)
+
+      Module.put_attribute(
+        module,
+        :ecto_autoupdate,
+        {field_names, {Ecto.Schema, :__timestamps__, [storage_type]}}
+      )
+    end)
+
+    Enum.each(individual_update, fn attr ->
+      storage_type = Ash.Type.storage_type(attr.type, attr.constraints)
+
+      Module.put_attribute(
+        module,
+        :ecto_autoupdate,
+        {[attr.name], {Ecto.Schema, :__timestamps__, [storage_type]}}
+      )
+    end)
+  end
+
+  @doc false
+  def timestamp_attribute?(attr) do
+    ecto_datetime_type?(Ash.Type.storage_type(attr.type, attr.constraints)) &&
+      attr.writable? == false &&
+      datetime_default?(attr.default) &&
+      attr.allow_nil? == false
+  end
+
+  defp datetime_default?(fun) when is_function(fun, 0) do
+    fun == (&DateTime.utc_now/0)
+  end
+
+  defp datetime_default?(_), do: false
+
+  defp ecto_datetime_type?(type) do
+    type in [:utc_datetime, :utc_datetime_usec, :naive_datetime, :naive_datetime_usec]
+  end
 end

--- a/test/resource/ecto_compat_test.exs
+++ b/test/resource/ecto_compat_test.exs
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.EctoCompatTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  # Verifies that Ash-generated Ecto schemas properly register timestamp
+  # attributes with Ecto's autogenerate system, so that Repo.insert/1 and
+  # Repo.update/1 can auto-populate them without going through Ash's
+  # changeset pipeline.
+  #
+  # See: https://github.com/ash-project/ash/issues/769
+
+  describe "timestamp autogenerate registration" do
+    test "create_timestamp fields appear in __schema__(:autogenerate_fields)" do
+      defmodule CreateTimestampResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          create_timestamp :inserted_at
+        end
+      end
+
+      autogen_fields = CreateTimestampResource.__schema__(:autogenerate_fields)
+      assert :inserted_at in autogen_fields
+    end
+
+    test "update_timestamp fields appear in __schema__(:autogenerate_fields)" do
+      defmodule UpdateTimestampResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          update_timestamp :updated_at
+        end
+      end
+
+      autogen_fields = UpdateTimestampResource.__schema__(:autogenerate_fields)
+      assert :updated_at in autogen_fields
+    end
+
+    test "both timestamps are registered together for autogenerate on insert" do
+      defmodule BothTimestampsResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          create_timestamp :inserted_at
+          update_timestamp :updated_at
+        end
+      end
+
+      autogen_fields = BothTimestampsResource.__schema__(:autogenerate_fields)
+      assert :inserted_at in autogen_fields
+      assert :updated_at in autogen_fields
+    end
+
+    test "update_timestamp fields are registered in autoupdate" do
+      defmodule AutoupdateResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          create_timestamp :inserted_at
+          update_timestamp :updated_at
+        end
+      end
+
+      # :autoupdate returns a list of {[fields], {mod, fun, args}} tuples.
+      # update_timestamp fields should be registered here.
+      autoupdate = AutoupdateResource.__schema__(:autoupdate)
+      autoupdate_fields = Enum.flat_map(autoupdate, &elem(&1, 0))
+
+      assert :updated_at in autoupdate_fields
+      refute :inserted_at in autoupdate_fields
+    end
+
+    test "timestamps of the same type are grouped (match_other_defaults)" do
+      defmodule GroupedTimestampsResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          create_timestamp :inserted_at
+          update_timestamp :updated_at
+        end
+      end
+
+      # Both timestamps default to Ash.Type.UtcDatetimeUsec, so they should
+      # be grouped into a single {[fields], mfa} tuple for autogenerate.
+      # This ensures Ecto calls the MFA once and assigns the same value to
+      # both fields — matching Ash's match_other_defaults? behavior.
+      autogenerate = GroupedTimestampsResource.__schema__(:autogenerate)
+
+      grouped_entry =
+        Enum.find(autogenerate, fn {fields, _mfa} ->
+          :inserted_at in fields and :updated_at in fields
+        end)
+
+      assert grouped_entry != nil,
+             "Expected inserted_at and updated_at to be grouped in a single autogenerate entry, " <>
+               "got: #{inspect(autogenerate)}"
+    end
+
+    test "resource with no timestamps has empty autogenerate_fields" do
+      defmodule NoTimestampResource do
+        @moduledoc false
+        use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+      end
+
+      autogen_fields = NoTimestampResource.__schema__(:autogenerate_fields)
+      assert autogen_fields == []
+    end
+  end
+end


### PR DESCRIPTION
Ash resources generate Ecto schemas automatically, but create_timestamp/update_timestamp attributes were not registered with Ecto's autogenerate system. This meant __schema__(:autogenerate_fields) returned [] and Repo.insert/1 left timestamp fields as nil.

This wires Ash's timestamp attributes into Ecto's :ecto_autogenerate and :ecto_autoupdate module attributes at compile time, so that Repo.insert/1 and Repo.update/1 auto-populate them — matching what Ecto's native timestamps() macro does.

Timestamps sharing the same storage type are grouped into a single registration entry so they receive the same generated value, preserving Ash's match_other_defaults? semantics.

Closes #769

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies