### PR TITLE
fix: on_match :destroy for many_to_many now destroys both join and destination

### DIFF
--- a/documentation/topics/development/backwards-compatibility-config.md
+++ b/documentation/topics/development/backwards-compatibility-config.md
@@ -252,3 +252,23 @@ When a field is marked `sensitive?: true`, its value in validation error structs
 replaced with a redacted placeholder via `Ash.Helpers.redact/1`. This applies to both
 the non-atomic (`validate/3`) and atomic (`atomic/3`) code paths across all built-in
 validations.
+
+## many_to_many_destroy_destination_on_match?
+
+```elixir
+config :ash, many_to_many_destroy_destination_on_match?: true
+```
+
+### Old Behavior
+
+When using `on_match: {:destroy, :action_name}` (2-tuple form) with a `many_to_many`
+relationship, only the join record was destroyed using the given action. The
+destination record was left intact, making it effectively the same as `:unrelate`.
+
+### New Behavior
+
+The 2-tuple `{:destroy, :action_name}` for `many_to_many` now destroys both
+the destination record (using the given action) and the join record (using the
+primary destroy action on the join resource). This makes the 2-tuple behavior
+consistent with the `:destroy` shorthand and the explicit 3-tuple
+`{:destroy, :dest_action, :join_action}`.

--- a/lib/ash/actions/managed_relationships.ex
+++ b/lib/ash/actions/managed_relationships.ex
@@ -2306,6 +2306,25 @@ defmodule Ash.Actions.ManagedRelationships do
       :missing ->
         {:ok, current_value, []}
 
+      {:destroy, action_name, join_action_name} ->
+        case destroy_data_m2m(
+               source_record,
+               match,
+               domain,
+               actor,
+               opts,
+               action_name,
+               join_action_name,
+               changeset,
+               relationship
+             ) do
+          {:ok, notifications} ->
+            {:ok, current_value, notifications}
+
+          {:error, error} ->
+            {:error, add_bread_crumb(error, relationship, :destroy)}
+        end
+
       {:destroy, action_name} ->
         case destroy_data(
                source_record,
@@ -3277,6 +3296,38 @@ defmodule Ash.Actions.ManagedRelationships do
     {:ok, []}
   end
 
+  # Destroys both the join record and the destination record for a many_to_many relationship.
+  # Used by on_match: {:destroy, dest_action, join_action} (3-tuple) and on_match: :destroy shorthand.
+  defp destroy_data_m2m(
+         source_record,
+         record,
+         domain,
+         actor,
+         opts,
+         dest_action_name,
+         join_action_name,
+         changeset,
+         %{type: :many_to_many} = relationship
+       ) do
+    with {:ok, join_notifications} <-
+           destroy_m2m_join_record(
+             source_record,
+             record,
+             actor,
+             opts,
+             join_action_name,
+             changeset,
+             relationship
+           ),
+         {:ok, dest_notifications} <-
+           destroy_record(record, domain, actor, opts, dest_action_name, changeset, relationship) do
+      {:ok, join_notifications ++ dest_notifications}
+    end
+  end
+
+  # Destroys only the join record for a many_to_many relationship.
+  # Used by on_match: {:destroy, action} (2-tuple) for backward compatibility.
+  # Functionally equivalent to :unrelate — the destination record is left intact.
   defp destroy_data(
          source_record,
          record,
@@ -3286,6 +3337,50 @@ defmodule Ash.Actions.ManagedRelationships do
          action_name,
          changeset,
          %{type: :many_to_many} = relationship
+       ) do
+    destroy_m2m_join_record(
+      source_record,
+      record,
+      actor,
+      opts,
+      action_name,
+      changeset,
+      relationship
+    )
+  end
+
+  # Destroys the destination record directly. Used by non-many_to_many relationships.
+  defp destroy_data(
+         _source_record,
+         record,
+         domain,
+         actor,
+         opts,
+         action_name,
+         changeset,
+         relationship
+       ) do
+    destroy_record(
+      record,
+      domain,
+      actor,
+      opts,
+      action_name,
+      changeset,
+      relationship
+    )
+  end
+
+  # Finds and destroys a single join record for a many_to_many relationship.
+  # Looks up the join record by source and destination attribute values, then destroys it.
+  defp destroy_m2m_join_record(
+         source_record,
+         record,
+         actor,
+         opts,
+         action_name,
+         changeset,
+         relationship
        ) do
     tenant = changeset.tenant
 
@@ -3312,6 +3407,10 @@ defmodule Ash.Actions.ManagedRelationships do
       domain: domain(changeset, join_relationship)
     )
     |> case do
+      {:ok, nil} ->
+        debug_log(relationship.name, changeset, :read, :ok, opts[:debug?])
+        {:ok, []}
+
       {:ok, result} ->
         debug_log(relationship.name, changeset, :read, :ok, opts[:debug?])
 
@@ -3332,12 +3431,10 @@ defmodule Ash.Actions.ManagedRelationships do
         |> case do
           {:ok, notifications} ->
             debug_log(relationship.name, changeset, :destroy, :ok, opts[:debug?])
-
             {:ok, notifications}
 
           {:ok, _record, notifications} ->
             debug_log(relationship.name, changeset, :destroy, :ok, opts[:debug?])
-
             {:ok, notifications}
 
           {:error, error} ->
@@ -3358,16 +3455,8 @@ defmodule Ash.Actions.ManagedRelationships do
     end
   end
 
-  defp destroy_data(
-         _source_record,
-         record,
-         domain,
-         actor,
-         opts,
-         action_name,
-         changeset,
-         relationship
-       ) do
+  # Destroys a single record using the given action.
+  defp destroy_record(record, domain, actor, opts, action_name, changeset, relationship) do
     tenant = changeset.tenant
 
     record
@@ -3385,18 +3474,16 @@ defmodule Ash.Actions.ManagedRelationships do
     |> Ash.Changeset.set_tenant(tenant)
     |> Ash.destroy(return_notifications?: true)
     |> case do
-      {:ok, _record, notifications} ->
+      {:ok, notifications} ->
         debug_log(relationship.name, changeset, :destroy, :ok, opts[:debug?])
-
         {:ok, notifications}
 
-      {:ok, notifications} ->
+      {:ok, _record, notifications} ->
         debug_log(relationship.name, changeset, :destroy, :ok, opts[:debug?])
         {:ok, notifications}
 
       {:error, error} ->
         debug_log(relationship.name, changeset, :destroy, {:error, error}, opts[:debug?])
-
         {:error, add_bread_crumb(error, relationship, :destroy)}
     end
   end

--- a/lib/ash/actions/read/calculations.ex
+++ b/lib/ash/actions/read/calculations.ex
@@ -1001,8 +1001,7 @@ defmodule Ash.Actions.Read.Calculations do
                   calculation.context.tracer,
                   domain,
                   ash_query.resource,
-                  parent_stack:
-                    Ash.Actions.Read.parent_stack_from_context(ash_query.context),
+                  parent_stack: Ash.Actions.Read.parent_stack_from_context(ash_query.context),
                   source_context: ash_query.context
                 )
 
@@ -1187,8 +1186,7 @@ defmodule Ash.Actions.Read.Calculations do
                   calculation.context.tracer,
                   ash_query.domain,
                   ash_query.resource,
-                  parent_stack:
-                    Ash.Actions.Read.parent_stack_from_context(ash_query.context),
+                  parent_stack: Ash.Actions.Read.parent_stack_from_context(ash_query.context),
                   source_context: ash_query.context
                 )
 

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -5656,7 +5656,9 @@ defmodule Ash.Changeset do
       * `{:update_join, :join_table_action_name, [:list, :of, :params]}` - pass specified params from input into a join resource update action
       * `:destroy` - destroys the record using primary destroy actions. For `many_to_many`, destroys both the join record and the destination record.
       * `{:destroy, :action_name}` - the record is destroyed using the specified action. The action should be:
-        * `many_to_many` - a destroy action on the join resource only (the destination record is NOT destroyed)
+        * `many_to_many` - by default, a destroy action on the join resource only (the destination record is NOT destroyed).
+          When `config :ash, many_to_many_destroy_destination_on_match?: true` is set, destroys both the destination record
+          (using the given action) and the join record (using the primary destroy action).
         * `has_many` - a destroy action on the destination resource
         * `has_one` - a destroy action on the destination resource
         * `belongs_to` - a destroy action on the destination resource

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -5654,11 +5654,14 @@ defmodule Ash.Changeset do
       * `:update_join` - update only the join record (only valid for many to many)
       * `{:update_join, :join_table_action_name}` - use the specified update action on a join resource
       * `{:update_join, :join_table_action_name, [:list, :of, :params]}` - pass specified params from input into a join resource update action
-      * `{:destroy, :action_name}` - the record is destroyed using the specified action on the destination resource. The action should be:
-        * `many_to_many` - a destroy action on the join record
+      * `:destroy` - destroys the record using primary destroy actions. For `many_to_many`, destroys both the join record and the destination record.
+      * `{:destroy, :action_name}` - the record is destroyed using the specified action. The action should be:
+        * `many_to_many` - a destroy action on the join resource only (the destination record is NOT destroyed)
         * `has_many` - a destroy action on the destination resource
         * `has_one` - a destroy action on the destination resource
         * `belongs_to` - a destroy action on the destination resource
+      * `{:destroy, :destination_action_name, :join_action_name}` - (many_to_many only) destroys both the destination record
+        using the first action and the join record using the second action
       * `:error`  - an error is returned indicating that a record would have been updated
       * `:no_match` - follows the `on_no_match` instructions with these records
       * `:missing` - follows the `on_missing` instructions with these records

--- a/lib/ash/changeset/managed_relationship_helpers.ex
+++ b/lib/ash/changeset/managed_relationship_helpers.ex
@@ -110,8 +110,9 @@ defmodule Ash.Changeset.ManagedRelationshipHelpers do
         {:unrelate, nil}
 
       :destroy when is_many_to_many ->
+        destroy = primary_action_name!(relationship.destination, :destroy)
         join_destroy = primary_action_name!(relationship.through, :destroy)
-        {:destroy, join_destroy}
+        {:destroy, destroy, join_destroy}
 
       :destroy ->
         destroy = primary_action_name!(relationship.destination, :destroy)
@@ -179,6 +180,9 @@ defmodule Ash.Changeset.ManagedRelationshipHelpers do
 
       {:unrelate, _nil} ->
         nil
+
+      {:destroy, destroy, join_destroy} when relationship.type == :many_to_many ->
+        all([destination(destroy), join(join_destroy, :*)])
 
       {:destroy, join_destroy} when relationship.type == :many_to_many ->
         all(join(join_destroy, :*))

--- a/lib/ash/changeset/managed_relationship_helpers.ex
+++ b/lib/ash/changeset/managed_relationship_helpers.ex
@@ -114,6 +114,14 @@ defmodule Ash.Changeset.ManagedRelationshipHelpers do
         join_destroy = primary_action_name!(relationship.through, :destroy)
         {:destroy, destroy, join_destroy}
 
+      {:destroy, action} when is_many_to_many ->
+        if Application.get_env(:ash, :many_to_many_destroy_destination_on_match?, false) do
+          join_destroy = primary_action_name!(relationship.through, :destroy)
+          {:destroy, action, join_destroy}
+        else
+          {:destroy, action}
+        end
+
       :destroy ->
         destroy = primary_action_name!(relationship.destination, :destroy)
         {:destroy, destroy}

--- a/lib/mix/tasks/install/ash.install.ex
+++ b/lib/mix/tasks/install/ash.install.ex
@@ -240,6 +240,12 @@ if Code.ensure_loaded?(Igniter) do
               [:redact_sensitive_values_in_errors?],
               true
             )
+            |> Igniter.Project.Config.configure(
+              "config.exs",
+              :ash,
+              [:many_to_many_destroy_destination_on_match?],
+              true
+            )
           end)
         end
       )

--- a/test/manage_relationship_test.exs
+++ b/test/manage_relationship_test.exs
@@ -740,6 +740,44 @@ defmodule Ash.Test.ManageRelationshipTest do
     assert join_count_after == join_count_before - 1
   end
 
+  test "on_match {:destroy, action} 2-tuple destroys both when config enabled" do
+    Application.put_env(:ash, :many_to_many_destroy_destination_on_match?, true)
+
+    on_exit(fn ->
+      Application.delete_env(:ash, :many_to_many_destroy_destination_on_match?)
+    end)
+
+    assert {:ok, parent} =
+             ParentResource
+             |> Ash.Changeset.for_create(:create, %{
+               name: "Test Parent Resource",
+               many_to_many_resources: [%{name: "config_1"}, %{name: "config_2"}]
+             })
+             |> Ash.create!()
+             |> Ash.load([:many_to_many_resources])
+
+    first_id =
+      Enum.find(parent.many_to_many_resources, &(&1.name == "config_1")).id
+
+    join_count_before = Ash.read!(JoinResource) |> length()
+
+    assert {:ok, updated_parent} =
+             parent
+             |> Ash.Changeset.for_update(:update_many_on_match_destroy_join_only, %{
+               many_to_many_resources: [%{id: first_id}]
+             })
+             |> Ash.update!()
+             |> Ash.load([:many_to_many_resources])
+
+    # destination record should be destroyed (config enabled)
+    assert Enum.find(updated_parent.many_to_many_resources, &(&1.name == "config_1")) == nil
+    assert Ash.read!(ManyToManyResource) |> Enum.find(&(&1.name == "config_1")) == nil
+
+    # join record should also be destroyed
+    join_count_after = Ash.read!(JoinResource) |> length()
+    assert join_count_after == join_count_before - 1
+  end
+
   test "removing non-existent relationship returns NotFound error" do
     parent =
       ParentResource

--- a/test/manage_relationship_test.exs
+++ b/test/manage_relationship_test.exs
@@ -64,6 +64,36 @@ defmodule Ash.Test.ManageRelationshipTest do
                )
       end
 
+      update :update_many_on_match_destroy do
+        require_atomic? false
+        argument :many_to_many_resources, {:array, :map}
+
+        change manage_relationship(:many_to_many_resources,
+                 on_no_match: :error,
+                 on_match: :destroy
+               )
+      end
+
+      update :update_many_on_match_destroy_join_only do
+        require_atomic? false
+        argument :many_to_many_resources, {:array, :map}
+
+        change manage_relationship(:many_to_many_resources,
+                 on_no_match: :error,
+                 on_match: {:destroy, :destroy_hard}
+               )
+      end
+
+      update :update_many_on_match_destroy_both do
+        require_atomic? false
+        argument :many_to_many_resources, {:array, :map}
+
+        change manage_relationship(:many_to_many_resources,
+                 on_no_match: :error,
+                 on_match: {:destroy, :destroy_hard, :destroy_hard}
+               )
+      end
+
       update :remove_other_resource do
         require_atomic? false
         argument :other_resource_id, :uuid
@@ -610,6 +640,104 @@ defmodule Ash.Test.ManageRelationshipTest do
     third = Enum.find(updated_parent.many_to_many_resources, &(&1.name == "third"))
     assert is_nil(third.archived_at)
     assert is_nil(hd(third.join_resources).archived_at)
+  end
+
+  test "on_match :destroy shorthand destroys both join and destination for many_to_many" do
+    assert {:ok, parent} =
+             ParentResource
+             |> Ash.Changeset.for_create(:create, %{
+               name: "Test Parent Resource",
+               many_to_many_resources: [%{name: "match_destroy_1"}, %{name: "match_destroy_2"}]
+             })
+             |> Ash.create!()
+             |> Ash.load([:many_to_many_resources])
+
+    first_id =
+      Enum.find(parent.many_to_many_resources, &(&1.name == "match_destroy_1")).id
+
+    join_count_before = Ash.read!(JoinResource) |> length()
+
+    assert {:ok, updated_parent} =
+             parent
+             |> Ash.Changeset.for_update(:update_many_on_match_destroy, %{
+               many_to_many_resources: [%{id: first_id}]
+             })
+             |> Ash.update!()
+             |> Ash.load([:many_to_many_resources])
+
+    # matched destination record should be destroyed
+    assert Enum.find(updated_parent.many_to_many_resources, &(&1.name == "match_destroy_1")) ==
+             nil
+
+    # join record for matched item should be destroyed
+    join_count_after = Ash.read!(JoinResource) |> length()
+    assert join_count_after == join_count_before - 1
+  end
+
+  test "on_match {:destroy, action} 2-tuple only destroys join for many_to_many (backward compat)" do
+    assert {:ok, parent} =
+             ParentResource
+             |> Ash.Changeset.for_create(:create, %{
+               name: "Test Parent Resource",
+               many_to_many_resources: [%{name: "join_only_1"}, %{name: "join_only_2"}]
+             })
+             |> Ash.create!()
+             |> Ash.load([:many_to_many_resources])
+
+    first_id =
+      Enum.find(parent.many_to_many_resources, &(&1.name == "join_only_1")).id
+
+    join_count_before = Ash.read!(JoinResource) |> length()
+
+    assert {:ok, updated_parent} =
+             parent
+             |> Ash.Changeset.for_update(:update_many_on_match_destroy_join_only, %{
+               many_to_many_resources: [%{id: first_id}]
+             })
+             |> Ash.update!()
+             |> Ash.load([:many_to_many_resources])
+
+    # destination record should still exist (only join destroyed)
+    assert Enum.find(updated_parent.many_to_many_resources, &(&1.name == "join_only_1")) == nil
+
+    # but the destination record itself still exists in the table
+    assert Ash.read!(ManyToManyResource) |> Enum.find(&(&1.name == "join_only_1")) != nil
+
+    # join record should be destroyed
+    join_count_after = Ash.read!(JoinResource) |> length()
+    assert join_count_after == join_count_before - 1
+  end
+
+  test "on_match {:destroy, dest_action, join_action} 3-tuple destroys both for many_to_many" do
+    assert {:ok, parent} =
+             ParentResource
+             |> Ash.Changeset.for_create(:create, %{
+               name: "Test Parent Resource",
+               many_to_many_resources: [%{name: "both_destroy_1"}, %{name: "both_destroy_2"}]
+             })
+             |> Ash.create!()
+             |> Ash.load([:many_to_many_resources])
+
+    first_id =
+      Enum.find(parent.many_to_many_resources, &(&1.name == "both_destroy_1")).id
+
+    join_count_before = Ash.read!(JoinResource) |> length()
+
+    assert {:ok, updated_parent} =
+             parent
+             |> Ash.Changeset.for_update(:update_many_on_match_destroy_both, %{
+               many_to_many_resources: [%{id: first_id}]
+             })
+             |> Ash.update!()
+             |> Ash.load([:many_to_many_resources])
+
+    # matched destination record should be destroyed
+    assert Enum.find(updated_parent.many_to_many_resources, &(&1.name == "both_destroy_1")) ==
+             nil
+
+    # join record should also be destroyed
+    join_count_after = Ash.read!(JoinResource) |> length()
+    assert join_count_after == join_count_before - 1
   end
 
   test "removing non-existent relationship returns NotFound error" do


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

- Fixes `on_match: :destroy` for `many_to_many` relationships to destroy both the join record and the destination record, consistent with how `on_missing: :destroy` already works
- Adds a new 3-tuple form `{:destroy, :dest_action, :join_action}` for explicit control over both actions
- Adds `many_to_many_destroy_destination_on_match?` backward compatibility config:
  - `false` (default): `{:destroy, action}` 2-tuple only destroys the join record (old behavior)
  - `true` (set by installer for new projects): 2-tuple also destroys both join and destination
  - Will be removed in 4.0

Closes #859