### PR TITLE
docs: correct Ash.Can.can's default for maybe_is

### DIFF
--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -63,7 +63,7 @@ defmodule Ash.Can do
 
   You should prefer to use `Ash.can/3` over this module, directly.
 
-  Note: `is_maybe` is set to `true`, if not set.
+  Note: `maybe_is` is set to `:maybe`, if not set.
   """
   @spec can(subject(), Ash.Domain.t(), Ash.actor() | Ash.Scope.t(), Keyword.t()) ::
           {:ok, boolean() | :maybe}


### PR DESCRIPTION
# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2667.