### PR TITLE
fix: handle nil return from generic actions with load option

### DIFF
--- a/lib/ash/actions/action.ex
+++ b/lib/ash/actions/action.ex
@@ -79,18 +79,7 @@ defmodule Ash.Actions.Action do
             end
           end)
 
-        result =
-          with {:ok, result, _} <-
-                 Ash.Actions.Helpers.load(result, input, domain,
-                   actor: opts[:actor],
-                   reuse_values?: true,
-                   action:
-                     Ash.Resource.Info.primary_action(input.resource, :read) || input.action,
-                   authorize?: opts[:authorize?],
-                   tracer: opts[:tracer]
-                 ) do
-            {:ok, result}
-          end
+        result = maybe_load(result, input, domain, opts)
 
         case result do
           {:error, error} ->
@@ -125,6 +114,35 @@ defmodule Ash.Actions.Action do
             other
         end
       end
+    end
+  end
+
+  defp validate_allow_nil(nil, %{action: %{allow_nil?: false}} = input, _in_transaction?) do
+    {:error,
+     Ash.Error.Framework.InvalidReturnType.exception(
+       message: """
+       Generic action #{inspect(input.resource)}.#{input.action.name} returned nil, \
+       but allow_nil? is set to false. Either return a value or set `allow_nil? true` \
+       on the action.
+       """
+     )}
+  end
+
+  defp validate_allow_nil(_result, _input, _in_transaction?), do: :ok
+
+  defp maybe_load(:ok, _input, _domain, _opts), do: :ok
+  defp maybe_load({:ok, nil}, _input, _domain, _opts), do: {:ok, nil}
+
+  defp maybe_load(result, input, domain, opts) do
+    with {:ok, result, _} <-
+           Ash.Actions.Helpers.load(result, input, domain,
+             actor: opts[:actor],
+             reuse_values?: true,
+             action: Ash.Resource.Info.primary_action(input.resource, :read) || input.action,
+             authorize?: opts[:authorize?],
+             tracer: opts[:tracer]
+           ) do
+      {:ok, result}
     end
   end
 
@@ -408,11 +426,15 @@ defmodule Ash.Actions.Action do
 
           {:ok, result} ->
             if input.action.returns do
-              # Run after_action hooks
-              case Ash.ActionInput.run_after_actions(result, input, before_action_notifications) do
-                {:ok, result, _input, %{notifications: all_notifications}} ->
-                  {:ok, result, all_notifications}
-
+              with :ok <- validate_allow_nil(result, input, in_transaction?),
+                   {:ok, result, _input, %{notifications: all_notifications}} <-
+                     Ash.ActionInput.run_after_actions(
+                       result,
+                       input,
+                       before_action_notifications
+                     ) do
+                {:ok, result, all_notifications}
+              else
                 {:error, error} ->
                   if in_transaction? do
                     Ash.DataLayer.rollback([input.resource], error)
@@ -425,15 +447,15 @@ defmodule Ash.Actions.Action do
             end
 
           {:ok, result, notifications} ->
-            # Run after_action hooks
-            case Ash.ActionInput.run_after_actions(
-                   result,
-                   input,
-                   before_action_notifications ++ notifications
-                 ) do
-              {:ok, result, _input, %{notifications: all_notifications}} ->
-                {:ok, result, all_notifications}
-
+            with :ok <- validate_allow_nil(result, input, in_transaction?),
+                 {:ok, result, _input, %{notifications: all_notifications}} <-
+                   Ash.ActionInput.run_after_actions(
+                     result,
+                     input,
+                     before_action_notifications ++ notifications
+                   ) do
+              {:ok, result, all_notifications}
+            else
               {:error, error} ->
                 if in_transaction? do
                   Ash.DataLayer.rollback([input.resource], error)

--- a/test/actions/generic_actions_test.exs
+++ b/test/actions/generic_actions_test.exs
@@ -227,6 +227,23 @@ defmodule Ash.Test.Actions.GenericActionsTest do
         end
       end
 
+      action :return_nil_post, :struct do
+        constraints instance_of: __MODULE__
+        allow_nil? true
+
+        run fn _input, _ ->
+          {:ok, nil}
+        end
+      end
+
+      action :return_nil_post_not_allowed, :struct do
+        constraints instance_of: __MODULE__
+
+        run fn _input, _ ->
+          {:ok, nil}
+        end
+      end
+
       action :errors_out, :struct do
         run fn input, _ ->
           {:error, %Ash.Error.Unknown{}}
@@ -354,6 +371,14 @@ defmodule Ash.Test.Actions.GenericActionsTest do
       end
 
       policy action(:return_post_with_author) do
+        authorize_if always()
+      end
+
+      policy action(:return_nil_post) do
+        authorize_if always()
+      end
+
+      policy action(:return_nil_post_not_allowed) do
         authorize_if always()
       end
 
@@ -1226,6 +1251,31 @@ defmodule Ash.Test.Actions.GenericActionsTest do
         |> Ash.ActionInput.for_action(:errors_out, %{})
         |> Ash.run_action!(load: [:author])
       end
+    end
+
+    test "it returns nil without error when action returns nil with load option and allow_nil?" do
+      result =
+        Post
+        |> Ash.ActionInput.for_action(:return_nil_post, %{})
+        |> Ash.run_action!(load: [:author])
+
+      assert is_nil(result)
+    end
+
+    test "it returns nil without error when action returns nil without load and allow_nil?" do
+      result =
+        Post
+        |> Ash.ActionInput.for_action(:return_nil_post, %{})
+        |> Ash.run_action!()
+
+      assert is_nil(result)
+    end
+
+    test "it returns an error when action returns nil with allow_nil? false" do
+      assert {:error, %Ash.Error.Framework{}} =
+               Post
+               |> Ash.ActionInput.for_action(:return_nil_post_not_allowed, %{})
+               |> Ash.run_action()
     end
   end
 


### PR DESCRIPTION
## Summary
- Fix `BadMapError` crash when a generic action returns `nil` and `load:` option is specified
- Enforce the existing `allow_nil?` DSL option (defaults to `false`) which was previously never checked at runtime
- Extract load logic into `maybe_load/4` and validation into `validate_allow_nil/3` for clarity

## Context
When a generic action returns `nil` (e.g., a lookup action that finds no record) and the caller passes `load: [:some_relationship]`, `Ash.Actions.Helpers.load/4` would call `Map.get(nil, :id)` via `Ash.Resource.selected?/3`, causing a `BadMapError`.

The `allow_nil?` option existed in the generic action DSL (defaulting to `false`) but was never enforced. Now:
- `allow_nil? true` → `nil` is returned successfully, loads are skipped
- `allow_nil? false` (default) → returns a clear `InvalidReturnType` error instead of crashing

## Test plan
- [x] Test generic action returning nil with `load:` and `allow_nil? true` succeeds
- [x] Test generic action returning nil without `load:` and `allow_nil? true` succeeds
- [x] Test generic action returning nil with `allow_nil? false` (default) returns proper error
- [x] All existing generic action tests pass (62 tests, 0 failures)