### PR TITLE
feat: add manual keyset pagination delegated to data layer

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -344,6 +344,7 @@ spark_locals_without_parens = [
   validate: 1,
   validate: 2,
   validate_destination_attribute?: 1,
+  via_data_layer?: 1,
   violation_message: 1,
   wait_for: 1,
   wait_for: 2,

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -1700,6 +1700,7 @@ Adds pagination options to a resource
 |------|------|---------|------|
 | [`keyset?`](#actions-read-pagination-keyset?){: #actions-read-pagination-keyset? } | `boolean` | `false` | Whether or not keyset based pagination is supported |
 | [`offset?`](#actions-read-pagination-offset?){: #actions-read-pagination-offset? } | `boolean` | `false` | Whether or not offset based pagination is supported |
+| [`via_data_layer?`](#actions-read-pagination-via_data_layer?){: #actions-read-pagination-via_data_layer? } | `true \| false \| :data_layer_default` | `:data_layer_default` | Whether or not the pagination should be handled by the data layer. Use `:data_layer_default` to let the data layer decide |
 | [`default_limit`](#actions-read-pagination-default_limit){: #actions-read-pagination-default_limit } | `pos_integer` |  | The default page size to apply, if one is not supplied |
 | [`countable`](#actions-read-pagination-countable){: #actions-read-pagination-countable } | `true \| false \| :by_default` | `true` | Whether not a returned page will have a full count of all records. Use `:by_default` to do it automatically. |
 | [`max_page_size`](#actions-read-pagination-max_page_size){: #actions-read-pagination-max_page_size } | `pos_integer` | `250` | The maximum amount of records that can be requested in a single page |

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -2986,7 +2986,13 @@ defmodule Ash.Actions.Read do
         data
       end
 
-    more? = not Enum.empty?(rest)
+    more? =
+      if use_data_layer_keyset?(original_query, action.pagination) do
+        last_record = List.last(data)
+        not is_nil(last_record) && not is_nil(last_record.__metadata__[:keyset])
+      else
+        not Enum.empty?(rest)
+      end
 
     if page_opts[:offset] do
       Ash.Page.Offset.new(data, count, original_query, more?, opts)
@@ -3014,10 +3020,15 @@ defmodule Ash.Actions.Read do
   end
 
   defp add_keysets(original_query, data, sort) do
-    if Enum.any?(
-         Ash.Resource.Info.actions(original_query.resource),
-         &(&1.type == :read && &1.pagination && &1.pagination.keyset?)
-       ) do
+    action =
+      Enum.find(
+        Ash.Resource.Info.actions(original_query.resource),
+        &(&1.type == :read && &1.pagination && &1.pagination.keyset?)
+      )
+
+    pagination = action && action.pagination
+
+    if pagination && !use_data_layer_keyset?(original_query, pagination) do
       Ash.Page.Keyset.data_with_keyset(data, original_query.resource, sort)
     else
       data
@@ -3045,6 +3056,15 @@ defmodule Ash.Actions.Read do
          _missing_pkeys?
        ) do
     data
+  end
+
+  defp use_data_layer_keyset?(query, pagination) do
+    cond do
+      !Ash.DataLayer.data_layer_can?(query.resource, :keyset) -> false
+      pagination.via_data_layer? != :data_layer_default -> pagination.via_data_layer?
+      Ash.Resource.Info.data_layer(query.resource).data_layer_keyset_by_default?() == true -> true
+      true -> false
+    end
   end
 
   defp attach_fields(
@@ -3977,45 +3997,57 @@ defmodule Ash.Actions.Read do
   end
 
   defp keyset_pagination(query, pagination, opts) do
-    limited = Ash.Query.limit(query, limit(query, opts[:limit], query.limit, pagination) + 1)
+    if use_data_layer_keyset?(query, pagination) do
+      limited = Ash.Query.limit(query, limit(query, opts[:limit], query.limit, pagination))
 
-    if opts[:before] || opts[:after] do
-      reversed =
-        if opts[:before] do
-          reversed_sort = Ash.Sort.reverse(limited.sort)
-          max_index = Enum.count(reversed_sort) - 1
+      context = %{
+        data_layer: %{
+          keyset_opts: opts
+        }
+      }
 
-          inverted_sort_input_indices = Enum.map(query.sort_input_indices, &(max_index - &1))
-
-          limited
-          |> Ash.Query.unset(:sort)
-          |> Map.put(:sort, reversed_sort)
-          |> Map.put(:sort_input_indices, inverted_sort_input_indices)
-        else
-          limited
-        end
-
-      after_or_before =
-        if opts[:before] do
-          :before
-        else
-          :after
-        end
-
-      case Ash.Page.Keyset.filter(
-             query,
-             opts[:before] || opts[:after],
-             query.sort,
-             after_or_before
-           ) do
-        {:ok, filter} ->
-          {:ok, Ash.Query.do_filter(reversed, filter)}
-
-        {:error, error} ->
-          {:error, error}
-      end
+      {:ok, Ash.Query.set_context(limited, context)}
     else
-      {:ok, limited}
+      limited = Ash.Query.limit(query, limit(query, opts[:limit], query.limit, pagination) + 1)
+
+      if opts[:before] || opts[:after] do
+        reversed =
+          if opts[:before] do
+            reversed_sort = Ash.Sort.reverse(limited.sort)
+            max_index = Enum.count(reversed_sort) - 1
+
+            inverted_sort_input_indices = Enum.map(query.sort_input_indices, &(max_index - &1))
+
+            limited
+            |> Ash.Query.unset(:sort)
+            |> Map.put(:sort, reversed_sort)
+            |> Map.put(:sort_input_indices, inverted_sort_input_indices)
+          else
+            limited
+          end
+
+        after_or_before =
+          if opts[:before] do
+            :before
+          else
+            :after
+          end
+
+        case Ash.Page.Keyset.filter(
+               query,
+               opts[:before] || opts[:after],
+               query.sort,
+               after_or_before
+             ) do
+          {:ok, filter} ->
+            {:ok, Ash.Query.do_filter(reversed, filter)}
+
+          {:error, error} ->
+            {:error, error}
+        end
+      else
+        {:ok, limited}
+      end
     end
   end
 

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -105,6 +105,7 @@ defmodule Ash.DataLayer do
           | :destroy
           | :limit
           | :offset
+          | :keyset
           | :transact
           | :filter
           | :composite_type
@@ -150,6 +151,7 @@ defmodule Ash.DataLayer do
               offset :: non_neg_integer(),
               resource :: Ash.Resource.t()
             ) :: {:ok, data_layer_query()} | {:error, term}
+  @callback data_layer_keyset_by_default?() :: boolean
   @callback select(
               data_layer_query(),
               select :: list(atom),
@@ -341,6 +343,7 @@ defmodule Ash.DataLayer do
                       select: 3,
                       limit: 3,
                       offset: 3,
+                      data_layer_keyset_by_default?: 0,
                       transaction: 4,
                       rollback: 2,
                       upsert: 3,

--- a/lib/ash/resource/actions/read.ex
+++ b/lib/ash/resource/actions/read.ex
@@ -123,6 +123,12 @@ defmodule Ash.Resource.Actions.Read do
       doc: "Whether or not offset based pagination is supported",
       default: false
     ],
+    via_data_layer?: [
+      type: {:in, [true, false, :data_layer_default]},
+      doc:
+        "Whether or not the pagination should be handled by the data layer. Use `:data_layer_default` to let the data layer decide",
+      default: :data_layer_default
+    ],
     default_limit: [
       type: :pos_integer,
       doc: "The default page size to apply, if one is not supplied"
@@ -169,6 +175,7 @@ defmodule Ash.Resource.Actions.Read do
       paginate_by_default?: false,
       keyset?: false,
       offset?: false,
+      via_data_layer?: false,
       __spark_metadata__: nil
     ]
 

--- a/test/ash/data_layer/keyset_pagination_test.exs
+++ b/test/ash/data_layer/keyset_pagination_test.exs
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Ash.DataLayer.KeysetPaginationTest do
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule KeysetDataLayer do
+    use Spark.Dsl.Extension, sections: []
+    @behaviour Ash.DataLayer
+
+    @impl true
+    def can?(_, :read), do: true
+    def can?(_, :create), do: true
+    def can?(_, :limit), do: true
+    def can?(_, :sort), do: true
+    def can?(_, {:sort, _}), do: true
+    def can?(_, :filter), do: true
+    def can?(_, {:filter_expr, _}), do: true
+    def can?(_, :keyset), do: true
+    def can?(_, _), do: false
+
+    @impl true
+    def data_layer_keyset_by_default?, do: true
+
+    @impl true
+    def resource_to_query(_resource, _domain), do: %{context: %{}}
+
+    @impl true
+    def run_query(query, resource) do
+      cursor = query.context[:data_layer][:keyset_opts][:after]
+      reverse = query.context[:reverse]
+
+      {name, keyset_meta} =
+        cond do
+          cursor == "page1-cursor" -> {"record-1", "page2-cursor"}
+          cursor == "page2-cursor" -> {"record-2", nil}
+          reverse -> {"record-3", "reversed-cursor"}
+          true -> {"record-0", "page1-cursor"}
+        end
+
+      record =
+        Ash.create!(resource, %{name: name})
+        |> Ash.Resource.put_metadata(:keyset, keyset_meta)
+
+      {:ok, [record]}
+    end
+
+    @impl true
+    def create(_resource, changeset) do
+      Ash.Changeset.apply_attributes(changeset)
+    end
+
+    @impl true
+    def set_context(_resource, query, context) do
+      {:ok, Map.put(query, :context, Map.merge(query.context || %{}, context))}
+    end
+
+    @impl true
+    def limit(query, limit, _resource), do: {:ok, Map.put(query, :limit, limit)}
+    @impl true
+    def sort(query, sort, _resource), do: {:ok, Map.put(query, :sort, sort)}
+    @impl true
+    def filter(query, filter, _resource), do: {:ok, Map.put(query, :filter, filter)}
+  end
+
+  defmodule NoKeysetDataLayer do
+    use Spark.Dsl.Extension, sections: []
+    @behaviour Ash.DataLayer
+
+    @impl true
+    def can?(_, :create), do: true
+    def can?(_, :read), do: true
+    def can?(_, :limit), do: true
+    def can?(_, :sort), do: true
+    def can?(_, {:sort, _}), do: true
+    def can?(_, :filter), do: true
+    def can?(_, {:filter_expr, _}), do: true
+    def can?(_, :keyset), do: false
+    def can?(_, _), do: false
+
+    @impl true
+    def data_layer_keyset_by_default?, do: false
+
+    @impl true
+    def resource_to_query(_resource, _domain), do: %{context: %{}}
+
+    @impl true
+    def run_query(_query, resource) do
+      {:ok, [Ash.create!(resource, %{name: "record-0"})]}
+    end
+
+    @impl true
+    def create(_resource, changeset) do
+      Ash.Changeset.apply_attributes(changeset)
+    end
+
+    @impl true
+    def set_context(_resource, query, context) do
+      {:ok, Map.put(query, :context, Map.merge(query.context || %{}, context))}
+    end
+
+    @impl true
+    def limit(query, limit, _resource), do: {:ok, Map.put(query, :limit, limit)}
+    @impl true
+    def sort(query, sort, _resource), do: {:ok, Map.put(query, :sort, sort)}
+    @impl true
+    def filter(query, filter, _resource), do: {:ok, Map.put(query, :filter, filter)}
+  end
+
+  defmodule ExplicitKeysetDataLayer do
+    use Spark.Dsl.Extension, sections: []
+    @behaviour Ash.DataLayer
+
+    @impl true
+    def can?(_, :read), do: true
+    def can?(_, :create), do: true
+    def can?(_, :limit), do: true
+    def can?(_, :sort), do: true
+    def can?(_, {:sort, _}), do: true
+    def can?(_, :filter), do: true
+    def can?(_, {:filter_expr, _}), do: true
+    def can?(_, :keyset), do: true
+    def can?(_, _), do: false
+
+    @impl true
+    def data_layer_keyset_by_default?, do: false
+
+    @impl true
+    def resource_to_query(_resource, _domain), do: %{context: %{}}
+
+    @impl true
+    def run_query(_query, resource) do
+      {:ok,
+       [
+         Ash.create!(resource, %{name: "record-from-dl"})
+         |> Ash.Resource.put_metadata(:keyset, "some-cursor")
+       ]}
+    end
+
+    @impl true
+    def create(_resource, changeset) do
+      Ash.Changeset.apply_attributes(changeset)
+    end
+
+    @impl true
+    def set_context(_resource, query, context) do
+      {:ok, Map.put(query, :context, Map.merge(query.context || %{}, context))}
+    end
+
+    @impl true
+    def limit(query, limit, _resource), do: {:ok, Map.put(query, :limit, limit)}
+    @impl true
+    def sort(query, sort, _resource), do: {:ok, Map.put(query, :sort, sort)}
+    @impl true
+    def filter(query, filter, _resource), do: {:ok, Map.put(query, :filter, filter)}
+  end
+
+  defmodule KeysetResource do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.Test.Ash.DataLayer.KeysetPaginationTest.KeysetDataLayer
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+    end
+
+    actions do
+      defaults create: :*
+
+      read :read do
+        pagination keyset?: true, via_data_layer?: :data_layer_default
+      end
+    end
+  end
+
+  defmodule ExplicitKeysetResource do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.Test.Ash.DataLayer.KeysetPaginationTest.ExplicitKeysetDataLayer
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+    end
+
+    actions do
+      defaults create: :*
+
+      read :read do
+        pagination keyset?: true, via_data_layer?: true
+      end
+    end
+  end
+
+  defmodule NoKeysetResource do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.Test.Ash.DataLayer.KeysetPaginationTest.NoKeysetDataLayer
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+    end
+
+    actions do
+      defaults create: :*
+
+      read :read do
+        pagination keyset?: true, via_data_layer?: false
+      end
+    end
+  end
+
+  describe "use_data_layer_keyset? logic" do
+    test "data layer declares :keyset capability and via_data_layer?: :data_layer_default => uses data layer" do
+      assert Ash.DataLayer.data_layer_can?(KeysetResource, :keyset)
+    end
+
+    test "data layer declares :keyset as false => falls back to Ash keyset pagination" do
+      refute Ash.DataLayer.data_layer_can?(NoKeysetResource, :keyset)
+      refute Ash.Resource.Info.data_layer(NoKeysetResource).data_layer_keyset_by_default?()
+    end
+  end
+
+  describe "keyset pagination via data layer (data_layer_keyset_by_default? true)" do
+    test "does not add +1 to limit" do
+      page =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.sort(name: :asc)
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      assert length(page.results) == 1
+    end
+
+    test "more? is true when the last record has non-nil keyset metadata" do
+      page =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      assert page.more?
+      assert hd(page.results).__metadata__[:keyset] == "page1-cursor"
+    end
+
+    test "more? is false when the last record has nil keyset metadata" do
+      page =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(after: "page2-cursor", limit: 1)
+        |> Ash.read!()
+
+      refute page.more?
+      assert hd(page.results).__metadata__[:keyset] == nil
+    end
+
+    test "page forwards correctly using data layer cursor" do
+      page1 =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      assert hd(page1.results).name == "record-0"
+      assert hd(page1.results).__metadata__[:keyset] == "page1-cursor"
+
+      page2 =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(after: hd(page1.results).__metadata__[:keyset], limit: 1)
+        |> Ash.read!()
+
+      assert hd(page2.results).name == "record-1"
+      assert page2.more?
+    end
+
+    test "keyset metadata is set by data layer, not overwritten by Ash" do
+      page =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      refute is_nil(hd(page.results).__metadata__[:keyset])
+      assert hd(page.results).__metadata__[:keyset] == "page1-cursor"
+    end
+
+    test "custom context is passed through to data layer" do
+      page =
+        KeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.set_context(%{reverse: true})
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      assert hd(page.results).name == "record-3"
+      assert hd(page.results).__metadata__[:keyset] == "reversed-cursor"
+    end
+  end
+
+  describe "keyset pagination via data layer (explicit via_data_layer?: true)" do
+    test "respects via_data_layer?: true even when data_layer_keyset_by_default? returns false" do
+      page =
+        ExplicitKeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      assert hd(page.results).name == "record-from-dl"
+      assert hd(page.results).__metadata__[:keyset] == "some-cursor"
+    end
+  end
+
+  describe "keyset pagination not via data layer (via_data_layer?: false)" do
+    test "falls back to Ash managed keyset pagination" do
+      data_layer = Ash.Resource.Info.data_layer(NoKeysetResource)
+      refute data_layer.can?(NoKeysetResource, :keyset)
+    end
+
+    test "data layer does not need to implement cursor logic" do
+      page =
+        NoKeysetResource
+        |> Ash.Query.new()
+        |> Ash.Query.for_read(:read)
+        |> Ash.Query.page(limit: 1)
+        |> Ash.read!()
+
+      assert length(page.results) == 1
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

## Summary
- Add new `can?` feature to data layer (`:keyset`), which is checked to decide which layer will handle keyset pagination
- Add conditions to avoid keyset pagination in the Ash core layer in case the data layer is handling it
- Change `more?` logic to rely on keyset passed by data layer if delegated
- Pass page options directly to data layer through context if delegated

Closes #2684