### PR TITLE
chore: Include documentation as part of the published package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -358,7 +358,7 @@ defmodule Ash.MixProject do
       ],
       licenses: ["MIT"],
       files: ~w(lib priv .formatter.exs mix.exs README* LICENSE*
-      CHANGELOG* usage-rules.md usage-rules),
+      CHANGELOG* usage-rules.md usage-rules documentation .github/CONTRIBUTING.md),
       links: %{
         "GitHub" => "https://github.com/ash-project/ash",
         "Changelog" => "https://github.com/ash-project/ash/blob/main/CHANGELOG.md",


### PR DESCRIPTION
This will allow the links in the README to work when viewed on hex.pm

Currently the README links here https://hex.pm/packages/ash don't work, because those documentation files aren't part of the published package. This should fix it!

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
