### PR TITLE
improvement: add --domain option to ash.gen.gettext for merging into existing pot files

### DIFF
--- a/lib/mix/tasks/gen/ash.gen.gettext.ex
+++ b/lib/mix/tasks/gen/ash.gen.gettext.ex
@@ -12,8 +12,27 @@ defmodule Mix.Tasks.Ash.Gen.Gettext do
   ## Usage
 
       $ mix ash.gen.gettext
+      $ mix ash.gen.gettext --domain errors
+
+  ## Options
+
+    * `--domain` / `-d` — Target gettext domain. Defaults to `"ash"`.
+
+      When set to a domain other than `"ash"` (e.g., `"errors"`), Ash's
+      translatable messages are **merged** into the existing
+      `priv/gettext/<domain>.pot` file. The Ash entries are placed
+      after a marker comment and replaced on each run, making this
+      operation idempotent. Multiple libraries (e.g., `ash`,
+      `ash_authentication`) can each maintain their own marked
+      section in the same file.
+
+      This is useful when your application already translates errors
+      under the `"errors"` domain and you want Ash messages available
+      there without changing your `translate_error/1` code.
 
   ## Workflow
+
+  ### Default (`ash` domain)
 
   1. Run `mix ash.gen.gettext` to copy `ash.pot` into your `priv/gettext/`.
   2. Run `mix gettext.merge priv/gettext --locale ko` to create
@@ -22,14 +41,40 @@ defmodule Mix.Tasks.Ash.Gen.Gettext do
   4. In your `translate_error/1`, call:
 
          Gettext.dgettext(MyApp.Gettext, "ash", msg, vars)
+
+  ### Custom domain (e.g., `errors`)
+
+  1. Run `mix ash.gen.gettext --domain errors` to merge Ash messages
+     into your existing `priv/gettext/errors.pot`.
+  2. Run `mix gettext.merge priv/gettext --locale ko` as usual.
+  3. Your existing `translate_error/1` using `dgettext(backend, "errors", ...)`
+     works without changes.
   """
 
   use Mix.Task
 
   @shortdoc "Copies Ash's .pot file for error message translation"
 
+  @marker "## -- ash-gettext:start --"
+  @marker_pattern ~r/^## -- [\w]+-gettext:start --$/m
+  @domain_regex ~r/^[a-z][a-z0-9_]*$/
+
   @impl Mix.Task
-  def run(_argv) do
+  def run(argv) do
+    {opts, _} =
+      OptionParser.parse!(argv,
+        strict: [domain: :string],
+        aliases: [d: :domain]
+      )
+
+    domain = Keyword.get(opts, :domain, "ash")
+
+    if not Regex.match?(@domain_regex, domain) do
+      Mix.raise(
+        "Invalid domain #{inspect(domain)}. Must be lowercase alphanumeric with underscores."
+      )
+    end
+
     source = Application.app_dir(:ash, "priv/gettext/ash.pot")
 
     if !File.exists?(source) do
@@ -39,11 +84,87 @@ defmodule Mix.Tasks.Ash.Gen.Gettext do
     end
 
     dest_dir = "priv/gettext"
-    dest = Path.join(dest_dir, "ash.pot")
+    dest = Path.join(dest_dir, "#{domain}.pot")
 
     File.mkdir_p!(dest_dir)
-    File.cp!(source, dest)
 
-    Mix.shell().info([:green, "* creating ", :reset, dest])
+    if domain == "ash" do
+      File.cp!(source, dest)
+      Mix.shell().info([:green, "* creating ", :reset, dest])
+    else
+      ash_block = build_ash_block(source)
+
+      content =
+        case File.read(dest) do
+          {:ok, existing} ->
+            merge_into_existing(existing, ash_block)
+
+          {:error, :enoent} ->
+            pot_header(domain) <> ash_block
+
+          {:error, reason} ->
+            Mix.raise("Could not read #{dest}: #{inspect(reason)}")
+        end
+
+      File.write!(dest, content)
+
+      Mix.shell().info([:green, "* updating ", :reset, dest])
+    end
+  end
+
+  defp build_ash_block(source_path) do
+    entries =
+      source_path
+      |> File.read!()
+      |> extract_entries()
+
+    @marker <> "\n" <> entries
+  end
+
+  defp extract_entries(pot_content) do
+    entries =
+      pot_content
+      |> String.split("\n\n")
+      |> Enum.filter(&String.contains?(&1, "msgid \""))
+      |> Enum.reject(fn chunk ->
+        chunk |> String.trim() |> String.starts_with?("msgid \"\"")
+      end)
+      |> Enum.map_join("\n\n", &String.trim/1)
+
+    entries <> "\n\n"
+  end
+
+  defp merge_into_existing(existing, ash_block) do
+    if String.contains?(existing, @marker) do
+      [before, rest] = String.split(existing, @marker, parts: 2)
+
+      after_block =
+        case Regex.run(@marker_pattern, rest, return: :index) do
+          [{pos, _len}] ->
+            String.slice(rest, pos, String.length(rest))
+
+          nil ->
+            ""
+        end
+
+      String.trim_trailing(before) <> "\n\n" <> ash_block <> after_block
+    else
+      String.trim_trailing(existing) <> "\n\n" <> ash_block
+    end
+  end
+
+  defp pot_header(domain) do
+    """
+    ## This file is a PO Template file.
+    ##
+    ## Run `mix gettext.merge priv/gettext --locale LOCALE` to merge into a .po file.
+
+    msgid ""
+    msgstr ""
+    "Content-Type: text/plain; charset=UTF-8\\n"
+    "Content-Transfer-Encoding: 8bit\\n"
+    "Domain: #{domain}\\n"
+
+    """
   end
 end

--- a/test/mix/tasks/ash.gen.gettext_test.exs
+++ b/test/mix/tasks/ash.gen.gettext_test.exs
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2024 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Mix.Tasks.Ash.Gen.GettextTest do
+  use ExUnit.Case, async: false
+
+  @marker "## -- ash-gettext:start --"
+
+  setup do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "ash_gen_gettext_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+    on_cleanup = fn -> File.rm_rf!(tmp_dir) end
+
+    original_cwd = File.cwd!()
+    File.cd!(tmp_dir)
+
+    on_exit(fn ->
+      File.cd!(original_cwd)
+      on_cleanup.()
+    end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  describe "default (ash domain)" do
+    test "copies ash.pot as before" do
+      Mix.Tasks.Ash.Gen.Gettext.run([])
+
+      dest = "priv/gettext/ash.pot"
+      assert File.exists?(dest)
+
+      content = File.read!(dest)
+      assert content =~ "must be present"
+      assert content =~ ~s("Domain: ash\\n")
+    end
+  end
+
+  describe "--domain errors" do
+    test "creates new errors.pot when file does not exist" do
+      Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "errors"])
+
+      dest = "priv/gettext/errors.pot"
+      assert File.exists?(dest)
+
+      content = File.read!(dest)
+      assert content =~ @marker
+      assert content =~ "must be present"
+      assert content =~ ~s("Domain: errors\\n")
+      refute content =~ ~s("Domain: ash\\n")
+    end
+
+    test "merges into existing errors.pot preserving existing entries" do
+      File.mkdir_p!("priv/gettext")
+
+      existing = """
+      ## This file is a PO Template file.
+
+      msgid ""
+      msgstr ""
+      "Content-Type: text/plain; charset=UTF-8\\n"
+      "Domain: errors\\n"
+
+      #: lib/my_app/accounts.ex:10
+      msgid "custom app error"
+      msgstr ""
+      """
+
+      File.write!("priv/gettext/errors.pot", existing)
+
+      Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "errors"])
+
+      content = File.read!("priv/gettext/errors.pot")
+      assert content =~ "custom app error"
+      assert content =~ @marker
+      assert content =~ "must be present"
+    end
+
+    test "is idempotent — re-running replaces marker block" do
+      Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "errors"])
+      first = File.read!("priv/gettext/errors.pot")
+
+      Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "errors"])
+      second = File.read!("priv/gettext/errors.pot")
+
+      assert first == second
+    end
+
+    test "preserves other library blocks after ash block" do
+      File.mkdir_p!("priv/gettext")
+
+      other_marker = "## -- ash_authentication-gettext:start --"
+
+      existing = """
+      msgid ""
+      msgstr ""
+      "Domain: errors\\n"
+
+      #{@marker}
+      msgid "old ash message"
+      msgstr ""
+
+      #{other_marker}
+      msgid "must confirm email"
+      msgstr ""
+      """
+
+      File.write!("priv/gettext/errors.pot", existing)
+
+      Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "errors"])
+
+      content = File.read!("priv/gettext/errors.pot")
+      # ash block replaced
+      assert content =~ "must be present"
+      refute content =~ "old ash message"
+      # other library block preserved
+      assert content =~ other_marker
+      assert content =~ "must confirm email"
+    end
+  end
+
+  describe "domain validation" do
+    test "rejects invalid domain names" do
+      assert_raise Mix.Error, ~r/Invalid domain/, fn ->
+        Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "../escape"])
+      end
+
+      assert_raise Mix.Error, ~r/Invalid domain/, fn ->
+        Mix.Tasks.Ash.Gen.Gettext.run(["--domain", ""])
+      end
+
+      assert_raise Mix.Error, ~r/Invalid domain/, fn ->
+        Mix.Tasks.Ash.Gen.Gettext.run(["--domain", "has/slash"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

- Add `--domain` / `-d` option to `mix ash.gen.gettext` so Ash error messages can be merged into an existing domain (e.g., `errors`) instead of creating a separate `ash.pot`
- Ash entries are placed between marker comments (`ash-gen-gettext:start/end`) and replaced on each run, making the operation idempotent
- Default behavior (`mix ash.gen.gettext` without `--domain`) is unchanged

## Motivation

When an app already uses the `"errors"` domain for all error translations (e.g., `dgettext(backend, "errors", msg, vars)` in `translate_error/1`), having Ash messages in a separate `"ash"` domain requires either changing the translation code or maintaining two domains. With `--domain errors`, Ash messages merge directly into `errors.pot` and the existing translation pipeline works without changes.

## Usage

```bash
# Merge Ash messages into errors.pot (idempotent)
mix ash.gen.gettext --domain errors
```

## Implementation note

The merge logic extracts entries from `ash.pot` by splitting on blank lines and filtering for `msgid` blocks — not a full PO parser. This works because `ash.pot` is generated by `mix ash.gettext.extract` with a simple, predictable structure (single-line msgids, no multiline strings, consistent blank-line separation). If `ash.pot`'s format becomes more complex in the future, this would need to be revisited with a proper parser like `expo`.