### PR TITLE
feat: add `init/1` callback to `Ash.Policy.Check`

### DIFF
--- a/lib/ash/policy/check.ex
+++ b/lib/ash/policy/check.ex
@@ -23,7 +23,14 @@ defmodule Ash.Policy.Check do
 
   @doc false
   def transform(%{check: {check_module, opts}} = policy) do
-    {:ok, %{policy | check_module: check_module, check_opts: opts}}
+    case init(check_module, opts) do
+      {:ok, opts} ->
+        {:ok,
+         %{policy | check: {check_module, opts}, check_module: check_module, check_opts: opts}}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   @type context() :: %{resource: Ash.Resource.t()}
@@ -108,6 +115,14 @@ defmodule Ash.Policy.Check do
   when two checks cannot both be true at the same time.
   """
   @callback conflicts?(ref(), ref(), context()) :: boolean()
+
+  @doc """
+  Initialize and validate the opts for the check module.
+
+  This callback is called at compile time when the check is defined in a policy.
+  It allows checks to verify and normalize their options before they are used.
+  """
+  @callback init(opts :: Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
 
   @optional_callbacks check: 4,
                       auto_filter: 3,
@@ -203,6 +218,19 @@ defmodule Ash.Policy.Check do
         The callback #{inspect(__MODULE__)}.describe/1 expects a String.t().
         """
     end
+  end
+
+  @doc false
+  @spec init(module(), Keyword.t()) :: {:ok, Keyword.t()} | {:error, String.t()}
+  def init(module, opts) do
+    Ash.BehaviourHelpers.call_and_validate_return(
+      module,
+      :init,
+      [opts],
+      [{:ok, :_}, {:error, :_}],
+      behaviour: __MODULE__,
+      callback_name: "init/1"
+    )
   end
 
   @doc false
@@ -346,6 +374,7 @@ defmodule Ash.Policy.Check do
       require Ash.Query
 
       def type, do: :manual
+      def init(opts), do: {:ok, opts}
       def requires_original_data?(_, _), do: false
       def prefer_expanded_description?, do: false
       def eager_evaluate?, do: false
@@ -354,6 +383,7 @@ defmodule Ash.Policy.Check do
       def conflicts?(_, _, _context), do: false
 
       defoverridable type: 0,
+                     init: 1,
                      requires_original_data?: 2,
                      prefer_expanded_description?: 0,
                      eager_evaluate?: 0,

--- a/lib/ash/policy/filter_check.ex
+++ b/lib/ash/policy/filter_check.ex
@@ -54,6 +54,8 @@ defmodule Ash.Policy.FilterCheck do
 
       def type, do: :filter
 
+      def init(opts), do: {:ok, opts}
+
       def requires_original_data?(_, _), do: false
 
       def eager_evaluate?, do: false
@@ -398,7 +400,8 @@ defmodule Ash.Policy.FilterCheck do
 
       def prefer_expanded_description?, do: false
 
-      defoverridable reject: 3,
+      defoverridable init: 1,
+                     reject: 3,
                      requires_original_data?: 2,
                      expand_description: 3,
                      prefer_expanded_description?: 0

--- a/lib/ash/policy/simple_check.ex
+++ b/lib/ash/policy/simple_check.ex
@@ -49,6 +49,8 @@ defmodule Ash.Policy.SimpleCheck do
 
       def type, do: :simple
 
+      def init(opts), do: {:ok, opts}
+
       def requires_original_data?(_, _), do: false
 
       @dialyzer {:nowarn_function, strict_check: 3}
@@ -63,7 +65,8 @@ defmodule Ash.Policy.SimpleCheck do
       def prefer_expanded_description?, do: false
       def eager_evaluate?, do: true
 
-      defoverridable requires_original_data?: 2,
+      defoverridable init: 1,
+                     requires_original_data?: 2,
                      prefer_expanded_description?: 0,
                      eager_evaluate?: 0
     end

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -111,6 +111,25 @@ defmodule Ash.Test.Policy.SimpleTest do
     end
   end
 
+  defmodule CheckWithInit do
+    use Ash.Policy.SimpleCheck
+
+    @impl true
+    def init(opts) do
+      if opts[:required_option] do
+        {:ok, Keyword.put(opts, :initialized, true)}
+      else
+        {:error, "required_option is required"}
+      end
+    end
+
+    @impl true
+    def describe(_opts), do: "check with init"
+
+    @impl true
+    def match?(_, _, opts), do: opts[:initialized] == true
+  end
+
   defmodule OldEnoughToDrink do
     use Ash.Policy.FilterCheck
 
@@ -1113,6 +1132,74 @@ defmodule Ash.Test.Policy.SimpleTest do
         |> Enum.sort()
 
       assert super_admin_results == Enum.sort([public_record.id, confidential_record.id])
+    end
+  end
+
+  describe "check init/1 callback" do
+    test "init/1 is called and normalizes opts during compilation" do
+      # CheckWithInit sets :initialized to true when :required_option is provided.
+      # The resource ResourceWithCheckInit uses it with required_option: true,
+      # so the check should work and the opts should be normalized.
+      defmodule ResourceWithCheckInit do
+        use Ash.Resource,
+          domain: Ash.Test.Domain,
+          data_layer: Ash.DataLayer.Ets,
+          authorizers: [Ash.Policy.Authorizer]
+
+        ets do
+          private? true
+        end
+
+        attributes do
+          uuid_primary_key :id
+        end
+
+        actions do
+          defaults [:create, :read]
+        end
+
+        policies do
+          policy action_type(:read) do
+            authorize_if {CheckWithInit, required_option: true}
+          end
+
+          policy action_type(:create) do
+            authorize_if always()
+          end
+        end
+      end
+
+      actor = %{id: "test"}
+
+      ResourceWithCheckInit
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!(authorize?: false)
+
+      assert [_] = Ash.read!(ResourceWithCheckInit, actor: actor)
+    end
+
+    test "init/1 returning error prevents compilation" do
+      assert_raise Spark.Error.DslError, ~r/required_option is required/, fn ->
+        defmodule ResourceWithBadCheckInit do
+          use Ash.Resource,
+            domain: Ash.Test.Domain,
+            authorizers: [Ash.Policy.Authorizer]
+
+          attributes do
+            uuid_primary_key :id
+          end
+
+          actions do
+            defaults [:read]
+          end
+
+          policies do
+            policy action_type(:read) do
+              authorize_if {CheckWithInit, []}
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Closes #1118