### PR TITLE
fix: bulk create/update/destroy global validation ordering

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -389,6 +389,7 @@ defmodule Ash.Actions.Create.Bulk do
 
   defp pre_template_all_changes(action, resource, :create, base, actor, tenant) do
     action.changes
+    |> Enum.concat(Ash.Resource.Info.changes(resource, action.type))
     |> then(fn changes ->
       if action.skip_global_validations? do
         changes
@@ -396,7 +397,6 @@ defmodule Ash.Actions.Create.Bulk do
         Enum.concat(changes, Ash.Resource.Info.validations(resource, action.type))
       end
     end)
-    |> Enum.concat(Ash.Resource.Info.changes(resource, action.type))
     |> Enum.map(fn
       %{change: {module, opts}} = change ->
         %{change | change: {module, pre_template(opts, base, actor, tenant)}}

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1442,6 +1442,7 @@ defmodule Ash.Actions.Destroy.Bulk do
 
   defp pre_template_all_changes(action, resource, :destroy, base, actor, tenant) do
     action.changes
+    |> Enum.concat(Ash.Resource.Info.changes(resource, action.type))
     |> then(fn changes ->
       if action.skip_global_validations? do
         changes
@@ -1449,7 +1450,6 @@ defmodule Ash.Actions.Destroy.Bulk do
         Enum.concat(changes, Ash.Resource.Info.validations(resource, action.type))
       end
     end)
-    |> Enum.concat(Ash.Resource.Info.changes(resource, action.type))
     |> Enum.map(fn
       %{change: {module, opts}} = change ->
         %{change | change: {module, pre_template(opts, base, actor, tenant)}}

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1791,6 +1791,7 @@ defmodule Ash.Actions.Update.Bulk do
 
   defp pre_template_all_changes(action, resource, _type, base, actor, tenant) do
     action.changes
+    |> Enum.concat(Ash.Resource.Info.changes(resource, action.type))
     |> then(fn changes ->
       if action.skip_global_validations? do
         changes
@@ -1798,7 +1799,6 @@ defmodule Ash.Actions.Update.Bulk do
         Enum.concat(changes, Ash.Resource.Info.validations(resource, action.type))
       end
     end)
-    |> Enum.concat(Ash.Resource.Info.changes(resource, action.type))
     |> Enum.map(fn
       %{change: {module, opts}} = change ->
         %{change | change: {module, pre_template(opts, base, actor, tenant)}}

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -101,6 +101,66 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     end
   end
 
+  defmodule CopyTitleToStatusChange do
+    @moduledoc false
+    use Ash.Resource.Change
+
+    @impl true
+    def change(changeset, _, _) do
+      title = Ash.Changeset.get_attribute(changeset, :title)
+      Ash.Changeset.force_change_attribute(changeset, :status, title)
+    end
+  end
+
+  defmodule ValidateStatusPresenceAndNotBad do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(changeset, _, _) do
+      case Ash.Changeset.get_attribute(changeset, :status) do
+        nil -> {:error, field: :status, message: "status must be set"}
+        "bad" -> {:error, field: :status, message: "status cannot be bad"}
+        _ -> :ok
+      end
+    end
+  end
+
+  defmodule PostWithBulkValidationOrdering do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      create :create do
+        primary? true
+        accept [:title]
+      end
+    end
+
+    changes do
+      change CopyTitleToStatusChange
+    end
+
+    validations do
+      validate ValidateStatusPresenceAndNotBad
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+      attribute :status, :string, public?: true
+    end
+  end
+
   defmodule Org do
     @moduledoc false
     use Ash.Resource,
@@ -2388,6 +2448,33 @@ defmodule Ash.Test.Actions.BulkCreateTest do
       assert [%{title: "success_1"}] = result.records
       assert_received {:notification, _}
       assert result.notifications == nil
+    end
+  end
+
+  describe "bulk_create global validation ordering" do
+    test "succeeds when global change sets status that passes validation" do
+      assert %Ash.BulkResult{status: :success, records: [%{status: "good"}]} =
+               Ash.bulk_create(
+                 [%{title: "good"}],
+                 PostWithBulkValidationOrdering,
+                 :create,
+                 return_records?: true,
+                 return_errors?: true,
+                 authorize?: false
+               )
+    end
+
+    test "global validation rejects with correct error" do
+      assert %Ash.BulkResult{status: :error, errors: [error]} =
+               Ash.bulk_create(
+                 [%{title: "bad"}],
+                 PostWithBulkValidationOrdering,
+                 :create,
+                 return_errors?: true,
+                 authorize?: false
+               )
+
+      assert Exception.message(error) =~ "status cannot be bad"
     end
   end
 end

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -109,6 +109,66 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
     end
   end
 
+  defmodule CopyTitleToStatusChange do
+    @moduledoc false
+    use Ash.Resource.Change
+
+    @impl true
+    def change(changeset, _, _) do
+      title = Ash.Changeset.get_attribute(changeset, :title)
+      Ash.Changeset.force_change_attribute(changeset, :status, title)
+    end
+  end
+
+  defmodule ValidateStatusPresenceAndNotBad do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(changeset, _, _) do
+      case Ash.Changeset.get_attribute(changeset, :status) do
+        nil -> {:error, field: :status, message: "status must be set"}
+        "bad" -> {:error, field: :status, message: "status cannot be bad"}
+        _ -> :ok
+      end
+    end
+  end
+
+  defmodule PostWithBulkValidationOrdering do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, create: :*]
+
+      destroy :destroy do
+        primary? true
+        require_atomic? false
+      end
+    end
+
+    changes do
+      change CopyTitleToStatusChange, on: [:destroy]
+    end
+
+    validations do
+      validate ValidateStatusPresenceAndNotBad, on: [:destroy]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+      attribute :status, :string, public?: true
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource,
@@ -1338,6 +1398,46 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
       for notification <- result.notifications do
         assert %Author{name: "Test Author"} = notification.data.author
       end
+    end
+  end
+
+  describe "bulk_destroy global validation ordering" do
+    test "succeeds when global change sets status that passes validation" do
+      post =
+        PostWithBulkValidationOrdering
+        |> Ash.Changeset.for_create(:create, %{title: "good"})
+        |> Ash.create!()
+
+      assert %Ash.BulkResult{status: :success} =
+               Ash.bulk_destroy(
+                 [post],
+                 :destroy,
+                 %{},
+                 resource: PostWithBulkValidationOrdering,
+                 return_errors?: true,
+                 strategy: :stream,
+                 authorize?: false
+               )
+    end
+
+    test "global validation rejects with correct error" do
+      post =
+        PostWithBulkValidationOrdering
+        |> Ash.Changeset.for_create(:create, %{title: "bad"})
+        |> Ash.create!()
+
+      assert %Ash.BulkResult{status: :error, errors: [error]} =
+               Ash.bulk_destroy(
+                 [post],
+                 :destroy,
+                 %{},
+                 resource: PostWithBulkValidationOrdering,
+                 return_errors?: true,
+                 strategy: :stream,
+                 authorize?: false
+               )
+
+      assert Exception.message(error) =~ "status cannot be bad"
     end
   end
 end

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -220,6 +220,67 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
     end
   end
 
+  defmodule CopyTitleToStatusChange do
+    @moduledoc false
+    use Ash.Resource.Change
+
+    @impl true
+    def change(changeset, _, _) do
+      title = Ash.Changeset.get_attribute(changeset, :title)
+      Ash.Changeset.force_change_attribute(changeset, :status, title)
+    end
+  end
+
+  defmodule ValidateStatusPresenceAndNotBad do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(changeset, _, _) do
+      case Ash.Changeset.get_attribute(changeset, :status) do
+        nil -> {:error, field: :status, message: "status must be set"}
+        "bad" -> {:error, field: :status, message: "status cannot be bad"}
+        _ -> :ok
+      end
+    end
+  end
+
+  defmodule PostWithBulkValidationOrdering do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, create: :*]
+
+      update :update do
+        primary? true
+        accept [:title]
+        require_atomic? false
+      end
+    end
+
+    changes do
+      change CopyTitleToStatusChange, on: [:update]
+    end
+
+    validations do
+      validate ValidateStatusPresenceAndNotBad, on: [:update]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+      attribute :status, :string, public?: true
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource,
@@ -2295,6 +2356,47 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
       updated_post = Ash.load!(updated_post, :related_posts)
       assert length(updated_post.related_posts) == 1
       assert hd(updated_post.related_posts).id == related_post.id
+    end
+  end
+
+  describe "bulk_update global validation ordering" do
+    test "succeeds when global change sets status that passes validation" do
+      post =
+        PostWithBulkValidationOrdering
+        |> Ash.Changeset.for_create(:create, %{title: "initial"})
+        |> Ash.create!()
+
+      assert %Ash.BulkResult{status: :success, records: [%{status: "good"}]} =
+               Ash.bulk_update(
+                 [post],
+                 :update,
+                 %{title: "good"},
+                 resource: PostWithBulkValidationOrdering,
+                 return_records?: true,
+                 return_errors?: true,
+                 strategy: :stream,
+                 authorize?: false
+               )
+    end
+
+    test "global validation rejects with correct error" do
+      post =
+        PostWithBulkValidationOrdering
+        |> Ash.Changeset.for_create(:create, %{title: "initial"})
+        |> Ash.create!()
+
+      assert %Ash.BulkResult{status: :error, errors: [error]} =
+               Ash.bulk_update(
+                 [post],
+                 :update,
+                 %{title: "bad"},
+                 resource: PostWithBulkValidationOrdering,
+                 return_errors?: true,
+                 strategy: :stream,
+                 authorize?: false
+               )
+
+      assert Exception.message(error) =~ "status cannot be bad"
     end
   end
 end


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

- Fix ordering in `pre_template_all_changes/6` for bulk create, update, and destroy so that global resource changes are concatenated **before** global validations
- Previously, global changes were appended **after** validations, which meant validations could not see attribute values set by global changes

## Problem

In `pre_template_all_changes`, the pipeline was:

```
action.changes -> concat(validations) -> concat(global changes)
```

This caused global validations to run **before** global resource changes, so if a global change set an attribute (e.g. copying `title` to `status`), a validation checking that attribute would fail because the value hadn't been set yet.

This is inconsistent with how non-bulk actions work, where changes and validations are interleaved in the order they are defined.

## Fix

Reorder the pipeline to:

```
action.changes -> concat(global changes) -> concat(validations)
```

This ensures global resource changes run before validations, matching the expected behavior.