### PR TITLE
fix: do not ignore missing context on `Ash.PlugHelpers.update_context/2`

### DIFF
--- a/lib/ash/plug_helpers.ex
+++ b/lib/ash/plug_helpers.ex
@@ -244,14 +244,9 @@ if Code.ensure_loaded?(Plug.Conn) do
     @spec update_context(Conn.t(), (nil | map() -> nil | map())) ::
             Conn.t()
     def update_context(conn, callback) do
-      case get_context(conn) do
-        nil ->
-          conn
-
-        context ->
-          conn
-          |> set_context(callback.(context))
-      end
+      get_context(conn)
+      |> callback.()
+      |> set_context()
     end
   end
 else


### PR DESCRIPTION
Previously, it was swallowing the case when context was not yet initialized. Currently, it will just call the callback and set the context.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
