### PR TITLE
fix: recompute changed? after setup_managed_belongs_to_relationships

### DIFF
--- a/lib/ash/actions/update/update.ex
+++ b/lib/ash/actions/update/update.ex
@@ -471,8 +471,22 @@ defmodule Ash.Actions.Update do
                 {:error, error}
 
               {changeset, manage_instructions} ->
+                # Recompute changed? after setup_managed_belongs_to_relationships
+                # may have set FK attributes via force_change_attribute (e.g. when
+                # manage_relationship is called from before_transaction hooks on
+                # update actions). Without this, the changed? flag computed before
+                # the func callback would be false, causing the DB update to be
+                # skipped entirely.
+                changed? =
+                  Ash.Changeset.changing_attributes?(changeset) or
+                    not Enum.empty?(changeset.atomics)
+
                 changeset =
                   changeset
+                  |> Ash.Changeset.put_context(
+                    :changed?,
+                    changeset.context[:changed?] || changed?
+                  )
                   |> Ash.Changeset.require_values(
                     :update,
                     true

--- a/test/manage_relationship_test.exs
+++ b/test/manage_relationship_test.exs
@@ -252,6 +252,22 @@ defmodule Ash.Test.ManageRelationshipTest do
 
         change manage_relationship(:parent_resource, on_match: :update)
       end
+
+      update :update_create_parent_in_hook do
+        require_atomic? false
+
+        change fn changeset, _context ->
+          Ash.Changeset.before_transaction(changeset, fn changeset ->
+            Ash.Changeset.manage_relationship(
+              changeset,
+              :parent_resource,
+              %{name: "created-in-hook"},
+              type: :create,
+              on_no_match: :create
+            )
+          end)
+        end
+      end
     end
 
     attributes do
@@ -1287,6 +1303,27 @@ defmodule Ash.Test.ManageRelationshipTest do
 
       names = Enum.map(updated.other_resources, & &1.required_attribute)
       assert names == ["new1", "existing1", "new2", "existing2"]
+    end
+  end
+
+  describe "manage_relationship called from before_transaction hook on update" do
+    test "creates related record via belongs_to when manage_relationship is called in before_transaction" do
+      related =
+        RelatedResource
+        |> Ash.Changeset.for_create(:create, %{required_attribute: "test"})
+        |> Ash.create!()
+
+      assert related.parent_resource_id == nil
+
+      updated =
+        related
+        |> Ash.Changeset.for_update(:update_create_parent_in_hook, %{})
+        |> Ash.update!()
+
+      assert updated.parent_resource_id != nil
+
+      {:ok, loaded} = Ash.load(updated, :parent_resource)
+      assert loaded.parent_resource.name == "created-in-hook"
     end
   end
 end


### PR DESCRIPTION
## Summary

- When `manage_relationship` is called from `before_transaction` or `before_action` hooks on update actions, the `changed?` flag was computed **before** `setup_managed_belongs_to_relationships` runs, so it remained `false` even after the FK was set via `force_change_attribute`
- This caused the `cond` branch to skip the DB update entirely — the related record was created but the source record's FK was never persisted
- Fix: recompute `changed?` after `setup_managed_belongs_to_relationships` returns, so FK changes from hook-added managed relationships are detected

**Companion PR:** ash-project/ash_postgres — regression tests (will link once created)

## Test plan

- [x] Added test in `test/manage_relationship_test.exs` for update + `before_transaction` hook with ETS data layer
- [x] All 33 manage_relationship tests pass
- [x] Full ash_postgres suite passes (713 tests) with this fix