### PR TITLE
improvement: generate `@type t` typespec for `TypedStruct` modules

### DIFF
--- a/lib/ash/typed_struct.ex
+++ b/lib/ash/typed_struct.ex
@@ -193,13 +193,16 @@ defmodule Ash.TypedStruct do
             instance_of: module
           ]
 
+        typespec_ast = Ash.TypedStruct.build_typespec_ast(fields)
+
         # sobelow_skip ["RCE.CodeModule"]
         Code.eval_quoted(
           Ash.TypedStruct.__define_typed_struct__(
             enforce_keys,
             fields_with_defaults,
             map_constraints,
-            defaults
+            defaults,
+            typespec_ast
             # map_required_fields_match
           ),
           [],
@@ -217,7 +220,8 @@ defmodule Ash.TypedStruct do
         enforce_keys,
         fields_with_defaults,
         map_constraints,
-        defaults
+        defaults,
+        typespec_ast
         # map_required_fields_match
       ) do
     keyed_defaults =
@@ -226,6 +230,10 @@ defmodule Ash.TypedStruct do
       end)
 
     quote do
+      if !Kernel.Typespec.defines_type?(__MODULE__, {:t, 0}) do
+        @type t :: unquote(typespec_ast)
+      end
+
       @enforce_keys unquote(enforce_keys)
       defstruct unquote(Macro.escape(fields_with_defaults))
 
@@ -326,6 +334,87 @@ defmodule Ash.TypedStruct do
 
       defoverridable new: 1
     end
+  end
+
+  @doc false
+  def build_typespec_ast(fields) do
+    field_types =
+      Enum.map(fields, fn field ->
+        base_type = ash_type_to_typespec(field.type)
+
+        type_ast =
+          if field.allow_nil? != false do
+            {:|, [], [base_type, nil]}
+          else
+            base_type
+          end
+
+        {field.name, type_ast}
+      end)
+
+    {:%, [],
+     [
+       {:__MODULE__, [], Elixir},
+       {:%{}, [], field_types}
+     ]}
+  end
+
+  @primitive_typespecs %{
+    Ash.Type.Integer => :integer,
+    Ash.Type.Float => :float,
+    Ash.Type.Boolean => :boolean,
+    Ash.Type.Atom => :atom,
+    Ash.Type.Map => :map,
+    Ash.Type.Binary => :binary,
+    Ash.Type.Term => :term,
+    Ash.Type.Keyword => :keyword,
+    Ash.Type.Tuple => :tuple,
+    Ash.Type.Module => :module,
+    Ash.Type.UrlEncodedBinary => :binary,
+    Ash.Type.Struct => :struct,
+    Ash.Type.Union => :term,
+    Ash.Type.Function => :term,
+    Ash.Type.DurationName => :atom
+  }
+
+  @remote_typespecs %{
+    Ash.Type.String => [:String],
+    Ash.Type.UUID => [:String],
+    Ash.Type.UUIDv7 => [:String],
+    Ash.Type.Decimal => [:Decimal],
+    Ash.Type.Date => [:Date],
+    Ash.Type.Time => [:Time],
+    Ash.Type.TimeUsec => [:Time],
+    Ash.Type.NaiveDatetime => [:NaiveDateTime],
+    Ash.Type.UtcDatetime => [:DateTime],
+    Ash.Type.UtcDatetimeUsec => [:DateTime],
+    Ash.Type.DateTime => [:DateTime],
+    Ash.Type.Duration => [:Duration],
+    Ash.Type.CiString => [:Ash, :CiString],
+    Ash.Type.Vector => [:Ash, :Vector],
+    Ash.Type.File => [:Ash, :Type, :File]
+  }
+
+  @doc false
+  def ash_type_to_typespec({:array, inner_type}) do
+    [ash_type_to_typespec(inner_type)]
+  end
+
+  for {type, primitive} <- @primitive_typespecs do
+    def ash_type_to_typespec(unquote(type)), do: {unquote(primitive), [], Elixir}
+  end
+
+  for {type, module_parts} <- @remote_typespecs do
+    def ash_type_to_typespec(unquote(type)), do: remote_type(unquote(module_parts), :t)
+  end
+
+  def ash_type_to_typespec(module) when is_atom(module) do
+    parts = module |> Module.split() |> Enum.map(&String.to_atom/1)
+    remote_type(parts, :t)
+  end
+
+  defp remote_type(module_parts, func_name) do
+    {{:., [], [{:__aliases__, [alias: false], module_parts}, func_name]}, [], []}
   end
 
   use Spark.Dsl, default_extensions: [extensions: [Dsl]]

--- a/test/typed_struct_test.exs
+++ b/test/typed_struct_test.exs
@@ -390,6 +390,90 @@ defmodule Ash.TypedStructTest do
     end
   end
 
+  describe "typespec generation" do
+    test "ash_type_to_typespec maps built-in types correctly" do
+      # Primitives
+      assert {:integer, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Integer)
+      assert {:float, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Float)
+      assert {:boolean, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Boolean)
+      assert {:atom, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Atom)
+      assert {:map, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Map)
+      assert {:binary, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Binary)
+      assert {:term, [], Elixir} = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Term)
+
+      # String-like
+      string_t = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.String)
+      assert Macro.to_string(string_t) == "String.t()"
+
+      uuid_t = Ash.TypedStruct.ash_type_to_typespec(Ash.Type.UUID)
+      assert Macro.to_string(uuid_t) == "String.t()"
+
+      # Date/time
+      assert Macro.to_string(Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Date)) == "Date.t()"
+
+      assert Macro.to_string(Ash.TypedStruct.ash_type_to_typespec(Ash.Type.UtcDatetime)) ==
+               "DateTime.t()"
+
+      assert Macro.to_string(Ash.TypedStruct.ash_type_to_typespec(Ash.Type.Decimal)) ==
+               "Decimal.t()"
+    end
+
+    test "ash_type_to_typespec handles arrays" do
+      array_spec = Ash.TypedStruct.ash_type_to_typespec({:array, Ash.Type.String})
+      assert Macro.to_string(array_spec) == "[String.t()]"
+
+      nested = Ash.TypedStruct.ash_type_to_typespec({:array, {:array, Ash.Type.Integer}})
+      assert Macro.to_string(nested) =~ "integer"
+    end
+
+    test "ash_type_to_typespec falls back to Module.t() for unknown types" do
+      spec = Ash.TypedStruct.ash_type_to_typespec(MyApp.CustomType)
+      assert Macro.to_string(spec) == "MyApp.CustomType.t()"
+    end
+
+    test "build_typespec_ast generates correct struct typespec" do
+      fields = [
+        %Ash.TypedStruct.Field{
+          name: :name,
+          type: Ash.Type.String,
+          allow_nil?: true,
+          constraints: [],
+          default: nil
+        },
+        %Ash.TypedStruct.Field{
+          name: :age,
+          type: Ash.Type.Integer,
+          allow_nil?: false,
+          constraints: [],
+          default: nil
+        }
+      ]
+
+      ast = Ash.TypedStruct.build_typespec_ast(fields)
+      type_string = Macro.to_string(quote(do: @type(t :: unquote(ast))))
+
+      assert type_string =~ "name: String.t() | nil"
+      assert type_string =~ "age: integer"
+      refute type_string =~ "age: integer | nil"
+    end
+
+    test "user-defined @type t is not overridden" do
+      # This compiles without error, proving the guard works —
+      # without it, defining @type t twice would raise Kernel.TypespecError
+      id = System.unique_integer([:positive])
+
+      Code.compile_string("""
+      defmodule CustomTsGuardTest#{id} do
+        @type t :: %__MODULE__{name: binary()}
+        use Ash.TypedStruct
+        typed_struct do
+          field :name, :string
+        end
+      end
+      """)
+    end
+  end
+
   describe "typed struct introspection" do
     test "field names can be introspected in order" do
       assert Ash.TypedStruct.Info.field_names(UserStruct) == [:id, :name, :email, :age, :active]


### PR DESCRIPTION
Previously, a `TypedStruct` didn't actually specify any _types_. This PR adds a `@spec` definition for typed structs, while still respecting userdefined specs.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
