### PR TITLE
 feat: add batch_validate callback to Ash.Resource.Validation

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -1856,41 +1856,75 @@ defmodule Ash.Actions.Create.Bulk do
       %{must_return_records?: false, re_sort?: false, batch: batch, changes: %{}},
       fn
         {%{validation: {module, opts}} = validation, _change_index}, %{batch: batch} = state ->
+          validation_context =
+            struct(
+              Ash.Resource.Validation.Context,
+              Map.put(context, :message, validation.message)
+            )
+
           batch =
-            Enum.map(batch, fn changeset ->
-              cond do
-                !module.has_validate?() ->
-                  Ash.Changeset.add_error(
-                    changeset,
-                    Ash.Error.Framework.CanNotBeAtomic.exception(
-                      resource: changeset.resource,
-                      change: module,
-                      reason: "Create actions cannot be made atomic"
+            if module.has_batch_validate?() &&
+                 module.batch_callbacks?(batch, opts, validation_context) do
+              Ash.Actions.Helpers.Bulk.run_batch_validation(
+                validation,
+                batch,
+                validation_context,
+                actor
+              )
+            else
+              Enum.map(batch, fn changeset ->
+                cond do
+                  !module.has_validate?() ->
+                    Ash.Changeset.add_error(
+                      changeset,
+                      Ash.Error.Framework.CanNotBeAtomic.exception(
+                        resource: changeset.resource,
+                        change: module,
+                        reason: "Create actions cannot be made atomic"
+                      )
                     )
-                  )
 
-                invalid =
-                    Enum.find(validation.where, fn {where_mod, _} ->
-                      !where_mod.has_validate?()
-                    end) ->
-                  {invalid_mod, _} = invalid
+                  invalid =
+                      Enum.find(validation.where, fn {where_mod, _} ->
+                        !where_mod.has_validate?()
+                      end) ->
+                    {invalid_mod, _} = invalid
 
-                  Ash.Changeset.add_error(
-                    changeset,
-                    Ash.Error.Framework.CanNotBeAtomic.exception(
-                      resource: changeset.resource,
-                      change: invalid_mod,
-                      reason: "Create actions cannot be made atomic"
+                    Ash.Changeset.add_error(
+                      changeset,
+                      Ash.Error.Framework.CanNotBeAtomic.exception(
+                        resource: changeset.resource,
+                        change: invalid_mod,
+                        reason: "Create actions cannot be made atomic"
+                      )
                     )
-                  )
 
-                validation.only_when_valid? && !changeset.valid? ->
-                  changeset
+                  validation.only_when_valid? && !changeset.valid? ->
+                    changeset
 
-                Enum.all?(validation.where || [], fn {where_mod, where_opts} ->
-                  where_opts =
+                  Enum.all?(validation.where || [], fn {where_mod, where_opts} ->
+                    where_opts =
+                        templated_opts(
+                          where_opts,
+                          actor,
+                          changeset.to_tenant,
+                          changeset.arguments,
+                          changeset.context,
+                          changeset
+                        )
+
+                    {:ok, where_opts} = Ash.Resource.Validation.init(where_mod, where_opts)
+
+                    Ash.Resource.Validation.validate(
+                      where_mod,
+                      changeset,
+                      where_opts,
+                      struct(Ash.Resource.Validation.Context, context)
+                    ) == :ok
+                  end) ->
+                    opts =
                       templated_opts(
-                        where_opts,
+                        opts,
                         actor,
                         changeset.to_tenant,
                         changeset.arguments,
@@ -1898,56 +1932,38 @@ defmodule Ash.Actions.Create.Bulk do
                         changeset
                       )
 
-                  {:ok, where_opts} = Ash.Resource.Validation.init(where_mod, where_opts)
+                    {:ok, opts} = Ash.Resource.Validation.init(module, opts)
 
-                  Ash.Resource.Validation.validate(
-                    where_mod,
-                    changeset,
-                    where_opts,
-                    struct(Ash.Resource.Validation.Context, context)
-                  ) == :ok
-                end) ->
-                  opts =
-                    templated_opts(
-                      opts,
-                      actor,
-                      changeset.to_tenant,
-                      changeset.arguments,
-                      changeset.context,
-                      changeset
-                    )
+                    case Ash.Resource.Validation.validate(
+                           module,
+                           changeset,
+                           opts,
+                           struct(
+                             Ash.Resource.Validation.Context,
+                             Map.put(context, :message, validation.message)
+                           )
+                         ) do
+                      :ok ->
+                        changeset
 
-                  {:ok, opts} = Ash.Resource.Validation.init(module, opts)
+                      {:error, error} ->
+                        error = Ash.Error.to_ash_error(error)
 
-                  case Ash.Resource.Validation.validate(
-                         module,
-                         changeset,
-                         opts,
-                         struct(
-                           Ash.Resource.Validation.Context,
-                           Map.put(context, :message, validation.message)
-                         )
-                       ) do
-                    :ok ->
-                      changeset
+                        if validation.message do
+                          error =
+                            Ash.Error.override_validation_message(error, validation.message)
 
-                    {:error, error} ->
-                      error = Ash.Error.to_ash_error(error)
+                          Ash.Changeset.add_error(changeset, error)
+                        else
+                          Ash.Changeset.add_error(changeset, error)
+                        end
+                    end
 
-                      if validation.message do
-                        error =
-                          Ash.Error.override_validation_message(error, validation.message)
-
-                        Ash.Changeset.add_error(changeset, error)
-                      else
-                        Ash.Changeset.add_error(changeset, error)
-                      end
-                  end
-
-                true ->
-                  changeset
-              end
-            end)
+                  true ->
+                    changeset
+                end
+              end)
+            end
 
           %{
             state
@@ -2165,4 +2181,5 @@ defmodule Ash.Actions.Create.Bulk do
       end
     end)
   end
+
 end

--- a/lib/ash/actions/helpers/bulk.ex
+++ b/lib/ash/actions/helpers/bulk.ex
@@ -496,4 +496,74 @@ defmodule Ash.Actions.Helpers.Bulk do
   end
 
   def clean_changeset_id_metadata(other), do: other
+
+  @doc """
+  Runs batch validation for a validation that implements `batch_validate/3`.
+
+  Splits the batch into matching/non-matching changesets based on `where` and
+  `only_when_valid?` conditions, runs `batch_validate` on the matches, and
+  merges the results back together.
+  """
+  def run_batch_validation(
+        %{validation: {module, opts}} = validation,
+        batch,
+        validation_context,
+        actor
+      ) do
+    {matches, non_matches} =
+      if Enum.empty?(validation.where) && !validation.only_when_valid? do
+        {batch, []}
+      else
+        Enum.split_with(batch, fn changeset ->
+          applies_from_only_when_valid? =
+            if validation.only_when_valid?, do: changeset.valid?, else: true
+
+          applies_from_where? =
+            Enum.all?(validation.where || [], fn {where_module, where_opts} ->
+              where_opts =
+                Ash.Actions.Helpers.templated_opts(
+                  where_opts,
+                  actor,
+                  changeset.to_tenant,
+                  changeset.arguments,
+                  changeset.context,
+                  changeset
+                )
+
+              {:ok, where_opts} = where_module.init(where_opts)
+
+              Ash.Resource.Validation.validate(
+                where_module,
+                changeset,
+                where_opts,
+                validation_context
+              ) == :ok
+            end)
+
+          applies_from_where? and applies_from_only_when_valid?
+        end)
+      end
+
+    if Enum.empty?(matches) do
+      non_matches
+    else
+      opts =
+        case opts do
+          {:templated, opts} -> opts
+          opts -> opts
+        end
+
+      {:ok, opts} = module.init(opts)
+
+      validated =
+        module.batch_validate(
+          matches,
+          opts,
+          struct(validation_context, bulk?: true)
+        )
+        |> Enum.to_list()
+
+      Enum.concat(validated, non_matches)
+    end
+  end
 end

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -3545,7 +3545,8 @@ defmodule Ash.Actions.Update.Bulk do
       all_changes,
       %{must_return_records?: false, re_sort?: false, batch: batch, changes: %{}},
       fn
-        {%{validation: {module, _opts}} = validation, _change_index}, %{batch: batch} = state ->
+        {%{validation: {module, validation_opts}} = validation, _change_index},
+        %{batch: batch} = state ->
           validation_context =
             struct(
               Ash.Resource.Validation.Context,
@@ -3553,36 +3554,46 @@ defmodule Ash.Actions.Update.Bulk do
             )
 
           batch =
-            if module.has_validate?() &&
-                 Enum.all?(validation.where, fn {module, _opts} ->
-                   module.has_validate?()
-                 end) do
-              if validation.before_action? do
-                Enum.map(batch, fn changeset ->
-                  Ash.Changeset.before_action(changeset, fn changeset ->
-                    [changeset] =
-                      validate_batch_non_atomically(
-                        validation,
-                        [changeset],
-                        validation_context,
-                        actor
-                      )
-
-                    changeset
-                  end)
-                end)
-              else
-                validate_batch_non_atomically(validation, batch, validation_context, actor)
-              end
+            if module.has_batch_validate?() &&
+                 module.batch_callbacks?(batch, validation_opts, validation_context) do
+              Ash.Actions.Helpers.Bulk.run_batch_validation(
+                validation,
+                batch,
+                validation_context,
+                actor
+              )
             else
-              if module.atomic?() do
-                validate_batch_atomically(validation, batch, validation_context, context, actor)
-              else
-                raise """
-                Cannot use a non-atomic validation with an atomic condition.
+              if module.has_validate?() &&
+                   Enum.all?(validation.where, fn {module, _opts} ->
+                     module.has_validate?()
+                   end) do
+                if validation.before_action? do
+                  Enum.map(batch, fn changeset ->
+                    Ash.Changeset.before_action(changeset, fn changeset ->
+                      [changeset] =
+                        validate_batch_non_atomically(
+                          validation,
+                          [changeset],
+                          validation_context,
+                          actor
+                        )
 
-                Attempting to run action: `#{inspect(resource)}.#{action.name}`
-                """
+                      changeset
+                    end)
+                  end)
+                else
+                  validate_batch_non_atomically(validation, batch, validation_context, actor)
+                end
+              else
+                if module.atomic?() do
+                  validate_batch_atomically(validation, batch, validation_context, context, actor)
+                else
+                  raise """
+                  Cannot use a non-atomic validation with an atomic condition.
+
+                  Attempting to run action: `#{inspect(resource)}.#{action.name}`
+                  """
+                end
               end
             end
 

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -91,10 +91,35 @@ defmodule Ash.Resource.Validation do
               | {:not_atomic, String.t()}
               | {:error, term()}
 
+  @doc """
+  Replaces `validate/3` for batch actions, allowing to optimize validations for bulk actions.
+
+  Receives all changesets in the batch and returns them with errors added to any that
+  fail validation. Unlike `validate/3` which returns `:ok | {:error, term}`, this callback
+  returns the changesets directly (with errors already added via `Ash.Changeset.add_error/2`).
+  """
+  @callback batch_validate(
+              changesets :: [Ash.Changeset.t()],
+              opts :: Keyword.t(),
+              context :: Context.t()
+            ) ::
+              Enumerable.t(Ash.Changeset.t())
+
+  @doc """
+  Whether or not batch callbacks should be run (if they are defined). Defaults to `true`.
+  """
+  @callback batch_callbacks?(
+              changesets_or_query :: [Ash.Changeset.t()] | Ash.Query.t(),
+              opts :: Keyword.t(),
+              context :: Context.t()
+            ) ::
+              boolean
+
   @callback atomic?() :: boolean
   @callback has_validate?() :: boolean
+  @callback has_batch_validate?() :: boolean
 
-  @optional_callbacks describe: 1, validate: 3, atomic: 3
+  @optional_callbacks describe: 1, validate: 3, atomic: 3, batch_validate: 3
 
   @validation_type {:spark_function_behaviour, Ash.Resource.Validation,
                     Ash.Resource.Validation.Builtins, {Ash.Resource.Validation.Function, 2}}
@@ -164,6 +189,9 @@ defmodule Ash.Resource.Validation do
       @impl true
       def supports(_opts), do: [Ash.Changeset]
 
+      @impl true
+      def batch_callbacks?(_, _, _), do: true
+
       defp with_description(keyword, opts) do
         if Kernel.function_exported?(__MODULE__, :describe, 1) do
           keyword ++ Ash.Resource.Validation.describe(__MODULE__, opts)
@@ -172,7 +200,7 @@ defmodule Ash.Resource.Validation do
         end
       end
 
-      defoverridable init: 1, supports: 1
+      defoverridable init: 1, supports: 1, batch_callbacks?: 3
     end
   end
 
@@ -185,6 +213,14 @@ defmodule Ash.Resource.Validation do
       else
         @impl true
         def has_validate?, do: false
+      end
+
+      if Module.defines?(__MODULE__, {:batch_validate, 3}, :def) do
+        @impl true
+        def has_batch_validate?, do: true
+      else
+        @impl true
+        def has_batch_validate?, do: false
       end
 
       if Module.defines?(__MODULE__, {:atomic, 3}, :def) do

--- a/test/actions/bulk/bulk_batch_validate_test.exs
+++ b/test/actions/bulk/bulk_batch_validate_test.exs
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Actions.BulkBatchValidateTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule BatchTitleValidation do
+    @moduledoc "Validates the entire batch at once, rejecting titles containing 'invalid'"
+    use Ash.Resource.Validation
+
+    @impl true
+    def batch_validate(changesets, _opts, _context) do
+      send(self(), {:batch_validate_called, length(Enum.to_list(changesets))})
+
+      Enum.map(changesets, fn changeset ->
+        title = Ash.Changeset.get_attribute(changeset, :title)
+
+        if title && String.contains?(title, "invalid") do
+          Ash.Changeset.add_error(changeset, field: :title, message: "title is invalid")
+        else
+          changeset
+        end
+      end)
+    end
+
+    @impl true
+    def validate(changeset, _opts, _context) do
+      title = Ash.Changeset.get_attribute(changeset, :title)
+
+      if title && String.contains?(title, "invalid") do
+        {:error, field: :title, message: "title is invalid (per-changeset)"}
+      else
+        :ok
+      end
+    end
+  end
+
+  defmodule BatchOnlyValidation do
+    @moduledoc "Only defines batch_validate, no per-changeset validate"
+    use Ash.Resource.Validation
+
+    @impl true
+    def batch_validate(changesets, _opts, _context) do
+      send(self(), {:batch_only_validate_called, length(Enum.to_list(changesets))})
+
+      Enum.map(changesets, fn changeset ->
+        title = Ash.Changeset.get_attribute(changeset, :title)
+
+        if title && String.contains?(title, "forbidden") do
+          Ash.Changeset.add_error(changeset, field: :title, message: "title is forbidden")
+        else
+          changeset
+        end
+      end)
+    end
+  end
+
+  defmodule NoBatchCallbacksValidation do
+    @moduledoc "Has batch_validate but batch_callbacks? returns false, forcing per-changeset fallback"
+    use Ash.Resource.Validation
+
+    @impl true
+    def batch_callbacks?(_, _, _), do: false
+
+    @impl true
+    def batch_validate(changesets, _opts, _context) do
+      send(self(), {:no_batch_callbacks_batch_validate_called, length(Enum.to_list(changesets))})
+      Enum.to_list(changesets)
+    end
+
+    @impl true
+    def validate(changeset, _opts, _context) do
+      send(self(), :no_batch_callbacks_validate_called)
+      title = Ash.Changeset.get_attribute(changeset, :title)
+
+      if title && String.contains?(title, "reject") do
+        {:error, field: :title, message: "title rejected"}
+      else
+        :ok
+      end
+    end
+  end
+
+  defmodule TitleContainsValidation do
+    @moduledoc "Where-condition validation: passes if title contains a given substring"
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(changeset, opts, _context) do
+      title = Ash.Changeset.get_attribute(changeset, :title)
+
+      if title && String.contains?(title, opts[:substring] || "") do
+        :ok
+      else
+        {:error, field: :title, message: "title must contain '#{opts[:substring]}'"}
+      end
+    end
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+
+      create :create_with_batch_validation do
+        validate BatchTitleValidation
+      end
+
+      create :create_with_batch_only_validation do
+        validate BatchOnlyValidation
+      end
+
+      create :create_with_no_batch_callbacks do
+        validate NoBatchCallbacksValidation
+      end
+
+      create :create_with_where_batch_validation do
+        validate BatchTitleValidation,
+          where: [{TitleContainsValidation, substring: "check"}]
+      end
+
+      create :create_with_only_when_valid_batch_validation do
+        validate fn changeset, _context ->
+          if Ash.Changeset.get_attribute(changeset, :title) == "force_error" do
+            {:error, field: :title, message: "forced error"}
+          else
+            :ok
+          end
+        end
+
+        validate BatchTitleValidation, only_when_valid?: true
+      end
+
+      update :update_with_batch_validation do
+        require_atomic? false
+        validate BatchTitleValidation
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :title, :string do
+        public? true
+        allow_nil? false
+      end
+    end
+  end
+
+  describe "batch_validate in bulk create" do
+    test "batch_validate receives all changesets at once" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create!(
+                 [%{title: "one"}, %{title: "two"}, %{title: "three"}],
+                 Post,
+                 :create_with_batch_validation,
+                 return_records?: true,
+                 authorize?: false
+               )
+
+      assert length(records) == 3
+      assert_received {:batch_validate_called, 3}
+    end
+
+    test "batch_validate can add errors to specific changesets" do
+      result =
+        Ash.bulk_create(
+          [%{title: "good"}, %{title: "invalid_title"}, %{title: "also_good"}],
+          Post,
+          :create_with_batch_validation,
+          return_records?: true,
+          return_errors?: true,
+          authorize?: false
+        )
+
+      assert result.status in [:partial_success, :error]
+      assert result.error_count > 0
+      assert_received {:batch_validate_called, _}
+    end
+
+    test "batch_callbacks? returning false causes fallback to per-changeset validate" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create!(
+                 [%{title: "ok1"}, %{title: "ok2"}],
+                 Post,
+                 :create_with_no_batch_callbacks,
+                 return_records?: true,
+                 authorize?: false
+               )
+
+      assert length(records) == 2
+      refute_received {:no_batch_callbacks_batch_validate_called, _}
+      assert_received :no_batch_callbacks_validate_called
+    end
+
+    test "where conditions filter which changesets reach batch_validate" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create!(
+                 [%{title: "check_this"}, %{title: "skip_this"}, %{title: "check_too"}],
+                 Post,
+                 :create_with_where_batch_validation,
+                 return_records?: true,
+                 authorize?: false
+               )
+
+      assert length(records) == 3
+      assert_received {:batch_validate_called, 2}
+    end
+
+    test "only_when_valid? skips batch_validate for invalid changesets" do
+      result =
+        Ash.bulk_create(
+          [%{title: "good"}, %{title: "force_error"}, %{title: "fine"}],
+          Post,
+          :create_with_only_when_valid_batch_validation,
+          return_records?: true,
+          return_errors?: true,
+          authorize?: false
+        )
+
+      assert_received {:batch_validate_called, 2}
+      assert result.error_count > 0
+    end
+  end
+
+  describe "batch_validate in bulk update" do
+    test "batch_validate receives all changesets during bulk update" do
+      %Ash.BulkResult{records: records} =
+        Ash.bulk_create!(
+          [%{title: "alpha"}, %{title: "beta"}, %{title: "gamma"}],
+          Post,
+          :create,
+          return_records?: true,
+          authorize?: false
+        )
+
+      assert length(records) == 3
+
+      assert %Ash.BulkResult{status: :success} =
+               Ash.bulk_update!(records, :update_with_batch_validation, %{title: "updated"},
+                 return_records?: true,
+                 authorize?: false,
+                 strategy: :stream
+               )
+
+      assert_received {:batch_validate_called, _}
+    end
+
+    test "batch_validate can reject records during bulk update" do
+      %Ash.BulkResult{records: records} =
+        Ash.bulk_create!(
+          [%{title: "alpha"}, %{title: "beta"}],
+          Post,
+          :create,
+          return_records?: true,
+          authorize?: false
+        )
+
+      result =
+        Ash.bulk_update(records, :update_with_batch_validation, %{title: "invalid_update"},
+          return_records?: true,
+          return_errors?: true,
+          authorize?: false,
+          strategy: :stream
+        )
+
+      assert length(result.errors) > 0
+      assert_received {:batch_validate_called, _}
+    end
+  end
+end


### PR DESCRIPTION
Summary

- Adds batch_validate/3, before_batch/3, after_batch/3, and batch_callbacks?/3 callbacks to Ash.Resource.Validation, mirroring the existing pattern on Ash.Resource.Change
- Wires batch validation into bulk create, update, and destroy (via delegation) so validations can process entire batches at once instead of one record at a time
- Fully backwards compatible - existing validations are unaffected; new code path only activates when batch_validate/3 is defined

Closes #1405

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
