### PR TITLE
fix: preserve all errors in Required dedupe accumulator

### DIFF
--- a/lib/ash/error/error.ex
+++ b/lib/ash/error/error.ex
@@ -157,7 +157,7 @@ defmodule Ash.Error do
            end) do
           errors
         else
-          [Enum.max_by(required_errors, &Enum.count(&1.bread_crumbs))]
+          [Enum.max_by(required_errors, &Enum.count(&1.bread_crumbs)) | errors]
         end
       end)
 

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -229,6 +229,100 @@ defmodule Ash.Test.ErrorTest do
       assert cs_child_error_1.bread_crumbs == ["some higher context", "some context"]
       assert cs_child_error_2.bread_crumbs == ["some higher context", "some other context"]
     end
+
+    # Regression test for `remove_required_if_other_errors_exist/1`. The dedupe
+    # is meant to keep one Required error per `{field, path}` group when a
+    # group has duplicates, but instead only returned the last error.
+    test "keeps one Required error per field when every Required error is duplicated" do
+      errors = [
+        %Ash.Error.Changes.Required{
+          field: :a,
+          type: :attribute,
+          resource: TestResource,
+          path: []
+        },
+        %Ash.Error.Changes.Required{
+          field: :b,
+          type: :attribute,
+          resource: TestResource,
+          path: []
+        },
+        %Ash.Error.Changes.Required{
+          field: :a,
+          type: :attribute,
+          resource: TestResource,
+          path: [],
+          bread_crumbs: ["dup"]
+        },
+        %Ash.Error.Changes.Required{
+          field: :b,
+          type: :attribute,
+          resource: TestResource,
+          path: [],
+          bread_crumbs: ["dup"]
+        }
+      ]
+
+      class = Ash.Error.to_error_class(errors)
+      fields = class.errors |> Enum.map(& &1.field) |> Enum.sort()
+
+      assert fields == [:a, :b]
+    end
+
+    # Same accumulator-replacement bug, broader consequence. The reduce seeds
+    # its accumulator with the non-Required errors, so replacing it on each
+    # iteration also dropped them.
+    test "preserves non-Required errors alongside duplicated Required errors" do
+      errors = [
+        %Ash.Error.Changes.Required{
+          field: :a,
+          type: :attribute,
+          resource: TestResource,
+          path: []
+        },
+        %Ash.Error.Changes.Required{
+          field: :b,
+          type: :attribute,
+          resource: TestResource,
+          path: []
+        },
+        %Ash.Error.Changes.Required{
+          field: :a,
+          type: :attribute,
+          resource: TestResource,
+          path: [],
+          bread_crumbs: ["dup"]
+        },
+        %Ash.Error.Changes.Required{
+          field: :b,
+          type: :attribute,
+          resource: TestResource,
+          path: [],
+          bread_crumbs: ["dup"]
+        },
+        Ash.Error.Changes.InvalidAttribute.exception(
+          field: :c,
+          message: "must have length of exactly %{exact}",
+          private_vars: [exact: 5]
+        )
+      ]
+
+      class = Ash.Error.to_error_class(errors)
+
+      required_fields =
+        class.errors
+        |> Enum.filter(&match?(%Ash.Error.Changes.Required{}, &1))
+        |> Enum.map(& &1.field)
+        |> Enum.sort()
+
+      invalid_attribute_fields =
+        class.errors
+        |> Enum.filter(&match?(%Ash.Error.Changes.InvalidAttribute{}, &1))
+        |> Enum.map(& &1.field)
+
+      assert required_fields == [:a, :b]
+      assert invalid_attribute_fields == [:c]
+    end
   end
 
   describe "to_ash_error" do


### PR DESCRIPTION
`remove_required_if_other_errors_exist/1` is meant to keep one Required error per `{field, path}` group when duplicates exist. Instead, its `Enum.reduce` `else` branch replaced the entire accumulator each iteration.

With N duplicated groups, only the last group's representative survived; non-Required errors seeded into the accumulator were dropped too.

## How this surfaced

When building an AshPhoenix form that has an embedded resource (eg. `ServiceLocation` has an `Address` attribute), I was only seeing a single validation error for the last invalid attribute of the embedded address. eg. the address was missing a required `line1`, `state` AND `zip_code` but I was only seeing the validation error about the missing zip code.

And if there were other validations (eg. validating the zip code format), those errors were never surfaced while there was a Required validation reported (the second test).

With Claude's assistance I narrowed the issue down to this fix.

## If its from AshPhoenix, why not fix it there?

The main reason this code path gets triggered is because AshPhoenix validates the embedded attribute twice - once as part of the parent form, and once as part of building a new nested form for the attribute. But it can also be triggered in different ways - we saw the same issue last week with an action that used `manage_relationship` with `on_no_match: {:create, :custom_create_action}`.

Plus it just seems like a fairly obvious bug in the function - `Enum.reduce` replacing instead of appending to the accumulator.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ashproject/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
