### PR TITLE
docs: clarify scope doc in Ash.can/can? opts

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -928,7 +928,7 @@ defmodule Ash do
     scope: [
       type: :any,
       doc:
-        "A value that implements the `Ash.Scope.ToOpts` protocol. Will overwrite any actor, tenant or context provided. See `Ash.Context` for more."
+        "A value that implements the `Ash.Scope.ToOpts` protocol. Provides a default tenant and deep merges context (explicit opts take precedence). The actor is always taken from the second argument to `can/3`. See `Ash.Scope` for more."
     ],
     context: [
       type: :map,


### PR DESCRIPTION
The `:scope` doc in `opts` for `Ash.can/3` said it would "overwrite any actor, tenant or context provided" which isn't accurate. 

`Ash.can/3` takes the actor as its second argument (either directly or from that scope, not from opts), `tenant` from scope is only used as a default (explicit `:tenant` opt wins), and `context` is deep merged with explicit `:context` opt taking precedence. 

Updated the doc to reflect that.


Related to #2619 and #2621


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
