### PR TITLE
Fix type casting

### DIFF
--- a/lib/ash/embeddable_type.ex
+++ b/lib/ash/embeddable_type.ex
@@ -426,11 +426,21 @@ defmodule Ash.EmbeddableType do
       def cast_input_array(_, _), do: :error
 
       def cast_stored(value, constraints) when is_map(value) do
+        cast_from_embedded(value, constraints)
+      end
+
+      def cast_stored(nil, _), do: {:ok, nil}
+
+      def cast_stored(_other, _) do
+        :error
+      end
+
+      def cast_from_embedded(value, constraints) when is_map(value) do
         __MODULE__
         |> Ash.Resource.Info.attributes()
         |> Enum.reduce_while({:ok, struct(__MODULE__)}, fn attr, {:ok, struct} ->
           with {:fetch, {:ok, value}} <- {:fetch, fetch_key(value, attr.source)},
-               {:ok, casted} <- Ash.Type.cast_stored(attr.type, value, attr.constraints) do
+               {:ok, casted} <- Ash.Type.cast_from_embedded(attr.type, value, attr.constraints) do
             {:cont, {:ok, Map.put(struct, attr.name, casted)}}
           else
             {:fetch, :error} ->
@@ -470,9 +480,9 @@ defmodule Ash.EmbeddableType do
         end
       end
 
-      def cast_stored(nil, _), do: {:ok, nil}
+      def cast_from_embedded(nil, _), do: {:ok, nil}
 
-      def cast_stored(_other, _) do
+      def cast_from_embedded(_other, _) do
         :error
       end
 

--- a/lib/ash/type/binary.ex
+++ b/lib/ash/type/binary.ex
@@ -47,4 +47,21 @@ defmodule Ash.Type.Binary do
   def dump_to_native(value, _) do
     Ecto.Type.dump(:binary, value)
   end
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(value, _) when is_binary(value) do
+    {:ok, Base.encode64(value)}
+  end
+
+  @impl true
+  def cast_from_embedded(nil, _), do: {:ok, nil}
+
+  def cast_from_embedded(value, _) when is_binary(value) do
+    case Base.decode64(value) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:ok, value}
+    end
+  end
 end

--- a/lib/ash/type/keyword.ex
+++ b/lib/ash/type/keyword.ex
@@ -151,18 +151,52 @@ defmodule Ash.Type.Keyword do
   @impl true
   def cast_stored(nil, _), do: {:ok, nil}
 
-  def cast_stored(value, constraints) when is_map(value),
-    do: {:ok, try_map_to_keyword(value, constraints)}
+  def cast_stored(value, constraints) when is_map(value) do
+    if fields = constraints[:fields] do
+      fields
+      |> Enum.reduce_while({:ok, []}, fn {key, config}, {:ok, acc} ->
+        case cast_stored_field(value, key, config) do
+          {:ok, value} -> {:cont, {:ok, [{key, value} | acc]}}
+          :skip -> {:cont, {:ok, acc}}
+          other -> {:halt, other}
+        end
+      end)
+      |> case do
+        {:ok, keyword} -> {:ok, Enum.reverse(keyword)}
+        other -> other
+      end
+    else
+      {:ok, try_map_to_keyword(value, constraints)}
+    end
+  end
 
   def cast_stored(_, _), do: :error
 
   @impl true
   def dump_to_native(nil, _), do: {:ok, nil}
-  def dump_to_native(value, _) when is_map(value), do: {:ok, value}
 
-  def dump_to_native(value, _) do
+  def dump_to_native(value, constraints) when is_map(value) do
+    dump_fields(value, constraints, &Ash.Type.dump_to_native/3)
+  end
+
+  def dump_to_native(value, constraints) do
     if Keyword.keyword?(value) do
-      {:ok, Map.new(value)}
+      dump_fields(value, constraints, &Ash.Type.dump_to_native/3)
+    else
+      :error
+    end
+  end
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(value, constraints) when is_map(value) do
+    dump_fields(value, constraints, &Ash.Type.dump_to_embedded/3)
+  end
+
+  def dump_to_embedded(value, constraints) do
+    if Keyword.keyword?(value) do
+      dump_fields(value, constraints, &Ash.Type.dump_to_embedded/3)
     else
       :error
     end
@@ -266,6 +300,46 @@ defmodule Ash.Type.Keyword do
   end
 
   defp fetch_field(_, _), do: :error
+
+  defp cast_stored_field(map, key, config) do
+    case fetch_map_field(map, key) do
+      {:ok, value} -> Ash.Type.cast_stored(config[:type], value, config[:constraints] || [])
+      :error -> :skip
+    end
+  end
+
+  defp dump_fields(value, constraints, dump_fn) do
+    if fields = constraints[:fields] do
+      Enum.reduce_while(fields, {:ok, %{}}, fn {key, config}, {:ok, acc} ->
+        case dump_field(value, key, config, dump_fn) do
+          {:ok, dumped} -> {:cont, {:ok, Map.put(acc, key, dumped)}}
+          :skip -> {:cont, {:ok, acc}}
+          other -> {:halt, other}
+        end
+      end)
+    else
+      {:ok, if(is_map(value), do: value, else: Map.new(value))}
+    end
+  end
+
+  defp dump_field(value, key, config, dump_fn) do
+    fetched =
+      if is_map(value),
+        do: fetch_map_field(value, key),
+        else: Keyword.fetch(value, key)
+
+    case fetched do
+      {:ok, field_value} -> dump_fn.(config[:type], field_value, config[:constraints] || [])
+      :error -> :skip
+    end
+  end
+
+  defp fetch_map_field(map, atom) when is_atom(atom) do
+    case Map.fetch(map, atom) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, to_string(atom))
+    end
+  end
 
   defp try_map_to_keyword(map, constraints) do
     constraints[:fields]

--- a/lib/ash/type/keyword.ex
+++ b/lib/ash/type/keyword.ex
@@ -152,22 +152,7 @@ defmodule Ash.Type.Keyword do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, constraints) when is_map(value) do
-    if fields = constraints[:fields] do
-      fields
-      |> Enum.reduce_while({:ok, []}, fn {key, config}, {:ok, acc} ->
-        case cast_stored_field(value, key, config) do
-          {:ok, value} -> {:cont, {:ok, [{key, value} | acc]}}
-          :skip -> {:cont, {:ok, acc}}
-          other -> {:halt, other}
-        end
-      end)
-      |> case do
-        {:ok, keyword} -> {:ok, Enum.reverse(keyword)}
-        other -> other
-      end
-    else
-      {:ok, try_map_to_keyword(value, constraints)}
-    end
+    cast_keyword_fields(value, constraints, &Ash.Type.cast_stored/3)
   end
 
   def cast_stored(_, _), do: :error
@@ -201,6 +186,15 @@ defmodule Ash.Type.Keyword do
       :error
     end
   end
+
+  @impl true
+  def cast_from_embedded(nil, _), do: {:ok, nil}
+
+  def cast_from_embedded(value, constraints) when is_map(value) do
+    cast_keyword_fields(value, constraints, &Ash.Type.cast_from_embedded/3)
+  end
+
+  def cast_from_embedded(_, _), do: :error
 
   @impl true
   def apply_constraints(value, constraints) do
@@ -301,9 +295,28 @@ defmodule Ash.Type.Keyword do
 
   defp fetch_field(_, _), do: :error
 
-  defp cast_stored_field(map, key, config) do
+  defp cast_keyword_fields(value, constraints, cast_fn) do
+    if fields = constraints[:fields] do
+      fields
+      |> Enum.reduce_while({:ok, []}, fn {key, config}, {:ok, acc} ->
+        case cast_keyword_field(value, key, config, cast_fn) do
+          {:ok, value} -> {:cont, {:ok, [{key, value} | acc]}}
+          :skip -> {:cont, {:ok, acc}}
+          other -> {:halt, other}
+        end
+      end)
+      |> case do
+        {:ok, keyword} -> {:ok, Enum.reverse(keyword)}
+        other -> other
+      end
+    else
+      {:ok, try_map_to_keyword(value, constraints)}
+    end
+  end
+
+  defp cast_keyword_field(map, key, config, cast_fn) do
     case fetch_map_field(map, key) do
-      {:ok, value} -> Ash.Type.cast_stored(config[:type], value, config[:constraints] || [])
+      {:ok, value} -> cast_fn.(config[:type], value, config[:constraints] || [])
       :error -> :skip
     end
   end

--- a/lib/ash/type/map.ex
+++ b/lib/ash/type/map.ex
@@ -156,7 +156,7 @@ defmodule Ash.Type.Map do
 
   def cast_stored(value, constraints) when is_map(value) do
     if fields = constraints[:fields] do
-      nil_values = constraints[:preserve_nil_values?]
+      nil_values = constraints[:preserve_nil_values?] == true
 
       Enum.reduce_while(fields, {:ok, %{}}, fn {key, config}, {:ok, acc} ->
         case fetch_field(value, key) do
@@ -186,8 +186,45 @@ defmodule Ash.Type.Map do
 
   @impl true
   def dump_to_native(nil, _), do: {:ok, nil}
-  def dump_to_native(value, _) when is_map(value), do: {:ok, value}
+
+  def dump_to_native(value, constraints) when is_map(value) do
+    dump_fields(value, constraints, &Ash.Type.dump_to_native/3)
+  end
+
   def dump_to_native(_, _), do: :error
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(value, constraints) when is_map(value) do
+    dump_fields(value, constraints, &Ash.Type.dump_to_embedded/3)
+  end
+
+  def dump_to_embedded(_, _), do: :error
+
+  defp dump_fields(value, constraints, dump_fn) do
+    if fields = constraints[:fields] do
+      nil_values = constraints[:preserve_nil_values?] == true
+
+      Enum.reduce_while(fields, {:ok, %{}}, fn {key, config}, {:ok, acc} ->
+        case dump_field(value, key, config, dump_fn) do
+          {:ok, nil} when not nil_values -> {:cont, {:ok, acc}}
+          {:ok, dumped} -> {:cont, {:ok, Map.put(acc, key, dumped)}}
+          :skip -> {:cont, {:ok, acc}}
+          other -> {:halt, other}
+        end
+      end)
+    else
+      {:ok, value}
+    end
+  end
+
+  defp dump_field(value, key, config, dump_fn) do
+    case fetch_field(value, key) do
+      {:ok, field_value} -> dump_fn.(config[:type], field_value, config[:constraints] || [])
+      :error -> :skip
+    end
+  end
 
   @impl true
   def apply_constraints(nil, _constraints), do: {:ok, nil}

--- a/lib/ash/type/map.ex
+++ b/lib/ash/type/map.ex
@@ -155,31 +155,7 @@ defmodule Ash.Type.Map do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, constraints) when is_map(value) do
-    if fields = constraints[:fields] do
-      nil_values = constraints[:preserve_nil_values?] == true
-
-      Enum.reduce_while(fields, {:ok, %{}}, fn {key, config}, {:ok, acc} ->
-        case fetch_field(value, key) do
-          {:ok, value} ->
-            case Ash.Type.cast_stored(config[:type], value, config[:constraints] || []) do
-              {:ok, value} ->
-                if is_nil(value) && !nil_values do
-                  {:cont, {:ok, acc}}
-                else
-                  {:cont, {:ok, Map.put(acc, key, value)}}
-                end
-
-              other ->
-                {:halt, other}
-            end
-
-          :error ->
-            {:cont, {:ok, acc}}
-        end
-      end)
-    else
-      {:ok, value}
-    end
+    cast_fields(value, constraints, &Ash.Type.cast_stored/3)
   end
 
   def cast_stored(_, _), do: :error
@@ -202,6 +178,15 @@ defmodule Ash.Type.Map do
 
   def dump_to_embedded(_, _), do: :error
 
+  @impl true
+  def cast_from_embedded(nil, _), do: {:ok, nil}
+
+  def cast_from_embedded(value, constraints) when is_map(value) do
+    cast_fields(value, constraints, &Ash.Type.cast_from_embedded/3)
+  end
+
+  def cast_from_embedded(_, _), do: :error
+
   defp dump_fields(value, constraints, dump_fn) do
     if fields = constraints[:fields] do
       nil_values = constraints[:preserve_nil_values?] == true
@@ -223,6 +208,34 @@ defmodule Ash.Type.Map do
     case fetch_field(value, key) do
       {:ok, field_value} -> dump_fn.(config[:type], field_value, config[:constraints] || [])
       :error -> :skip
+    end
+  end
+
+  defp cast_fields(value, constraints, cast_fn) do
+    if fields = constraints[:fields] do
+      nil_values = constraints[:preserve_nil_values?] == true
+
+      Enum.reduce_while(fields, {:ok, %{}}, fn {key, config}, {:ok, acc} ->
+        case fetch_field(value, key) do
+          {:ok, value} ->
+            case cast_fn.(config[:type], value, config[:constraints] || []) do
+              {:ok, value} ->
+                if is_nil(value) && !nil_values do
+                  {:cont, {:ok, acc}}
+                else
+                  {:cont, {:ok, Map.put(acc, key, value)}}
+                end
+
+              other ->
+                {:halt, other}
+            end
+
+          :error ->
+            {:cont, {:ok, acc}}
+        end
+      end)
+    else
+      {:ok, value}
     end
   end
 

--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -360,6 +360,12 @@ defmodule Ash.Type.NewType do
       end
 
       @impl Ash.Type
+      def cast_from_embedded(value, constraints) do
+        constraints = subtype_constraints(constraints)
+        Ash.Type.cast_from_embedded(unquote(subtype_of), value, constraints)
+      end
+
+      @impl Ash.Type
       def composite?(constraints) do
         constraints = subtype_constraints(constraints)
         unquote(subtype_of).composite?(constraints)
@@ -386,6 +392,41 @@ defmodule Ash.Type.NewType do
 
               error ->
                 {:halt, Ash.Helpers.error_with_context(error, index: index)}
+            end
+          end)
+        end
+      end
+
+      @impl Ash.Type
+      def cast_from_embedded_array(term, constraints) do
+        if is_nil(term) do
+          {:ok, nil}
+        else
+          term
+          |> Enum.with_index()
+          |> Enum.reverse()
+          |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, casted} ->
+            case cast_from_embedded(item, constraints) do
+              :error ->
+                {:halt, {:error, index: index}}
+
+              {:error, keyword} ->
+                errors =
+                  keyword
+                  |> List.wrap()
+                  |> Ash.Helpers.flatten_preserving_keywords()
+                  |> Enum.map(fn
+                    string when is_binary(string) ->
+                      [message: string, index: index]
+
+                    vars ->
+                      Keyword.put(vars, :index, index)
+                  end)
+
+                {:halt, {:error, errors}}
+
+              {:ok, value} ->
+                {:cont, {:ok, [value | casted]}}
             end
           end)
         end
@@ -658,6 +699,8 @@ defmodule Ash.Type.NewType do
                      constraints: 0,
                      dump_to_embedded_array: 2,
                      dump_to_embedded: 2,
+                     cast_from_embedded: 2,
+                     cast_from_embedded_array: 2,
                      dump_to_native_array: 2,
                      dump_to_native: 2,
                      generator: 1,

--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -242,21 +242,28 @@ defmodule Ash.Type.Struct do
   def dump_to_native(nil, _), do: {:ok, nil}
 
   def dump_to_native(value, constraints) when is_map(value) do
+    dump_struct_fields(value, constraints, &Ash.Type.dump_to_native/3)
+  end
+
+  def dump_to_native(_, _), do: :error
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(value, constraints) when is_map(value) do
+    dump_struct_fields(value, constraints, &Ash.Type.dump_to_embedded/3)
+  end
+
+  def dump_to_embedded(_, _), do: :error
+
+  defp dump_struct_fields(value, constraints, dump_fn) do
     if fields = fields(constraints) do
       if constraints[:instance_of] do
         Enum.reduce_while(fields, {:ok, %{}}, fn {key, config}, {:ok, acc} ->
-          case Map.fetch(value, key) do
-            {:ok, value} ->
-              case Ash.Type.dump_to_native(config[:type], value, config[:constraints] || []) do
-                {:ok, value} ->
-                  {:cont, {:ok, Map.put(acc, key, value)}}
-
-                other ->
-                  {:halt, other}
-              end
-
-            :error ->
-              {:cont, {:ok, acc}}
+          case dump_struct_field(value, key, config, dump_fn) do
+            {:ok, dumped} -> {:cont, {:ok, Map.put(acc, key, dumped)}}
+            :skip -> {:cont, {:ok, acc}}
+            other -> {:halt, other}
           end
         end)
       else
@@ -267,7 +274,12 @@ defmodule Ash.Type.Struct do
     end
   end
 
-  def dump_to_native(_, _), do: :error
+  defp dump_struct_field(value, key, config, dump_fn) do
+    case Map.fetch(value, key) do
+      {:ok, field_value} -> dump_fn.(config[:type], field_value, config[:constraints] || [])
+      :error -> :skip
+    end
+  end
 
   @impl true
   def generator(constraints) do

--- a/lib/ash/type/struct.ex
+++ b/lib/ash/type/struct.ex
@@ -204,36 +204,7 @@ defmodule Ash.Type.Struct do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, constraints) when is_map(value) do
-    if fields = fields(constraints) do
-      if constraints[:instance_of] do
-        nil_values = constraints[:preserve_nil_values?]
-
-        Enum.reduce_while(fields, {:ok, struct(constraints[:instance_of], [])}, fn {key, config},
-                                                                                   {:ok, acc} ->
-          case fetch_field(value, key) do
-            {:ok, value} ->
-              case Ash.Type.cast_stored(config[:type], value, config[:constraints] || []) do
-                {:ok, value} ->
-                  if is_nil(value) && !nil_values do
-                    {:cont, {:ok, acc}}
-                  else
-                    {:cont, {:ok, Map.put(acc, key, value)}}
-                  end
-
-                other ->
-                  {:halt, other}
-              end
-
-            :error ->
-              {:cont, {:ok, acc}}
-          end
-        end)
-      else
-        :error
-      end
-    else
-      :error
-    end
+    cast_struct_fields(value, constraints, &Ash.Type.cast_stored/3)
   end
 
   def cast_stored(_, _), do: :error
@@ -255,6 +226,15 @@ defmodule Ash.Type.Struct do
   end
 
   def dump_to_embedded(_, _), do: :error
+
+  @impl true
+  def cast_from_embedded(nil, _), do: {:ok, nil}
+
+  def cast_from_embedded(value, constraints) when is_map(value) do
+    cast_struct_fields(value, constraints, &Ash.Type.cast_from_embedded/3)
+  end
+
+  def cast_from_embedded(_, _), do: :error
 
   defp dump_struct_fields(value, constraints, dump_fn) do
     if fields = fields(constraints) do
@@ -278,6 +258,39 @@ defmodule Ash.Type.Struct do
     case Map.fetch(value, key) do
       {:ok, field_value} -> dump_fn.(config[:type], field_value, config[:constraints] || [])
       :error -> :skip
+    end
+  end
+
+  defp cast_struct_fields(value, constraints, cast_fn) do
+    if fields = fields(constraints) do
+      if constraints[:instance_of] do
+        nil_values = constraints[:preserve_nil_values?]
+
+        Enum.reduce_while(fields, {:ok, struct(constraints[:instance_of], [])}, fn {key, config},
+                                                                                   {:ok, acc} ->
+          case fetch_field(value, key) do
+            {:ok, value} ->
+              case cast_fn.(config[:type], value, config[:constraints] || []) do
+                {:ok, value} ->
+                  if is_nil(value) && !nil_values do
+                    {:cont, {:ok, acc}}
+                  else
+                    {:cont, {:ok, Map.put(acc, key, value)}}
+                  end
+
+                other ->
+                  {:halt, other}
+              end
+
+            :error ->
+              {:cont, {:ok, acc}}
+          end
+        end)
+      else
+        :error
+      end
+    else
+      :error
     end
   end
 

--- a/lib/ash/type/tuple.ex
+++ b/lib/ash/type/tuple.ex
@@ -157,21 +157,39 @@ defmodule Ash.Type.Tuple do
   def dump_to_native(nil, _), do: {:ok, nil}
 
   def dump_to_native(value, constraints) when is_tuple(value) do
+    dump_tuple_fields(value, constraints, &Ash.Type.dump_to_native/3)
+  end
+
+  def dump_to_native(_, _), do: :error
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(value, constraints) when is_tuple(value) do
+    dump_tuple_fields(value, constraints, &Ash.Type.dump_to_embedded/3)
+  end
+
+  def dump_to_embedded(_, _), do: :error
+
+  defp dump_tuple_fields(value, constraints, dump_fn) do
     list = Tuple.to_list(value)
 
     if length(list) == length(constraints[:fields]) do
       list
       |> Enum.zip(constraints[:fields])
-      |> Map.new(fn {tuple_val, {key, _config}} ->
-        {key, tuple_val}
+      |> Enum.reduce_while({:ok, %{}}, fn {tuple_val, {key, config}}, {:ok, acc} ->
+        case dump_fn.(config[:type], tuple_val, config[:constraints] || []) do
+          {:ok, dumped} ->
+            {:cont, {:ok, Map.put(acc, key, dumped)}}
+
+          other ->
+            {:halt, other}
+        end
       end)
-      |> then(&{:ok, &1})
     else
       :error
     end
   end
-
-  def dump_to_native(_, _), do: :error
 
   @impl true
   def apply_constraints(nil, _), do: {:ok, nil}

--- a/lib/ash/type/tuple.ex
+++ b/lib/ash/type/tuple.ex
@@ -130,25 +130,7 @@ defmodule Ash.Type.Tuple do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, constraints) when is_map(value) do
-    Enum.reduce_while(constraints[:fields], {:ok, []}, fn {key, config}, {:ok, acc} ->
-      case fetch_field(value, key) do
-        {:ok, value} ->
-          case Ash.Type.cast_stored(config[:type], value, config[:constraints] || []) do
-            {:ok, value} ->
-              {:cont, {:ok, [value | acc]}}
-
-            other ->
-              {:halt, other}
-          end
-
-        :error ->
-          {:cont, {:ok, acc}}
-      end
-    end)
-    |> case do
-      {:ok, value} -> {:ok, value |> Enum.reverse() |> List.to_tuple()}
-      {:error, error} -> {:error, error}
-    end
+    cast_tuple_fields(value, constraints, &Ash.Type.cast_stored/3)
   end
 
   def cast_stored(_, _), do: :error
@@ -170,6 +152,37 @@ defmodule Ash.Type.Tuple do
   end
 
   def dump_to_embedded(_, _), do: :error
+
+  @impl true
+  def cast_from_embedded(nil, _), do: {:ok, nil}
+
+  def cast_from_embedded(value, constraints) when is_map(value) do
+    cast_tuple_fields(value, constraints, &Ash.Type.cast_from_embedded/3)
+  end
+
+  def cast_from_embedded(_, _), do: :error
+
+  defp cast_tuple_fields(value, constraints, cast_fn) do
+    Enum.reduce_while(constraints[:fields], {:ok, []}, fn {key, config}, {:ok, acc} ->
+      case fetch_field(value, key) do
+        {:ok, value} ->
+          case cast_fn.(config[:type], value, config[:constraints] || []) do
+            {:ok, value} ->
+              {:cont, {:ok, [value | acc]}}
+
+            other ->
+              {:halt, other}
+          end
+
+        :error ->
+          {:cont, {:ok, acc}}
+      end
+    end)
+    |> case do
+      {:ok, value} -> {:ok, value |> Enum.reverse() |> List.to_tuple()}
+      {:error, error} -> {:error, error}
+    end
+  end
 
   defp dump_tuple_fields(value, constraints, dump_fn) do
     list = Tuple.to_list(value)

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -429,6 +429,16 @@ defmodule Ash.Type do
   """
   @callback dump_to_embedded_array(list(term), constraints) :: {:ok, term} | error()
 
+  @doc "Cast a value from a JSON-safe embedded format back to an Elixir value. The reverse of `c:dump_to_embedded/2`."
+  @callback cast_from_embedded(term, constraints) :: {:ok, term} | error()
+
+  @doc """
+  Cast a list of values from a JSON-safe embedded format back to a list of valid instances of the type.
+
+  If not defined, `c:cast_from_embedded/2` is called for each item.
+  """
+  @callback cast_from_embedded_array(list(term), constraints) :: {:ok, term} | error()
+
   @doc "React to a changing value. This could be used, for example, to have a type like `:strictly_increasing_integer`."
   @callback handle_change(old_term :: term, new_term :: term, constraints) ::
               {:ok, term} | error()
@@ -656,6 +666,8 @@ defmodule Ash.Type do
     array_constraints: 0,
     dump_to_embedded: 2,
     dump_to_embedded_array: 2,
+    cast_from_embedded: 2,
+    cast_from_embedded_array: 2,
     include_source: 2,
     load: 4,
     merge_load: 4,
@@ -1454,6 +1466,35 @@ defmodule Ash.Type do
   end
 
   @doc """
+  Casts a value from a JSON-safe embedded format back to an Elixir value.
+
+  This is the reverse of `dump_to_embedded/3`.
+  """
+  @spec cast_from_embedded(t(), term, constraints | nil) ::
+          {:ok, term} | {:error, keyword()} | :error
+  def cast_from_embedded(type, term, constraints \\ [])
+
+  def cast_from_embedded({:array, {:array, type}}, term, constraints) do
+    if is_nil(term) do
+      {:ok, nil}
+    else
+      map_while_ok(term, &cast_from_embedded({:array, type}, &1, item_constraints(constraints)))
+    end
+  end
+
+  def cast_from_embedded({:array, type}, term, constraints) do
+    type = Ash.Type.get_type(type)
+
+    type.cast_from_embedded_array(term, item_constraints(constraints))
+  end
+
+  def cast_from_embedded(type, term, constraints) do
+    type = get_type(type)
+
+    type.cast_from_embedded(term, constraints)
+  end
+
+  @doc """
   Determines if two values of a given type are equal.
 
   Maps to `Ecto.Type.equal?/3`
@@ -1864,6 +1905,11 @@ defmodule Ash.Type do
       end
 
       @impl true
+      def cast_from_embedded(value, constraints) do
+        cast_stored(value, constraints)
+      end
+
+      @impl true
       def loaded?(_, _, _, _), do: false
 
       @impl true
@@ -1995,6 +2041,41 @@ defmodule Ash.Type do
       end
 
       @impl true
+      def cast_from_embedded_array(term, single_constraints) do
+        if is_nil(term) do
+          {:ok, nil}
+        else
+          term
+          |> Enum.with_index()
+          |> Enum.reverse()
+          |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, casted} ->
+            case Ash.Type.cast_from_embedded(__MODULE__, item, single_constraints) do
+              :error ->
+                {:halt, {:error, index: index}}
+
+              {:error, keyword} ->
+                errors =
+                  keyword
+                  |> List.wrap()
+                  |> Ash.Helpers.flatten_preserving_keywords()
+                  |> Enum.map(fn
+                    string when is_binary(string) ->
+                      [message: string, index: index]
+
+                    vars ->
+                      Keyword.put(vars, :index, index)
+                  end)
+
+                {:halt, {:error, errors}}
+
+              {:ok, value} ->
+                {:cont, {:ok, [value | casted]}}
+            end
+          end)
+        end
+      end
+
+      @impl true
       def apply_atomic_constraints(new_value, _constraints) do
         {:ok, new_value}
       end
@@ -2085,6 +2166,8 @@ defmodule Ash.Type do
                      dump_to_native_array: 2,
                      dump_to_embedded: 2,
                      dump_to_embedded_array: 2,
+                     cast_from_embedded: 2,
+                     cast_from_embedded_array: 2,
                      matches_type?: 2,
                      embedded?: 0,
                      ecto_type: 0,

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -952,6 +952,19 @@ defmodule Ash.Type.Union do
   def dump_to_native(nil, _), do: {:ok, nil}
 
   def dump_to_native(%Ash.Union{value: value, type: type_name}, union_constraints) do
+    dump_union(value, type_name, union_constraints, &Ash.Type.dump_to_native/3)
+  end
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(%Ash.Union{value: value, type: type_name}, union_constraints) do
+    dump_union(value, type_name, union_constraints, &Ash.Type.dump_to_embedded/3)
+  end
+
+  def dump_to_embedded(_, _), do: :error
+
+  defp dump_union(value, type_name, union_constraints, dump_fn) do
     type = union_constraints[:types][type_name][:type]
 
     if type do
@@ -959,7 +972,7 @@ defmodule Ash.Type.Union do
 
       case union_constraints[:storage] do
         :type_and_value ->
-          case Ash.Type.dump_to_native(type, value, constraints) do
+          case dump_fn.(type, value, constraints) do
             {:ok, value} ->
               {:ok, %{"type" => type_name, "value" => value}}
 
@@ -974,7 +987,7 @@ defmodule Ash.Type.Union do
             raise "Found a type without a tag when using the `:map_with_tag` storage constraint. Constraints: #{inspect(union_constraints)}"
           end
 
-          case Ash.Type.dump_to_native(
+          case dump_fn.(
                  type,
                  value,
                  constraints

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -882,6 +882,37 @@ defmodule Ash.Type.Union do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, constraints) when is_map(value) do
+    cast_union(value, constraints, &Ash.Type.cast_stored/3)
+  end
+
+  def cast_stored(_, _), do: :error
+
+  @impl true
+  def dump_to_native(nil, _), do: {:ok, nil}
+
+  def dump_to_native(%Ash.Union{value: value, type: type_name}, union_constraints) do
+    dump_union(value, type_name, union_constraints, &Ash.Type.dump_to_native/3)
+  end
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+
+  def dump_to_embedded(%Ash.Union{value: value, type: type_name}, union_constraints) do
+    dump_union(value, type_name, union_constraints, &Ash.Type.dump_to_embedded/3)
+  end
+
+  def dump_to_embedded(_, _), do: :error
+
+  @impl true
+  def cast_from_embedded(nil, _), do: {:ok, nil}
+
+  def cast_from_embedded(value, constraints) when is_map(value) do
+    cast_union(value, constraints, &Ash.Type.cast_from_embedded/3)
+  end
+
+  def cast_from_embedded(_, _), do: :error
+
+  defp cast_union(value, constraints, cast_fn) do
     types = constraints[:types] || []
 
     case constraints[:storage] do
@@ -897,13 +928,9 @@ defmodule Ash.Type.Union do
 
             case Keyword.fetch(types, type) do
               {:ok, config} ->
-                case Ash.Type.cast_stored(config[:type], value, config[:constraints]) do
+                case cast_fn.(config[:type], value, config[:constraints]) do
                   {:ok, casted_value} ->
-                    {:ok,
-                     %Ash.Union{
-                       value: casted_value,
-                       type: type
-                     }}
+                    {:ok, %Ash.Union{value: casted_value, type: type}}
 
                   other ->
                     other
@@ -931,13 +958,9 @@ defmodule Ash.Type.Union do
             :error
 
           {type_name, config} ->
-            case Ash.Type.cast_stored(config[:type], value, config[:constraints]) do
+            case cast_fn.(config[:type], value, config[:constraints]) do
               {:ok, casted_value} ->
-                {:ok,
-                 %Ash.Union{
-                   value: casted_value,
-                   type: type_name
-                 }}
+                {:ok, %Ash.Union{value: casted_value, type: type_name}}
 
               other ->
                 other
@@ -945,24 +968,6 @@ defmodule Ash.Type.Union do
         end
     end
   end
-
-  def cast_stored(_, _), do: :error
-
-  @impl true
-  def dump_to_native(nil, _), do: {:ok, nil}
-
-  def dump_to_native(%Ash.Union{value: value, type: type_name}, union_constraints) do
-    dump_union(value, type_name, union_constraints, &Ash.Type.dump_to_native/3)
-  end
-
-  @impl true
-  def dump_to_embedded(nil, _), do: {:ok, nil}
-
-  def dump_to_embedded(%Ash.Union{value: value, type: type_name}, union_constraints) do
-    dump_union(value, type_name, union_constraints, &Ash.Type.dump_to_embedded/3)
-  end
-
-  def dump_to_embedded(_, _), do: :error
 
   defp dump_union(value, type_name, union_constraints, dump_fn) do
     type = union_constraints[:types][type_name][:type]

--- a/test/support/dump_test_type.ex
+++ b/test/support/dump_test_type.ex
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.DumpTestType do
+  @moduledoc """
+  Custom type where dump_to_native and dump_to_embedded produce distinguishable results.
+
+  Used in type tests to verify that composite types call the correct dump function
+  on their field types.
+  """
+  use Ash.Type
+
+  @impl true
+  def storage_type(_), do: :string
+
+  @impl true
+  def cast_input(value, _), do: {:ok, value}
+
+  @impl true
+  def cast_stored("native:" <> value, _), do: {:ok, value}
+  def cast_stored("embedded:" <> value, _), do: {:ok, value}
+  def cast_stored(value, _), do: {:ok, value}
+
+  @impl true
+  def dump_to_native(nil, _), do: {:ok, nil}
+  def dump_to_native(value, _), do: {:ok, "native:#{value}"}
+
+  @impl true
+  def dump_to_embedded(nil, _), do: {:ok, nil}
+  def dump_to_embedded(value, _), do: {:ok, "embedded:#{value}"}
+
+  @impl true
+  def matches_type?(_, _), do: true
+end

--- a/test/support/dump_test_type.ex
+++ b/test/support/dump_test_type.ex
@@ -19,8 +19,11 @@ defmodule Ash.Test.DumpTestType do
 
   @impl true
   def cast_stored("native:" <> value, _), do: {:ok, value}
-  def cast_stored("embedded:" <> value, _), do: {:ok, value}
   def cast_stored(value, _), do: {:ok, value}
+
+  @impl true
+  def cast_from_embedded("embedded:" <> value, _), do: {:ok, value}
+  def cast_from_embedded(value, _), do: {:ok, value}
 
   @impl true
   def dump_to_native(nil, _), do: {:ok, nil}

--- a/test/type/binary_test.exs
+++ b/test/type/binary_test.exs
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Type.BinaryTest do
+  use ExUnit.Case, async: true
+
+  @binary_hash :crypto.strong_rand_bytes(32)
+
+  describe "dump_to_embedded" do
+    test "base64-encodes binary values" do
+      assert {:ok, encoded} = Ash.Type.dump_to_embedded(:binary, @binary_hash, [])
+      assert encoded == Base.encode64(@binary_hash)
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_embedded(:binary, nil, [])
+    end
+  end
+
+  describe "cast_from_embedded" do
+    test "base64-decodes encoded values" do
+      encoded = Base.encode64(@binary_hash)
+      assert {:ok, decoded} = Ash.Type.cast_from_embedded(:binary, encoded, [])
+      assert decoded == @binary_hash
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_from_embedded(:binary, nil, [])
+    end
+
+    test "returns ok with value for non-base64 strings" do
+      assert {:ok, "plain text"} = Ash.Type.cast_from_embedded(:binary, "plain text", [])
+    end
+  end
+
+  describe "dump_to_embedded/cast_from_embedded round-trip" do
+    test "preserves binary data" do
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(:binary, @binary_hash, [])
+      assert {:ok, restored} = Ash.Type.cast_from_embedded(:binary, dumped, [])
+      assert restored == @binary_hash
+    end
+
+    test "preserves nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_embedded(:binary, nil, [])
+      assert {:ok, nil} = Ash.Type.cast_from_embedded(:binary, nil, [])
+    end
+  end
+
+  describe "array round-trip" do
+    test "encodes and decodes each element through cast_from_embedded_array" do
+      hashes = [
+        :crypto.strong_rand_bytes(16),
+        :crypto.strong_rand_bytes(24),
+        :crypto.strong_rand_bytes(32)
+      ]
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded({:array, :binary}, hashes, [])
+      assert dumped == Enum.map(hashes, &Base.encode64/1)
+
+      assert {:ok, restored} = Ash.Type.cast_from_embedded({:array, :binary}, dumped, [])
+      assert restored == hashes
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_from_embedded({:array, :binary}, nil, [])
+    end
+  end
+
+  describe "dump_to_native/cast_stored are unchanged" do
+    test "dump_to_native returns raw binary" do
+      assert {:ok, raw} = Ash.Type.dump_to_native(:binary, @binary_hash, [])
+      assert raw == @binary_hash
+    end
+
+    test "cast_stored returns raw binary" do
+      assert {:ok, raw} = Ash.Type.cast_stored(:binary, @binary_hash, [])
+      assert raw == @binary_hash
+    end
+  end
+end

--- a/test/type/keyword_test.exs
+++ b/test/type/keyword_test.exs
@@ -6,6 +6,7 @@ defmodule Type.KeywordTest do
   use ExUnit.Case, async: true
 
   alias Ash.Test.Domain, as: Domain
+  alias Ash.Test.DumpTestType
 
   defmodule Post do
     @moduledoc false
@@ -471,35 +472,259 @@ defmodule Type.KeywordTest do
     assert length(errors) > 1
   end
 
-  test "cast_stored casts atom field values from stored strings to atoms" do
-    constraints = [
-      fields: [
-        status: [type: :atom]
+  describe "cast_stored" do
+    test "casts atom field values from stored strings to atoms" do
+      constraints = [
+        fields: [
+          status: [type: :atom]
+        ]
       ]
-    ]
 
-    stored = %{"status" => "active"}
+      stored = %{"status" => "active"}
 
-    assert {:ok, keyword} = Ash.Type.Keyword.cast_stored(stored, constraints)
-    assert keyword[:status] == :active
+      assert {:ok, keyword} = Ash.Type.Keyword.cast_stored(stored, constraints)
+      assert keyword[:status] == :active
+    end
+
+    test "recursively casts field types from stored map" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, [name: "hello", count: 42]} =
+               Ash.Type.cast_stored(
+                 Ash.Type.Keyword,
+                 %{"name" => "hello", "count" => 42},
+                 constraints
+               )
+    end
+
+    test "handles string keys in stored map" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            foo: [type: :string]
+          ]
+        )
+
+      assert {:ok, [foo: "bar"]} =
+               Ash.Type.cast_stored(Ash.Type.Keyword, %{"foo" => "bar"}, constraints)
+    end
+
+    test "handles atom keys in stored map" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            foo: [type: :string]
+          ]
+        )
+
+      assert {:ok, [foo: "bar"]} =
+               Ash.Type.cast_stored(Ash.Type.Keyword, %{foo: "bar"}, constraints)
+    end
+
+    test "skips missing fields" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            age: [type: :integer]
+          ]
+        )
+
+      assert {:ok, [name: "hello"]} =
+               Ash.Type.cast_stored(Ash.Type.Keyword, %{"name" => "hello"}, constraints)
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_stored(Ash.Type.Keyword, nil, fields: [])
+    end
+
+    test "without fields falls back to simple conversion" do
+      # Without field definitions, try_map_to_keyword can't know which keys to extract
+      assert {:ok, []} =
+               Ash.Type.cast_stored(Ash.Type.Keyword, %{foo: "bar"}, [])
+    end
   end
 
-  test "dump_to_native converts keyword list to map" do
-    keyword_list = [foo: "bar", baz: 42]
-    assert Ash.Type.Keyword.dump_to_native(keyword_list, []) == {:ok, %{foo: "bar", baz: 42}}
+  describe "dump_to_native" do
+    test "recursively dumps field types from keyword list" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "native:hello", count: 42}} =
+               Ash.Type.dump_to_native(
+                 Ash.Type.Keyword,
+                 [name: "hello", count: 42],
+                 constraints
+               )
+    end
+
+    test "recursively dumps field types from map input" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: DumpTestType]
+          ]
+        )
+
+      assert {:ok, %{name: "native:hello"}} =
+               Ash.Type.dump_to_native(Ash.Type.Keyword, %{name: "hello"}, constraints)
+    end
+
+    test "drops extra keys not in field definitions" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [name: [type: :string]]
+        )
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.dump_to_native(
+                 Ash.Type.Keyword,
+                 [name: "hello", extra: "dropped"],
+                 constraints
+               )
+    end
+
+    test "without fields converts keyword list to map" do
+      assert {:ok, %{foo: "bar", baz: 42}} =
+               Ash.Type.dump_to_native(Ash.Type.Keyword, [foo: "bar", baz: 42], [])
+    end
+
+    test "without fields passes through map as-is" do
+      assert {:ok, %{foo: "bar"}} =
+               Ash.Type.dump_to_native(Ash.Type.Keyword, %{foo: "bar"}, [])
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_native(Ash.Type.Keyword, nil, [])
+    end
+
+    test "returns error for invalid input" do
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Keyword, "invalid", [])
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Keyword, 123, [])
+    end
+
+    test "handles missing fields gracefully" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            age: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.dump_to_native(Ash.Type.Keyword, [name: "hello"], constraints)
+    end
   end
 
-  test "dump_to_native handles nil" do
-    assert Ash.Type.Keyword.dump_to_native(nil, []) == {:ok, nil}
+  describe "dump_to_embedded" do
+    test "recursively calls dump_to_embedded on field types from keyword list" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "embedded:hello", count: 42}} =
+               Ash.Type.dump_to_embedded(
+                 Ash.Type.Keyword,
+                 [name: "hello", count: 42],
+                 constraints
+               )
+    end
+
+    test "recursively calls dump_to_embedded on field types from map input" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: DumpTestType]
+          ]
+        )
+
+      assert {:ok, %{name: "embedded:hello"}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Keyword, %{name: "hello"}, constraints)
+    end
+
+    test "uses dump_to_embedded not dump_to_native on fields" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            val: [type: DumpTestType]
+          ]
+        )
+
+      {:ok, native_result} =
+        Ash.Type.dump_to_native(Ash.Type.Keyword, [val: "test"], constraints)
+
+      {:ok, embedded_result} =
+        Ash.Type.dump_to_embedded(Ash.Type.Keyword, [val: "test"], constraints)
+
+      assert native_result[:val] == "native:test"
+      assert embedded_result[:val] == "embedded:test"
+    end
+
+    test "without fields converts keyword list to map" do
+      assert {:ok, %{foo: "bar"}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Keyword, [foo: "bar"], [])
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_embedded(Ash.Type.Keyword, nil, [])
+    end
+
+    test "returns error for invalid input" do
+      assert :error = Ash.Type.dump_to_embedded(Ash.Type.Keyword, "invalid", [])
+    end
   end
 
-  test "dump_to_native handles maps" do
-    map = %{foo: "bar", baz: 42}
-    assert Ash.Type.Keyword.dump_to_native(map, []) == {:ok, map}
-  end
+  describe "dump/cast round-trip" do
+    test "dump_to_native then cast_stored preserves data" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
 
-  test "dump_to_native returns error for invalid input" do
-    assert Ash.Type.Keyword.dump_to_native("invalid", []) == :error
-    assert Ash.Type.Keyword.dump_to_native(123, []) == :error
+      original = [name: "hello", count: 42]
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Keyword, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Keyword, dumped, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_native then cast_stored with string keys round-trips" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = [name: "hello", count: 42]
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Keyword, original, constraints)
+
+      # Simulate stored data having string keys
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Keyword, string_keyed, constraints)
+      assert restored == original
+    end
   end
 end

--- a/test/type/keyword_test.exs
+++ b/test/type/keyword_test.exs
@@ -690,6 +690,49 @@ defmodule Type.KeywordTest do
     end
   end
 
+  describe "cast_from_embedded" do
+    test "recursively calls cast_from_embedded on field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, [name: "hello", count: 42]} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Keyword,
+                 %{name: "embedded:hello", count: 42},
+                 constraints
+               )
+    end
+
+    test "handles string keys" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: DumpTestType]
+          ]
+        )
+
+      assert {:ok, [name: "hello"]} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Keyword,
+                 %{"name" => "embedded:hello"},
+                 constraints
+               )
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_from_embedded(Ash.Type.Keyword, nil, [])
+    end
+
+    test "returns error for non-map values" do
+      assert :error = Ash.Type.cast_from_embedded(Ash.Type.Keyword, "string", [])
+    end
+  end
+
   describe "dump/cast round-trip" do
     test "dump_to_native then cast_stored preserves data" do
       {:ok, constraints} =
@@ -724,6 +767,43 @@ defmodule Type.KeywordTest do
       string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
 
       assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Keyword, string_keyed, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_embedded then cast_from_embedded preserves data" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = [name: "hello", count: 42]
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Keyword, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_from_embedded(Ash.Type.Keyword, dumped, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_embedded then cast_from_embedded with string keys round-trips" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Keyword,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = [name: "hello", count: 42]
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Keyword, original, constraints)
+
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} =
+               Ash.Type.cast_from_embedded(Ash.Type.Keyword, string_keyed, constraints)
+
       assert restored == original
     end
   end

--- a/test/type/map_test.exs
+++ b/test/type/map_test.exs
@@ -6,6 +6,7 @@ defmodule Ash.Type.MapTest do
   use ExUnit.Case, async: true
 
   alias Ash.Test.Domain, as: Domain
+  alias Ash.Test.DumpTestType
 
   defmodule Post do
     @moduledoc false
@@ -466,6 +467,226 @@ defmodule Ash.Type.MapTest do
                path: [:metadata]
              }
            ] = changeset.errors
+  end
+
+  describe "dump_to_native" do
+    test "recursively dumps field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "native:hello", count: 42}} =
+               Ash.Type.dump_to_native(Ash.Type.Map, %{name: "hello", count: 42}, constraints)
+    end
+
+    test "drops extra keys not in field definitions" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: :string]
+          ]
+        )
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.dump_to_native(
+                 Ash.Type.Map,
+                 %{name: "hello", extra: "dropped"},
+                 constraints
+               )
+    end
+
+    test "without fields returns map as-is" do
+      assert {:ok, %{anything: "goes"}} =
+               Ash.Type.dump_to_native(Ash.Type.Map, %{anything: "goes"}, [])
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_native(Ash.Type.Map, nil, [])
+    end
+
+    test "handles missing fields gracefully" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: :string],
+            age: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.dump_to_native(Ash.Type.Map, %{name: "hello"}, constraints)
+    end
+
+    test "respects preserve_nil_values? true" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]],
+          preserve_nil_values?: true
+        )
+
+      assert {:ok, %{name: nil}} =
+               Ash.Type.dump_to_native(Ash.Type.Map, %{name: nil}, constraints)
+    end
+
+    test "respects preserve_nil_values? false" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]],
+          preserve_nil_values?: false
+        )
+
+      assert {:ok, %{}} =
+               Ash.Type.dump_to_native(Ash.Type.Map, %{name: nil}, constraints)
+    end
+
+    test "honors string keys in field lookup" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: DumpTestType]
+          ]
+        )
+
+      assert {:ok, %{name: "native:hello"}} =
+               Ash.Type.dump_to_native(Ash.Type.Map, %{"name" => "hello"}, constraints)
+    end
+
+    test "returns error for non-map values" do
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Map, "string", [])
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Map, 123, [])
+    end
+  end
+
+  describe "dump_to_embedded" do
+    test "recursively calls dump_to_embedded on field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "embedded:hello", count: 42}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Map, %{name: "hello", count: 42}, constraints)
+    end
+
+    test "uses dump_to_embedded not dump_to_native on fields" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            val: [type: DumpTestType]
+          ]
+        )
+
+      {:ok, native_result} =
+        Ash.Type.dump_to_native(Ash.Type.Map, %{val: "test"}, constraints)
+
+      {:ok, embedded_result} =
+        Ash.Type.dump_to_embedded(Ash.Type.Map, %{val: "test"}, constraints)
+
+      assert native_result[:val] == "native:test"
+      assert embedded_result[:val] == "embedded:test"
+    end
+
+    test "without fields returns map as-is" do
+      assert {:ok, %{anything: "goes"}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Map, %{anything: "goes"}, [])
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.dump_to_embedded(Ash.Type.Map, nil, [])
+    end
+
+    test "drops extra keys not in field definitions" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]]
+        )
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.dump_to_embedded(
+                 Ash.Type.Map,
+                 %{name: "hello", extra: "dropped"},
+                 constraints
+               )
+    end
+
+    test "respects preserve_nil_values?" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]],
+          preserve_nil_values?: true
+        )
+
+      assert {:ok, %{name: nil}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Map, %{name: nil}, constraints)
+
+      {:ok, constraints_no_nil} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]],
+          preserve_nil_values?: false
+        )
+
+      assert {:ok, %{}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Map, %{name: nil}, constraints_no_nil)
+    end
+
+    test "honors string keys in field lookup" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: DumpTestType]]
+        )
+
+      assert {:ok, %{name: "embedded:hello"}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Map, %{"name" => "hello"}, constraints)
+    end
+
+    test "returns error for non-map values" do
+      assert :error = Ash.Type.dump_to_embedded(Ash.Type.Map, "string", [])
+    end
+  end
+
+  describe "dump/cast round-trip" do
+    test "dump_to_native then cast_stored preserves data" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = %{name: "hello", count: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Map, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Map, dumped, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_native then cast_stored with string keys round-trips" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = %{name: "hello", count: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Map, original, constraints)
+
+      # Simulate stored data having string keys (common with JSON storage)
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Map, string_keyed, constraints)
+      assert restored == original
+    end
   end
 
   test "string_match validates against regex pattern" do

--- a/test/type/map_test.exs
+++ b/test/type/map_test.exs
@@ -651,6 +651,92 @@ defmodule Ash.Type.MapTest do
     end
   end
 
+  describe "cast_from_embedded" do
+    test "recursively calls cast_from_embedded on field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "hello", count: 42}} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Map,
+                 %{name: "embedded:hello", count: 42},
+                 constraints
+               )
+    end
+
+    test "uses cast_from_embedded not cast_stored on fields" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            val: [type: DumpTestType]
+          ]
+        )
+
+      # DumpTestType.cast_stored only strips "native:", DumpTestType.cast_from_embedded
+      # only strips "embedded:" — so the prefix tells us which callback ran on the field.
+      {:ok, from_stored} =
+        Ash.Type.cast_stored(Ash.Type.Map, %{val: "embedded:test"}, constraints)
+
+      {:ok, from_embedded} =
+        Ash.Type.cast_from_embedded(Ash.Type.Map, %{val: "embedded:test"}, constraints)
+
+      assert from_stored.val == "embedded:test"
+      assert from_embedded.val == "test"
+    end
+
+    test "without fields returns map as-is" do
+      assert {:ok, %{anything: "goes"}} =
+               Ash.Type.cast_from_embedded(Ash.Type.Map, %{anything: "goes"}, [])
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_from_embedded(Ash.Type.Map, nil, [])
+    end
+
+    test "respects preserve_nil_values?" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]],
+          preserve_nil_values?: true
+        )
+
+      assert {:ok, %{name: nil}} =
+               Ash.Type.cast_from_embedded(Ash.Type.Map, %{name: nil}, constraints)
+
+      {:ok, constraints_no_nil} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: :string]],
+          preserve_nil_values?: false
+        )
+
+      assert {:ok, %{}} =
+               Ash.Type.cast_from_embedded(Ash.Type.Map, %{name: nil}, constraints_no_nil)
+    end
+
+    test "honors string keys in field lookup" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [name: [type: DumpTestType]]
+        )
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Map,
+                 %{"name" => "embedded:hello"},
+                 constraints
+               )
+    end
+
+    test "returns error for non-map values" do
+      assert :error = Ash.Type.cast_from_embedded(Ash.Type.Map, "string", [])
+    end
+  end
+
   describe "dump/cast round-trip" do
     test "dump_to_native then cast_stored preserves data" do
       {:ok, constraints} =
@@ -685,6 +771,43 @@ defmodule Ash.Type.MapTest do
       string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
 
       assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Map, string_keyed, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_embedded then cast_from_embedded preserves data" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = %{name: "hello", count: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Map, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_from_embedded(Ash.Type.Map, dumped, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_embedded then cast_from_embedded with string keys round-trips" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Map,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = %{name: "hello", count: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Map, original, constraints)
+
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} =
+               Ash.Type.cast_from_embedded(Ash.Type.Map, string_keyed, constraints)
+
       assert restored == original
     end
   end

--- a/test/type/new_type_test.exs
+++ b/test/type/new_type_test.exs
@@ -504,6 +504,14 @@ defmodule Ash.Test.Type.NewTypeTest do
           other -> other
         end
       end
+
+      @impl Ash.Type
+      def cast_from_embedded(value, constraints) do
+        case super(value, constraints) do
+          {:ok, str} -> {:ok, "from_embedded:" <> str}
+          other -> other
+        end
+      end
     end
 
     test "cast_input_array calls overridden cast_input for each element" do
@@ -540,6 +548,15 @@ defmodule Ash.Test.Type.NewTypeTest do
 
     test "dump_to_embedded_array handles nil" do
       assert {:ok, nil} = Ash.Type.dump_to_embedded({:array, TaggedString}, nil)
+    end
+
+    test "cast_from_embedded_array calls overridden cast_from_embedded for each element" do
+      assert {:ok, ["from_embedded:hello", "from_embedded:world"]} =
+               Ash.Type.cast_from_embedded({:array, TaggedString}, ["hello", "world"])
+    end
+
+    test "cast_from_embedded_array handles nil" do
+      assert {:ok, nil} = Ash.Type.cast_from_embedded({:array, TaggedString}, nil)
     end
   end
 end

--- a/test/type/struct_test.exs
+++ b/test/type/struct_test.exs
@@ -6,6 +6,7 @@ defmodule Type.StructTest do
   use ExUnit.Case, async: true
 
   alias Ash.Test.Domain, as: Domain
+  alias Ash.Test.DumpTestType
 
   defmodule Metadata do
     defstruct [:foo, :bar, not_nil_by_default: "foo"]
@@ -494,5 +495,125 @@ defmodule Type.StructTest do
     assert result.__meta__.state == :loaded
     assert result.name == "fred"
     assert result.title == "title"
+  end
+
+  describe "dump_to_embedded" do
+    defmodule DumpMetadata do
+      defstruct [:name, :val]
+    end
+
+    test "recursively calls dump_to_embedded on field types" do
+      constraints = [
+        instance_of: DumpMetadata,
+        fields: [
+          name: [type: :string],
+          val: [type: DumpTestType]
+        ]
+      ]
+
+      assert {:ok, %{name: "hello", val: "embedded:world"}} =
+               Ash.Type.dump_to_embedded(
+                 Ash.Type.Struct,
+                 %DumpMetadata{name: "hello", val: "world"},
+                 constraints
+               )
+    end
+
+    test "uses dump_to_embedded not dump_to_native on fields" do
+      constraints = [
+        instance_of: DumpMetadata,
+        fields: [
+          val: [type: DumpTestType]
+        ]
+      ]
+
+      value = %DumpMetadata{val: "test"}
+
+      {:ok, native_result} = Ash.Type.dump_to_native(Ash.Type.Struct, value, constraints)
+      {:ok, embedded_result} = Ash.Type.dump_to_embedded(Ash.Type.Struct, value, constraints)
+
+      assert native_result[:val] == "native:test"
+      assert embedded_result[:val] == "embedded:test"
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} =
+               Ash.Type.dump_to_embedded(Ash.Type.Struct, nil, instance_of: DumpMetadata)
+    end
+
+    test "returns error without instance_of" do
+      assert :error =
+               Ash.Type.dump_to_embedded(
+                 Ash.Type.Struct,
+                 %DumpMetadata{name: "test"},
+                 fields: [name: [type: :string]]
+               )
+    end
+
+    test "returns error for non-map values" do
+      assert :error =
+               Ash.Type.dump_to_embedded(
+                 Ash.Type.Struct,
+                 "string",
+                 instance_of: DumpMetadata
+               )
+    end
+
+    test "handles missing fields gracefully" do
+      constraints = [
+        instance_of: DumpMetadata,
+        fields: [
+          name: [type: :string],
+          val: [type: DumpTestType]
+        ]
+      ]
+
+      assert {:ok, %{name: "hello"}} =
+               Ash.Type.dump_to_embedded(
+                 Ash.Type.Struct,
+                 %DumpMetadata{name: "hello", val: nil},
+                 constraints
+               )
+    end
+  end
+
+  describe "dump/cast round-trip" do
+    test "dump_to_native then cast_stored preserves data" do
+      constraints = [
+        instance_of: Metadata,
+        fields: [
+          foo: [type: :string],
+          bar: [type: :integer]
+        ]
+      ]
+
+      original = %Metadata{foo: "hello", bar: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Struct, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Struct, dumped, constraints)
+      assert restored.foo == original.foo
+      assert restored.bar == original.bar
+    end
+
+    test "dump_to_native then cast_stored with string keys round-trips" do
+      constraints = [
+        instance_of: Metadata,
+        fields: [
+          foo: [type: :string],
+          bar: [type: :integer]
+        ]
+      ]
+
+      original = %Metadata{foo: "hello", bar: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Struct, original, constraints)
+
+      # Simulate stored data having string keys
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Struct, string_keyed, constraints)
+      assert restored.foo == original.foo
+      assert restored.bar == original.bar
+    end
   end
 end

--- a/test/type/struct_test.exs
+++ b/test/type/struct_test.exs
@@ -577,6 +577,62 @@ defmodule Type.StructTest do
     end
   end
 
+  describe "cast_from_embedded" do
+    test "recursively calls cast_from_embedded on field types" do
+      constraints = [
+        instance_of: Metadata,
+        fields: [
+          foo: [type: DumpTestType],
+          bar: [type: :integer]
+        ]
+      ]
+
+      assert {:ok, restored} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Struct,
+                 %{foo: "embedded:hello", bar: 42},
+                 constraints
+               )
+
+      assert restored.foo == "hello"
+      assert restored.bar == 42
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} =
+               Ash.Type.cast_from_embedded(Ash.Type.Struct, nil, instance_of: Metadata)
+    end
+
+    test "returns error for non-map values" do
+      assert :error =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Struct,
+                 "string",
+                 instance_of: Metadata
+               )
+    end
+
+    test "handles string keys" do
+      constraints = [
+        instance_of: Metadata,
+        fields: [
+          foo: [type: DumpTestType],
+          bar: [type: :integer]
+        ]
+      ]
+
+      assert {:ok, restored} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Struct,
+                 %{"foo" => "embedded:hello", "bar" => 42},
+                 constraints
+               )
+
+      assert restored.foo == "hello"
+      assert restored.bar == 42
+    end
+  end
+
   describe "dump/cast round-trip" do
     test "dump_to_native then cast_stored preserves data" do
       constraints = [
@@ -612,6 +668,45 @@ defmodule Type.StructTest do
       string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
 
       assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Struct, string_keyed, constraints)
+      assert restored.foo == original.foo
+      assert restored.bar == original.bar
+    end
+
+    test "dump_to_embedded then cast_from_embedded preserves data" do
+      constraints = [
+        instance_of: Metadata,
+        fields: [
+          foo: [type: :string],
+          bar: [type: :integer]
+        ]
+      ]
+
+      original = %Metadata{foo: "hello", bar: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Struct, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_from_embedded(Ash.Type.Struct, dumped, constraints)
+      assert restored.foo == original.foo
+      assert restored.bar == original.bar
+    end
+
+    test "dump_to_embedded then cast_from_embedded with string keys round-trips" do
+      constraints = [
+        instance_of: Metadata,
+        fields: [
+          foo: [type: :string],
+          bar: [type: :integer]
+        ]
+      ]
+
+      original = %Metadata{foo: "hello", bar: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Struct, original, constraints)
+
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} =
+               Ash.Type.cast_from_embedded(Ash.Type.Struct, string_keyed, constraints)
+
       assert restored.foo == original.foo
       assert restored.bar == original.bar
     end

--- a/test/type/tuple_test.exs
+++ b/test/type/tuple_test.exs
@@ -6,6 +6,7 @@ defmodule Ash.Type.TupleTest do
   use ExUnit.Case, async: true
 
   alias Ash.Test.Domain, as: Domain
+  alias Ash.Test.DumpTestType
 
   defmodule TupleWithFields do
     use Ash.Type.NewType,
@@ -157,5 +158,153 @@ defmodule Ash.Type.TupleTest do
                path: [:metadata]
              }
            ] = changeset.errors
+  end
+
+  describe "dump_to_native" do
+    test "recursively dumps field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "native:hello", count: 42}} =
+               Ash.Type.dump_to_native(Ash.Type.Tuple, {"hello", 42}, constraints)
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} =
+               Ash.Type.dump_to_native(Ash.Type.Tuple, nil, fields: [foo: [type: :string]])
+    end
+
+    test "returns error for wrong tuple size" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            a: [type: :string],
+            b: [type: :string]
+          ]
+        )
+
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Tuple, {"only_one"}, constraints)
+    end
+
+    test "returns error for non-tuple values" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple, fields: [a: [type: :string]])
+
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Tuple, "string", constraints)
+      assert :error = Ash.Type.dump_to_native(Ash.Type.Tuple, %{a: "map"}, constraints)
+    end
+
+    test "handles nil field values" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: :string],
+            age: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: nil, age: nil}} =
+               Ash.Type.dump_to_native(Ash.Type.Tuple, {nil, nil}, constraints)
+    end
+  end
+
+  describe "dump_to_embedded" do
+    test "recursively calls dump_to_embedded on field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, %{name: "embedded:hello", count: 42}} =
+               Ash.Type.dump_to_embedded(Ash.Type.Tuple, {"hello", 42}, constraints)
+    end
+
+    test "uses dump_to_embedded not dump_to_native on fields" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            val: [type: DumpTestType]
+          ]
+        )
+
+      {:ok, native_result} =
+        Ash.Type.dump_to_native(Ash.Type.Tuple, {"test"}, constraints)
+
+      {:ok, embedded_result} =
+        Ash.Type.dump_to_embedded(Ash.Type.Tuple, {"test"}, constraints)
+
+      assert native_result[:val] == "native:test"
+      assert embedded_result[:val] == "embedded:test"
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} =
+               Ash.Type.dump_to_embedded(Ash.Type.Tuple, nil, fields: [foo: [type: :string]])
+    end
+
+    test "returns error for non-tuple values" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple, fields: [a: [type: :string]])
+
+      assert :error = Ash.Type.dump_to_embedded(Ash.Type.Tuple, "string", constraints)
+    end
+
+    test "returns error for wrong tuple size" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            a: [type: :string],
+            b: [type: :string]
+          ]
+        )
+
+      assert :error = Ash.Type.dump_to_embedded(Ash.Type.Tuple, {"only_one"}, constraints)
+    end
+  end
+
+  describe "dump/cast round-trip" do
+    test "dump_to_native then cast_stored preserves data" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = {"hello", 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Tuple, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Tuple, dumped, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_native then cast_stored with string keys round-trips" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = {"hello", 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_native(Ash.Type.Tuple, original, constraints)
+
+      # Simulate stored data having string keys
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Tuple, string_keyed, constraints)
+      assert restored == original
+    end
   end
 end

--- a/test/type/tuple_test.exs
+++ b/test/type/tuple_test.exs
@@ -270,6 +270,54 @@ defmodule Ash.Type.TupleTest do
     end
   end
 
+  describe "cast_from_embedded" do
+    test "recursively calls cast_from_embedded on field types" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, {"hello", 42}} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Tuple,
+                 %{name: "embedded:hello", count: 42},
+                 constraints
+               )
+    end
+
+    test "handles nil" do
+      assert {:ok, nil} =
+               Ash.Type.cast_from_embedded(Ash.Type.Tuple, nil, fields: [foo: [type: :string]])
+    end
+
+    test "returns error for non-map values" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple, fields: [a: [type: :string]])
+
+      assert :error = Ash.Type.cast_from_embedded(Ash.Type.Tuple, "string", constraints)
+    end
+
+    test "handles string keys" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: DumpTestType],
+            count: [type: :integer]
+          ]
+        )
+
+      assert {:ok, {"hello", 42}} =
+               Ash.Type.cast_from_embedded(
+                 Ash.Type.Tuple,
+                 %{"name" => "embedded:hello", "count" => 42},
+                 constraints
+               )
+    end
+  end
+
   describe "dump/cast round-trip" do
     test "dump_to_native then cast_stored preserves data" do
       {:ok, constraints} =
@@ -304,6 +352,43 @@ defmodule Ash.Type.TupleTest do
       string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
 
       assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Tuple, string_keyed, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_embedded then cast_from_embedded preserves data" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = {"hello", 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Tuple, original, constraints)
+      assert {:ok, restored} = Ash.Type.cast_from_embedded(Ash.Type.Tuple, dumped, constraints)
+      assert restored == original
+    end
+
+    test "dump_to_embedded then cast_from_embedded with string keys round-trips" do
+      {:ok, constraints} =
+        Ash.Type.init(Ash.Type.Tuple,
+          fields: [
+            name: [type: :string],
+            count: [type: :integer]
+          ]
+        )
+
+      original = {"hello", 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Tuple, original, constraints)
+
+      string_keyed = Map.new(dumped, fn {k, v} -> {to_string(k), v} end)
+
+      assert {:ok, restored} =
+               Ash.Type.cast_from_embedded(Ash.Type.Tuple, string_keyed, constraints)
+
       assert restored == original
     end
   end

--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -7,6 +7,7 @@ defmodule Ash.Test.Filter.UnionTest do
   use ExUnit.Case, async: true
 
   alias Ash.Test.Domain, as: Domain
+  alias Ash.Test.DumpTestType
 
   defmodule Foo do
     use Ash.Resource, data_layer: :embedded
@@ -789,6 +790,97 @@ defmodule Ash.Test.Filter.UnionTest do
     test "handles nil" do
       assert {:ok, nil} =
                Ash.Type.cast_stored(Ash.Type.Union, nil, integration_constraints())
+    end
+  end
+
+  describe "dump_to_embedded" do
+    test "uses dump_to_embedded on inner value with type_and_value storage" do
+      constraints = [
+        types: [
+          custom: [type: DumpTestType]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      union = %Ash.Union{type: :custom, value: "hello"}
+
+      {:ok, native_result} = Ash.Type.dump_to_native(Ash.Type.Union, union, constraints)
+      {:ok, embedded_result} = Ash.Type.dump_to_embedded(Ash.Type.Union, union, constraints)
+
+      assert native_result["value"] == "native:hello"
+      assert embedded_result["value"] == "embedded:hello"
+    end
+
+    test "uses dump_to_embedded on inner value with map_with_tag storage" do
+      constraints = [
+        storage: :map_with_tag,
+        types: [
+          foo: [
+            type: :map,
+            tag: :type,
+            tag_value: :foo
+          ]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      union = %Ash.Union{type: :foo, value: %{type: :foo, data: "test"}}
+
+      {:ok, native_result} = Ash.Type.dump_to_native(Ash.Type.Union, union, constraints)
+      {:ok, embedded_result} = Ash.Type.dump_to_embedded(Ash.Type.Union, union, constraints)
+
+      # Both should produce maps - the tag should be preserved
+      assert is_map(native_result)
+      assert is_map(embedded_result)
+      assert native_result[:type] == :foo || native_result["type"] == :foo
+    end
+
+    test "handles nil" do
+      constraints = [
+        types: [
+          custom: [type: DumpTestType]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      assert {:ok, nil} = Ash.Type.dump_to_embedded(Ash.Type.Union, nil, constraints)
+    end
+
+    test "returns error for non-union values" do
+      constraints = [
+        types: [
+          custom: [type: DumpTestType]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      assert :error = Ash.Type.dump_to_embedded(Ash.Type.Union, "string", constraints)
+    end
+
+    test "round-trips through dump_to_embedded and cast_stored" do
+      constraints = [
+        types: [
+          int: [type: :integer],
+          string: [type: :string]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      union = %Ash.Union{type: :int, value: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Union, union, constraints)
+      assert {:ok, restored} = Ash.Type.cast_stored(Ash.Type.Union, dumped, constraints)
+      assert %Ash.Union{type: :int, value: 42} = restored
     end
   end
 

--- a/test/type/union_test.exs
+++ b/test/type/union_test.exs
@@ -884,6 +884,89 @@ defmodule Ash.Test.Filter.UnionTest do
     end
   end
 
+  describe "cast_from_embedded" do
+    test "uses cast_from_embedded on inner value with type_and_value storage" do
+      constraints = [
+        types: [
+          custom: [type: DumpTestType]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      embedded_value = %{"type" => "custom", "value" => "embedded:hello"}
+
+      assert {:ok, %Ash.Union{type: :custom, value: "hello"}} =
+               Ash.Type.cast_from_embedded(Ash.Type.Union, embedded_value, constraints)
+    end
+
+    test "uses cast_from_embedded on inner value with map_with_tag storage" do
+      constraints = [
+        storage: :map_with_tag,
+        types: [
+          foo: [
+            type: :map,
+            tag: :type,
+            tag_value: :foo
+          ]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      embedded_value = %{"type" => "foo", "data" => "test"}
+
+      assert {:ok, %Ash.Union{type: :foo}} =
+               Ash.Type.cast_from_embedded(Ash.Type.Union, embedded_value, constraints)
+    end
+
+    test "handles nil" do
+      constraints = [
+        types: [
+          custom: [type: DumpTestType]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      assert {:ok, nil} = Ash.Type.cast_from_embedded(Ash.Type.Union, nil, constraints)
+    end
+
+    test "returns error for non-map values" do
+      constraints = [
+        types: [
+          custom: [type: DumpTestType]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      assert :error = Ash.Type.cast_from_embedded(Ash.Type.Union, "string", constraints)
+    end
+
+    test "round-trips through dump_to_embedded and cast_from_embedded" do
+      constraints = [
+        types: [
+          int: [type: :integer],
+          string: [type: :string]
+        ]
+      ]
+
+      {:ok, %{constraints: constraints}} =
+        Ash.Type.set_type_transformation(%{type: Ash.Type.Union, constraints: constraints})
+
+      union = %Ash.Union{type: :int, value: 42}
+
+      assert {:ok, dumped} = Ash.Type.dump_to_embedded(Ash.Type.Union, union, constraints)
+      assert {:ok, restored} = Ash.Type.cast_from_embedded(Ash.Type.Union, dumped, constraints)
+      assert %Ash.Union{type: :int, value: 42} = restored
+    end
+  end
+
   test "it fails when attempting to define a resource using a union with invalid constraints" do
     assert_raise Spark.Error.DslError, ~r/required :second option not found/, fn ->
       defmodule FailingExampleMissingSecond do


### PR DESCRIPTION
Round-trips embedded data through types whose embedded format differs from their native format.

Before: an embedded resource attribute typed as :binary (or any type where dump_to_embedded ≠ dump_to_native) wouldn't survive a save/load cycle — it was dumped with one encoding and read back with another.

Adds a cast_from_embedded/2 callback (with array variant) as the reverse of dump_to_embedded/2, implements it on :binary and the composite types (map, struct, tuple, keyword, union), and routes embedded-resource reads through it. Defaults to cast_stored/2, so custom types keep working unchanged.

# Contributor checklist


- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

