### PR TITLE
Fix/code interface validation hint

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -1631,7 +1631,7 @@ defmodule Ash.CodeInterface do
          error.key != nil do
       inputs = Ash.Resource.Info.action_inputs(resource, action_name)
 
-      if MapSet.size(inputs) > 0 && MapSet.member?(inputs, error.key) do
+      if MapSet.member?(inputs, error.key) do
         example_args =
           if action_type in [:update, :destroy] && require_reference? do
             "record, %{#{inspect(error.key)} => value}, []"

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -649,6 +649,9 @@ defmodule Ash.CodeInterface do
 
         resolve_params_and_opts =
           quote do
+            # Used in opts validation error hints so messages name the exact code interface function.
+            {function_name, function_arity} = __ENV__.function
+
             {params, opts, arg_params, filter_params, custom_input_errors} =
               Ash.CodeInterface.resolve_params_and_opts(
                 params_or_opts,
@@ -659,7 +662,12 @@ defmodule Ash.CodeInterface do
                 unquote(interface.exclude_inputs || []),
                 unquote(resource),
                 unquote(interface.name),
-                unquote(Enum.count(interface.args || []) + 2),
+                unquote(action.name),
+                unquote(action.type),
+                unquote(interface.require_reference?),
+                __MODULE__,
+                function_name,
+                function_arity,
                 unquote(custom_inputs),
                 unquote(filter_params)
               )
@@ -1599,6 +1607,58 @@ defmodule Ash.CodeInterface do
     end
   end
 
+  # Hint when attributes are passed as opts (e.g. `insert(first_name: "x")` vs a params map).
+  # Spark uses the same ValidationError and `:key` for every opts failure; only the
+  # "unknown options" message prefix isolates this case (no separate reason field on the struct).
+  defp code_interface_unknown_options_error?(%Spark.Options.ValidationError{message: message})
+       when is_binary(message) do
+    String.starts_with?(message, "unknown options")
+  end
+
+  defp code_interface_unknown_options_error?(_), do: false
+
+  defp enhance_code_interface_opts_validation_error(
+         %Spark.Options.ValidationError{} = error,
+         resource,
+         action_name,
+         action_type,
+         require_reference?,
+         interface_module,
+         function_name,
+         arity
+       ) do
+    if code_interface_unknown_options_error?(error) && is_atom(error.key) &&
+         error.key != nil do
+      inputs = Ash.Resource.Info.action_inputs(resource, action_name)
+
+      if MapSet.size(inputs) > 0 && MapSet.member?(inputs, error.key) do
+        example_args =
+          if action_type in [:update, :destroy] && require_reference? do
+            "record, %{#{inspect(error.key)} => value}, []"
+          else
+            "%{#{inspect(error.key)} => value}, []"
+          end
+
+        hint = """
+
+        Hint: `#{inspect(error.key)}` is an input for the #{inspect(action_name)} action on #{inspect(resource)}, but it was given as an option to `#{inspect(interface_module)}.#{function_name}/#{arity}`.
+
+        Pass inputs as a map in the params argument, for example:
+
+            #{inspect(interface_module)}.#{function_name}(#{example_args})
+
+        Put framework options (`:actor`, `:tenant`, `:authorize?`, etc.) in the second argument.
+        """
+
+        %Spark.Options.ValidationError{error | message: error.message <> hint}
+      else
+        error
+      end
+    else
+      error
+    end
+  end
+
   def resolve_params_and_opts(
         params_or_opts,
         opts,
@@ -1608,6 +1668,11 @@ defmodule Ash.CodeInterface do
         exclude_inputs,
         resource,
         interface_name,
+        action_name,
+        action_type,
+        require_reference?,
+        interface_module,
+        function_name,
         arity,
         custom_inputs,
         filter_params
@@ -1623,10 +1688,28 @@ defmodule Ash.CodeInterface do
               static_options -> static_options
             end
 
-          opts
-          |> Ash.CodeInterface.merge_default_opts(default_options)
-          |> interface_options.validate!()
-          |> interface_options.to_options()
+          # Enrich only unknown-options + known input keys; see `enhance_code_interface_opts_validation_error/8`.
+          try do
+            opts
+            |> Ash.CodeInterface.merge_default_opts(default_options)
+            |> interface_options.validate!()
+            |> interface_options.to_options()
+          rescue
+            error in [Spark.Options.ValidationError] ->
+              error =
+                enhance_code_interface_opts_validation_error(
+                  error,
+                  resource,
+                  action_name,
+                  action_type,
+                  require_reference?,
+                  interface_module,
+                  function_name,
+                  arity
+                )
+
+              reraise error, __STACKTRACE__
+          end
         end
       )
 

--- a/test/code_interface_test.exs
+++ b/test/code_interface_test.exs
@@ -494,6 +494,47 @@ defmodule Ash.Test.CodeInterfaceTest do
 
       assert %Ash.BulkResult{status: :success} = User.bulk_create!([], [])
     end
+
+    test "create code interface adds a hint when params are passed as a lone keyword list" do
+      error =
+        assert_raise Spark.Options.ValidationError, fn ->
+          User.insert(first_name: "fred")
+        end
+
+      message = Exception.message(error)
+      assert message =~ "unknown options"
+      assert message =~ "`:first_name` is an input"
+      assert message =~ "Ash.Test.CodeInterfaceTest.User.insert/2"
+      assert message =~ "Ash.Test.CodeInterfaceTest.User.insert(%{:first_name => value}, [])"
+      assert message =~ "Pass inputs as a map in the params argument"
+      assert message =~ "Hint:"
+    end
+
+    test "bang create code interface hint uses the bang function name" do
+      error =
+        assert_raise Spark.Options.ValidationError, fn ->
+          User.insert!(first_name: "fred")
+        end
+
+      message = Exception.message(error)
+      assert message =~ "unknown options"
+      assert message =~ "`:first_name` is an input"
+      assert message =~ "Ash.Test.CodeInterfaceTest.User.insert!/2"
+      assert message =~ "Ash.Test.CodeInterfaceTest.User.insert!(%{:first_name => value}, [])"
+      assert message =~ "Hint:"
+    end
+
+    test "create code interface does not add a hint for non-input unknown options" do
+      error =
+        assert_raise Spark.Options.ValidationError, fn ->
+          User.insert(not_an_input: true)
+        end
+
+      message = Exception.message(error)
+      assert message =~ "unknown options"
+      refute message =~ "Hint:"
+      refute message =~ "Pass inputs as a map in the params argument"
+    end
   end
 
   describe "update actions" do
@@ -514,6 +555,25 @@ defmodule Ash.Test.CodeInterfaceTest do
 
       assert {:ok, _record} = User.update(bob, %{first_name: "bob_updated"}, context: @context)
       assert _record = User.update!(bob, %{first_name: "bob_updated"}, context: @context)
+    end
+
+    test "update code interface hint includes the record argument" do
+      bob = User.create!("bob", context: @context)
+
+      error =
+        assert_raise Spark.Options.ValidationError, fn ->
+          User.update(bob, first_name: "fred")
+        end
+
+      message = Exception.message(error)
+      assert message =~ "unknown options"
+      assert message =~ "`:first_name` is an input"
+      assert message =~ "Ash.Test.CodeInterfaceTest.User.update/3"
+
+      assert message =~
+               "Ash.Test.CodeInterfaceTest.User.update(record, %{:first_name => value}, [])"
+
+      assert message =~ "Hint:"
     end
 
     test "can take a query" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Resolves https://github.com/ash-project/ash/issues/992

Improves code interface validation errors when action params are accidentally passed as a keyword list instead of a params map.

Example of the incorrect call shape:
```elixir
MyApi.create_user(first_name: "Fred")
```
instead of:
```elixir
MyApi.create_user(%{first_name: "Fred"})
```
Previously, Ash raised an unknown options error for :first_name even when it was a valid action input. This PR adds a targeted hint explaining the likely mistake and shows the expected call shape.

## Behavior

When unknown options are detected, Ash now checks whether those keys are valid action inputs.

If they are, the validation error includes a helpful hint with the proper function usage. Non-input unknown options continue behaving exactly as before.

## Tests

Added regression coverage for:

- create interfaces with keyword-list params
- bang interfaces showing the correct function name
- unknown non-input options not receiving hints
- update interfaces showing the record argument in examples
