### PR TITLE
fix: stabilize field order in Ash.Expr.determine_map_type/1

### DIFF
--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -1728,7 +1728,10 @@ defmodule Ash.Expr do
       end)
       |> case do
         {:ok, fields} ->
-          {:ok, {Ash.Type.Map, [fields: Enum.reverse(fields)]}}
+          # Maps aren't ordered — sort by the atom's string name so the
+          # output is stable across compiles for codegen consumers.
+          stable_fields = Enum.sort_by(fields, fn {key, _} -> Atom.to_string(key) end)
+          {:ok, {Ash.Type.Map, [fields: stable_fields]}}
 
         :error ->
           :error

--- a/test/type/auto_type_test.exs
+++ b/test/type/auto_type_test.exs
@@ -212,6 +212,10 @@ defmodule Ash.Test.Type.AutoTypeTest do
       # map literal
       calculate :card, :auto, expr(%{title: title, score: score, active: active}), public?: true
 
+      # map literal with source keys deliberately not in alphabetic order —
+      # used to assert deterministic (alphabetic-by-atom-name) field ordering.
+      calculate :ordered_card, :auto, expr(%{z: title, a: score, m: active}), public?: true
+
       # struct literal (Ash.Type - embedded resource)
       calculate :address_struct_calc,
                 :auto,
@@ -369,6 +373,16 @@ defmodule Ash.Test.Type.AutoTypeTest do
       assert Keyword.get(fields, :title)[:type] == Ash.Type.String
       assert Keyword.get(fields, :score)[:type] == Ash.Type.Integer
       assert Keyword.get(fields, :active)[:type] == Ash.Type.Boolean
+    end
+
+    test "map literal produces deterministic (alphabetic) field order" do
+      # `:ordered_card` has source keys z, a, m — the test guards against
+      # relying on Erlang map iteration order for small flatmaps, which is
+      # driven by internal atom term ordering and varies between BEAM loads.
+      calc = Ash.Resource.Info.calculation(Post, :ordered_card)
+      fields = calc.constraints[:fields]
+
+      assert Keyword.keys(fields) == [:a, :m, :z]
     end
 
     test "Ash.Type struct literal resolves to the type directly" do


### PR DESCRIPTION
## Summary

A literal map expression inside an `:auto`-typed calculation — e.g.
```elixir
calculate :card, :auto, expr(%{title: title, score: score, active: active})
```
currently produces a `{Ash.Type.Map, fields: [...]}` whose field order is **non-deterministic across compiles**.

`Ash.Expr.determine_map_type/1` receives the map and iterates it with `Enum.reduce_while`. For small Erlang flatmaps that dispatches to `:maps.to_list/1`, which walks by internal atom term order — i.e. atom-table index order — which varies between BEAM loads (warm `_build/dev` vs clean `_build/test`). The resulting `fields:` keyword list is stable within a single compile but can reshuffle between compiles.

## Impact

Any consumer that renders ordered output from `calc.constraints[:fields]` sees flaky results. Concrete case: [ash-project/ash_typescript#67](https://github.com/ash-project/ash_typescript/pull/67) — generated TypeScript interfaces whose field order changes between cold and warm builds, polluting snapshot diffs.

## Fix

One line: sort the accumulated fields by `Atom.to_string(key)` before returning. `Atom.to_string/1` is deterministic across BEAM loads (atom names are part of the atom's identity), unlike term ordering. Replaces the `Enum.reverse/1` that was there purely to counter the reduce-into-head pattern — sorting is end-to-end deterministic and doesn't need the reverse.

## Contract

The guarantee is **deterministic**, not **alphabetical**. Consumers must not depend on the specific ordering — only on stability across compiles. Today nothing downstream *can* rely on a specific order (there isn't one), so the behavior change is observable only as "the flaky thing stopped being flaky."

## Test plan

- [x] `mix test test/type/auto_type_test.exs` — 67 tests, 0 failures
- [x] New assertion on `:ordered_card` calc with source keys `z, a, m` expects `[:a, :m, :z]` output
- [x] `mix format --check-formatted` clean