### PR TITLE
fix: honor scope option in Ash.can/can?

### DIFF
--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -88,7 +88,8 @@ defmodule Ash.Can do
         |> Ash.Actions.Helpers.apply_scope_to_opts()
         |> Keyword.pop(:actor)
       else
-        {actor_or_scope, opts}
+        {actor_or_scope,
+         opts |> Ash.Actions.Helpers.apply_scope_to_opts() |> Keyword.delete(:actor)}
       end
 
     opts = Keyword.update(opts, :context, context, &Ash.Helpers.deep_merge_maps(&1, context))

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -481,6 +481,16 @@ defmodule Ash.Test.Policy.SimpleTest do
     refute Ash.can?({tweet, :read}, %Scope{actor: user})
   end
 
+  test "Ash.can and Ash.can? honor a provided scope in opts", %{admin: admin} do
+    context_record =
+      Context
+      |> Ash.Changeset.for_create(:create, %{name: "Foo"})
+      |> Ash.create!()
+
+    assert Ash.can?({context_record, :read}, admin, scope: %Scope{context: %{name: "Foo"}})
+    refute Ash.can?({context_record, :read}, admin, scope: %Scope{context: %{name: "Bar"}})
+  end
+
   test "arguments can be referenced in expression policies", %{admin: admin, user: user} do
     Tweet
     |> Ash.Changeset.for_create(:create_foo, %{foo: "foo", user_id: admin.id}, actor: user)


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies


`Ash.can/3` and `Ash.can?/3` were not applying `scope` from `opts` when the first argument was a direct actor (not a Scope struct). The else branch skipped `apply_scope_to_opts/1`, so tenant, context, and other scope-derived options were silently ignored.

This adds the missing `apply_scope_to_opts/1` call in the non-scope branch and includes a test that verifies context from a scope in opts is properly passed through to the policy engine.

Fixes #2619 