### PR TITLE
fix: dump attribute values to native in atomic upgrade path

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1752,7 +1752,13 @@ defmodule Ash.Changeset do
             {:cont, %{changeset | arguments: Map.put(changeset.arguments, key, value)}}
 
           attribute = Ash.Resource.Info.attribute(changeset.resource, key) ->
-            {:cont, atomic_update(changeset, attribute.name, {:atomic, value})}
+            case Ash.Type.dump_to_native(attribute.type, value, attribute.constraints) do
+              {:ok, dumped} ->
+                {:cont, atomic_update(changeset, attribute.name, {:atomic, dumped})}
+
+              :error ->
+                {:cont, add_invalid_errors(value, :attribute, changeset, attribute, "is invalid")}
+            end
 
           match?("_" <> _, key) ->
             {:cont, changeset}

--- a/test/actions/atomic_update_test.exs
+++ b/test/actions/atomic_update_test.exs
@@ -99,6 +99,10 @@ defmodule Ash.Test.Actions.AtomicUpdateTest do
         accept []
         change relate_actor(:owner)
       end
+
+      update :set_owner do
+        accept [:owner_id]
+      end
     end
 
     attributes do
@@ -403,6 +407,38 @@ defmodule Ash.Test.Actions.AtomicUpdateTest do
       assert is_nil(author.score)
       assert DateTime.compare(author.updated_at, original_updated_at) == :eq
     end
+  end
+
+  test "atomic upgrade dumps belongs_to UUID to native format" do
+    owner =
+      Author
+      |> Ash.Changeset.for_create(:create, %{name: "owner"})
+      |> Ash.create!()
+
+    author =
+      Author
+      |> Ash.Changeset.for_create(:create, %{name: "fred"})
+      |> Ash.create!()
+
+    atomic_changeset =
+      Ash.Changeset.fully_atomic_changeset(
+        Author,
+        :set_owner,
+        %{owner_id: owner.id},
+        assume_casted?: true,
+        data: author
+      )
+
+    # Must be 16-byte binary (dump_to_native), not 36-char string (cast_input)
+    owner_id_atomic = Keyword.get(atomic_changeset.atomics, :owner_id)
+    assert byte_size(owner_id_atomic) == 16
+
+    updated =
+      author
+      |> Ash.Changeset.for_update(:set_owner, %{owner_id: owner.id})
+      |> Ash.update!()
+
+    assert updated.owner_id == owner.id
   end
 
   describe "increment/1" do


### PR DESCRIPTION
The `assume_casted?` path in `atomic_params/4` was putting attribute values directly into `changeset.atomics` without calling `dump_to_native/3`.

For types where the cast representation differs from the native representation, this meant improperly formatted values reached the data layer.

This was leading to errors in our tests after upgrading to Ash 3.23.1, such as:

```
 {:error,
  %Ash.Error.Unknown{
    bread_crumbs: ["Returned from bulk query update: MyApp.FormBuilder.ClientFormResponse.complete"],
    changeset: "#Changeset<>",
    errors: [
      %Ash.Error.Unknown.UnknownError{
        error: "** (DBConnection.EncodeError) Postgrex expected a binary of 16 bytes, got \"019d66bc-d770-71ea-9eb7-3086dd6b77eb\". Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly.",
        field: nil,
        value: nil,
        splode: Ash.Error,
        bread_crumbs: ["Returned from bulk query update: MyApp.FormBuilder.ClientFormResponse.complete"],
        vars: [],
        path: [],
        stacktrace: #Splode.Stacktrace<>,
        class: :unknown
      }
    ]
  }}
```

## Notes

While UUID is the most visible case (hard Postgrex error), any type with a non-trivial `dump_to_native` could be silently affected on this code path. It may be worth auditing other types — though most built-in types have identity or near-identity dump functions.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
