### PR TITLE
fix: add query context to bulk destroy

### DIFF
--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -92,9 +92,11 @@ defmodule Ash.Actions.Destroy.Bulk do
                                     action: action_name
                                   }
                                 end do
-        opts = set_strategy(opts, query.resource)
-
-        opts = select(opts, query.resource)
+        opts =
+          opts
+          |> set_strategy(query.resource)
+          |> select(query.resource)
+          |> Keyword.put(:context, query.context)
 
         opts =
           if opts[:return_notifications?] do


### PR DESCRIPTION
# Description

This solves an issue with updates of polymorphic `has_many` and `many_to_many` relationships, they were missing the `data_layer.table` and therefore failed to be persisted.

See this PR for a reproduction scenario https://github.com/ash-project/ash_postgres/pull/753

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
