### PR TITLE
test: Add failing test for operator overload bug

### DIFF
--- a/test/query/operator/operator_overloads_test.exs
+++ b/test/query/operator/operator_overloads_test.exs
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Query.Operator.OperatorOverloadsTest do
+  use ExUnit.Case
+
+  alias Ash.Query.Operator
+
+  defmodule TypeWithOverloads do
+    use Ash.Type.NewType, subtype_of: :datetime
+
+    @impl true
+    def operator_overloads do
+      %{
+        :> => %{
+          [__MODULE__, __MODULE__] => Ash.Type.Boolean,
+          [__MODULE__, Ash.Type.UtcDatetime] => {[__MODULE__, __MODULE__], Ash.Type.Boolean}
+        }
+      }
+    end
+  end
+
+  describe "operator_overloads/1" do
+    test "does not crash when the same type appears once in known_types" do
+      original = Application.get_env(:ash, :known_types, [])
+
+      try do
+        Application.put_env(
+          :ash,
+          :known_types,
+          [TypeWithOverloads]
+        )
+
+        # This should not raise a BadMapError
+        result = Operator.operator_overloads(:>)
+        assert is_map(result)
+      after
+        Application.put_env(:ash, :known_types, original)
+      end
+    end
+
+    test "does not crash when the same type appears twice in known_types" do
+      original = Application.get_env(:ash, :known_types, [])
+
+      try do
+        Application.put_env(
+          :ash,
+          :known_types,
+          [TypeWithOverloads, TypeWithOverloads]
+        )
+
+        # This should not raise a BadMapError
+        result = Operator.operator_overloads(:>)
+        assert is_map(result)
+      after
+        Application.put_env(:ash, :known_types, original)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Ash.Query.Operator.operator_overloads/1` crashes with a `BadMapError` when two entries in `config :ash, :known_types` produce overlapping operator overload keys. The simplest trigger is a duplicate entry.

Notice in this PR that the first test passes, but the second fails with the following error message:

```
     ** (BadMapError) expected a map, got: Ash.Type.Boolean
     code: result = Operator.operator_overloads(:>)
     stacktrace:
       (stdlib 7.3) maps.erl:1303: :maps.merge_with(#Function<6.59831434/3 in Ash.Query.Operator.operator_overloads/1>, Ash.Type.Boolean, Ash.Type.Boolean)
       (stdlib 7.3) maps.erl:405: :maps.merge_with_1/3
       (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
       test/query/operator/operator_overloads_test.exs:54: (test)
```

While it may be incorrect to pass duplicate types to `:known_types`, I would at least expect a better error message.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
