### PR TITLE
fix: Handle calculations on data layers that disallow filters

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -3886,7 +3886,7 @@ defmodule Ash.Filter do
              {:func, function_module} when not is_nil(function_module) <-
                {:func, get_function(name, context.resource, context.public?)},
              {:ok, function} <- Function.new(function_module, args) do
-          if Ash.Expr.expr?(function) && !match?(%{__predicate__?: _}, function) do
+          if Ash.Expr.expr?(function) and not is_struct(function, function_module) do
             hydrate_refs(function, context)
           else
             if can_filter_expr?(context, function) do

--- a/test/type/auto_type_test.exs
+++ b/test/type/auto_type_test.exs
@@ -686,6 +686,61 @@ defmodule Ash.Test.Type.AutoTypeTest do
     end
   end
 
+  # ── Regression: is_nil with non-ETS data layers ───────────────────────
+  #
+  # is_nil(attr) as a standalone expression in an :auto calculation used to
+  # crash with `key :arguments not found in: is_nil(attr)` because
+  # Function.IsNil.new/1 delegates to Operator.IsNil which produces an
+  # operator struct (left/right) instead of a function struct (arguments).
+  # When the data layer does NOT support {:filter_expr, _}, resolve_call
+  # tried to access .arguments on the operator, causing a KeyError.
+  # ETS masks this because it accepts all filter expressions.
+
+  defmodule MinimalDataLayer do
+    @moduledoc false
+    use Spark.Dsl.Extension, sections: []
+    @behaviour Ash.DataLayer
+
+    @impl true
+    def can?(_, :read), do: true
+    def can?(_, :nested_expressions), do: true
+    def can?(_, {:filter_expr, _}), do: false
+    def can?(_, _), do: false
+
+    @impl true
+    def resource_to_query(resource, _), do: %{resource: resource}
+
+    @impl true
+    def run_query(_, _), do: {:ok, []}
+  end
+
+  describe "is_nil with data layer that does not support filter_expr" do
+    test "auto type resolves to boolean" do
+      defmodule MinimalResource do
+        use Ash.Resource,
+          domain: Ash.Test.Domain,
+          data_layer: MinimalDataLayer
+
+        actions do
+          default_accept :*
+          defaults [:read]
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :score, :integer, public?: true
+        end
+
+        calculations do
+          calculate :is_score_nil, :auto, expr(is_nil(score)), public?: true
+        end
+      end
+
+      assert Ash.Resource.Info.calculation(MinimalResource, :is_score_nil).type ==
+               Ash.Type.Boolean
+    end
+  end
+
   # ── Error tests ───────────────────────────────────────────────────────
 
   describe "errors" do


### PR DESCRIPTION
Previously, adding calculations using `is_nil` on resources in data layers that
didn't support filtering, such as the one in the included test, the following
error was returned (at compile time if using `:auto` as the type, at runtime if
using `:boolean` as the type):

    key :arguments not found in: is_nil(bookedInvoiceId)

Fix: remove the predicate exclusion from the hydrate_refs branch in
resolve_call. do_hydrate_refs already handles predicates correctly.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
