### PR TITLE
feat: add Ash.Query.where/2 as non-macro alternative to filter/2

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -695,6 +695,37 @@ defmodule Ash.Query do
   end
 
   @doc """
+  Attach a filter statement to the query.
+
+  This is a non-macro alternative to `filter/2` that doesn't require
+  `require Ash.Query`. It accepts keyword/map style filters but not
+  expression syntax (use `filter/2` for expressions like `filter(title == "foo")`).
+
+  Passing `nil` is a no-op, which is useful for conditional filtering in pipelines.
+
+  The filter is applied as an "and" to any filters currently on the query.
+
+  ## Examples
+
+      # Keyword syntax
+      MyApp.Post
+      |> Ash.Query.where(published: true)
+
+      # Map syntax
+      MyApp.Post
+      |> Ash.Query.where(%{points: %{greater_than: 100}})
+
+  ## See also
+
+  - `filter/2` for expression-style filters
+  - `filter_input/3` for user-submitted filter data
+  """
+  @spec where(t() | Ash.Resource.t(), Keyword.t() | map() | nil) :: t()
+  def where(query, filter) do
+    do_filter(query, filter)
+  end
+
+  @doc """
   Creates a new query for the given resource.
 
   This is the starting point for building queries.  The query will automatically include the resource's base filter

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -698,8 +698,10 @@ defmodule Ash.Query do
   Attach a filter statement to the query.
 
   This is a non-macro alternative to `filter/2` that doesn't require
-  `require Ash.Query`. It accepts keyword/map style filters but not
-  expression syntax (use `filter/2` for expressions like `filter(title == "foo")`).
+  `require Ash.Query`. It accepts keyword/map style filters by default,
+  and also accepts expressions when the caller wraps them with
+  `Ash.Expr.expr/1` (e.g. via `import Ash.Expr`), so a single function
+  handles both expression and non-expression filters.
 
   Passing `nil` is a no-op, which is useful for conditional filtering in pipelines.
 
@@ -715,12 +717,18 @@ defmodule Ash.Query do
       MyApp.Post
       |> Ash.Query.where(%{points: %{greater_than: 100}})
 
+      # Expression syntax (requires `Ash.Expr.expr/1`)
+      import Ash.Expr
+
+      MyApp.Post
+      |> Ash.Query.where(expr(points > 100))
+
   ## See also
 
-  - `filter/2` for expression-style filters
+  - `filter/2` for the macro form that wraps bare expressions automatically
   - `filter_input/3` for user-submitted filter data
   """
-  @spec where(t() | Ash.Resource.t(), Keyword.t() | map() | nil) :: t()
+  @spec where(t() | Ash.Resource.t(), term()) :: t()
   def where(query, filter) do
     do_filter(query, filter)
   end

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -508,6 +508,59 @@ defmodule Ash.Test.Filter.FilterTest do
     end
   end
 
+  describe "where/2" do
+    setup do
+      post1 =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "title1", contents: "contents1", points: 1})
+        |> Ash.create!()
+        |> strip_metadata()
+
+      post2 =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "title2", contents: "contents2", points: 2})
+        |> Ash.create!()
+        |> strip_metadata()
+
+      %{post1: post1, post2: post2}
+    end
+
+    test "filters with keyword syntax", %{post1: post1} do
+      assert [^post1] =
+               Post
+               |> Ash.Query.where(title: "title1")
+               |> Ash.read!()
+               |> strip_metadata()
+    end
+
+    test "filters with map syntax", %{post1: post1} do
+      assert [^post1] =
+               Post
+               |> Ash.Query.where(%{title: "title1"})
+               |> Ash.read!()
+               |> strip_metadata()
+    end
+
+    test "combines with existing filter using and", %{post1: post1} do
+      assert [^post1] =
+               Post
+               |> Ash.Query.where(title: [in: ["title1", "title2"]])
+               |> Ash.Query.where(points: [less_than: 2])
+               |> Ash.read!()
+               |> strip_metadata()
+    end
+
+    test "no-ops for nil" do
+      query = Post |> Ash.Query.where(nil)
+      assert query.filter == nil
+    end
+
+    test "no-ops for empty list" do
+      query = Post |> Ash.Query.where([])
+      assert query.filter == nil
+    end
+  end
+
   describe "embedded filters" do
     setup do
       Profile

--- a/test/filter/filter_test.exs
+++ b/test/filter/filter_test.exs
@@ -550,6 +550,16 @@ defmodule Ash.Test.Filter.FilterTest do
                |> strip_metadata()
     end
 
+    test "filters with expression syntax via Ash.Expr.expr/1", %{post2: post2} do
+      import Ash.Expr
+
+      assert [^post2] =
+               Post
+               |> Ash.Query.where(expr(points > 1))
+               |> Ash.read!()
+               |> strip_metadata()
+    end
+
     test "no-ops for nil" do
       query = Post |> Ash.Query.where(nil)
       assert query.filter == nil


### PR DESCRIPTION
## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary
- Add `Ash.Query.where/2` as a non-macro alternative to `Ash.Query.filter/2`
- Delegates to the existing `do_filter/3` function

Closes #1092