### PR TITLE
fix: Policy Authorizer strict checking forbid_unless

### DIFF
--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -1966,7 +1966,7 @@ defmodule Ash.Policy.Authorizer do
                  {check.check_module, check.check_opts}
                ) do
             {:ok, false, updated_auth} ->
-              {:cont, {:forbidden, updated_auth}}
+              {:halt, {:forbidden, updated_auth}}
 
             {:ok, _, updated_auth} ->
               {:cont, {status, updated_auth}}

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -78,6 +78,28 @@ defmodule Ash.Test.Policy.SimpleTest do
     end
   end
 
+  defmodule ResourceWithForbidUnlessAndAuthorizeIf do
+    use Ash.Resource,
+      domain: Ash.Test.Domain,
+      authorizers: [Ash.Policy.Authorizer]
+
+    attributes do
+      uuid_primary_key :id
+    end
+
+    actions do
+      defaults [:create, :read]
+    end
+
+    policies do
+      policy action_type(:read) do
+        access_type :strict
+        forbid_unless actor_attribute_equals(:role, :admin)
+        authorize_if actor_attribute_equals(:has_read_permission, true)
+      end
+    end
+  end
+
   defmodule ResourceWithAnImpossibleCreatePolicy do
     use Ash.Resource,
       domain: Ash.Test.Domain,
@@ -396,6 +418,20 @@ defmodule Ash.Test.Policy.SimpleTest do
     assert message =~ "Actor: %{id: \"#{actor_id}\"}"
     assert message =~ "authorize if: is old enough to drink | age > 21 | ? | 🔎"
     assert message =~ "authorize if: id == \"#{actor_id}\" | ? | 🔎"
+  end
+
+  test "Ash.can? returns false when forbid_unless denies and authorize_if would pass" do
+    # Actor is NOT admin but DOES have read permission.
+    # forbid_unless :role == :admin should deny before authorize_if is considered.
+    actor = %{role: :viewer, has_read_permission: true}
+
+    refute Ash.can?({ResourceWithForbidUnlessAndAuthorizeIf, :read}, actor)
+  end
+
+  test "Ash.can? returns true when both forbid_unless and authorize_if pass" do
+    actor = %{role: :admin, has_read_permission: true}
+
+    assert Ash.can?({ResourceWithForbidUnlessAndAuthorizeIf, :read}, actor)
   end
 
   test "strict read policies do not result in a filter" do


### PR DESCRIPTION
Fixes #2677 

`forbid_unless` checks would not `:halt` in `policy_fails_statically?`, causing a subsequent `authorize_if` to cause the result to be authorized.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
