### PR TITLE
fix: cast_stored on Keyword type now casts field values through their…

### DIFF
--- a/lib/ash/type/keyword.ex
+++ b/lib/ash/type/keyword.ex
@@ -270,13 +270,20 @@ defmodule Ash.Type.Keyword do
   defp try_map_to_keyword(map, constraints) do
     constraints[:fields]
     |> Kernel.||([])
-    |> Enum.flat_map(fn {key, _} ->
+    |> Enum.flat_map(fn {key, field_constraints} ->
       with :error <- Map.fetch(map, key),
            :error <- Map.fetch(map, to_string(key)) do
         []
       else
         {:ok, value} ->
-          [{key, value}]
+          if type = field_constraints[:type] do
+            case Ash.Type.cast_stored(type, value, field_constraints[:constraints] || []) do
+              {:ok, cast_value} -> [{key, cast_value}]
+              _ -> []
+            end
+          else
+            [{key, value}]
+          end
       end
     end)
   end

--- a/test/type/keyword_test.exs
+++ b/test/type/keyword_test.exs
@@ -471,6 +471,19 @@ defmodule Type.KeywordTest do
     assert length(errors) > 1
   end
 
+  test "cast_stored casts atom field values from stored strings to atoms" do
+    constraints = [
+      fields: [
+        status: [type: :atom]
+      ]
+    ]
+
+    stored = %{"status" => "active"}
+
+    assert {:ok, keyword} = Ash.Type.Keyword.cast_stored(stored, constraints)
+    assert keyword[:status] == :active
+  end
+
   test "dump_to_native converts keyword list to map" do
     keyword_list = [foo: "bar", baz: 42]
     assert Ash.Type.Keyword.dump_to_native(keyword_list, []) == {:ok, %{foo: "bar", baz: 42}}


### PR DESCRIPTION
Previously, `try_map_to_keyword/2` ignored field type constraints when reading values from storage, causing fields like `:atom` to come back as strings instead of being cast to their declared type. Now each field value is passed through `Ash.Type.cast_stored/3` using its configured type, matching the behaviour of the Map type.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [*] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [*] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
