### PR TITLE
Feat/ash info manifest

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,4 +60,11 @@ if config_env() == :test do
   config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
   config :ash, Ash.Type.UUIDv7, match_v4_uuids?: true
+
+  # Manifest tests use a dedicated otp_app so the generator only walks
+  # the manifest test domain — the other :ash test domains predate the
+  # `enforce_public_accept?` invariant and would fail validation.
+  config :ash_manifest_test, :ash_domains, [
+    Ash.Test.Manifest.Domain
+  ]
 end

--- a/lib/ash/info.ex
+++ b/lib/ash/info.ex
@@ -55,6 +55,18 @@ defmodule Ash.Info do
   end
 
   @doc """
+  Generate an `%Ash.Info.Manifest{}` describing the application's public Ash
+  surface — reachable resources, named types, and action entrypoints.
+
+  Delegates to `Ash.Info.Manifest.generate/1`. See that module's docs for the
+  full list of options (action filtering, overrides, private-field visibility).
+  """
+  @spec manifest(keyword()) :: {:ok, Ash.Info.Manifest.t()} | {:error, term()}
+  def manifest(opts) do
+    Ash.Info.Manifest.generate(opts)
+  end
+
+  @doc """
   Returns a list of extensions in use by all the domains and resources in the
   given application.
   """

--- a/lib/ash/info/manifest.ex
+++ b/lib/ash/info/manifest.ex
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest do
+  @moduledoc """
+  Generates a language-agnostic API specification from Ash resources and actions.
+
+  Given a list of `{resource, action_name}` tuples or an OTP app, traverses the
+  type graph to find all reachable resources and types, producing structured IR
+  (Elixir structs) that can also be serialized to JSON.
+  """
+
+  alias Ash.Info.Manifest.{Entrypoint, Resource}
+
+  @schema_version "1.0.0"
+
+  @type t :: %__MODULE__{
+          resources: [Resource.t()],
+          types: [Ash.Info.Manifest.Type.t()],
+          entrypoints: [Entrypoint.t()]
+        }
+
+  @type resource_lookup :: %{atom() => Resource.t()}
+  @type action_lookup :: %{{atom(), atom()} => Ash.Info.Manifest.Action.t()}
+  @type type_lookup :: %{atom() => Ash.Info.Manifest.Type.t()}
+
+  defstruct resources: [],
+            types: [],
+            entrypoints: []
+
+  @doc """
+  The schema version of the manifest's JSON serialization format.
+
+  Bumped when the JSON output schema in `Ash.Info.Manifest.JsonSerializer`
+  changes in a way downstream tools need to detect.
+  """
+  @spec schema_version() :: String.t()
+  def schema_version, do: @schema_version
+
+  @doc """
+  Generate an API specification for the given OTP app.
+
+  ## Options
+
+    * `:otp_app` - The OTP app to scan for Ash domains and resources (required)
+    * `:action_entrypoints` - Optional list of `{resource_module, action_name}` tuples
+      used as entrypoints for deriving the spec. When omitted, all public actions
+      across all domains are included.
+  """
+  @spec generate(keyword()) :: {:ok, t()} | {:error, term()}
+  def generate(opts) do
+    Ash.Info.Manifest.Generator.generate(opts)
+  end
+
+  @doc """
+  Builds a resource lookup map from the spec, keyed by resource module.
+  """
+  @spec resource_lookup(t()) :: resource_lookup()
+  def resource_lookup(%__MODULE__{resources: resources}) do
+    Map.new(resources, fn r -> {r.module, r} end)
+  end
+
+  @doc """
+  Builds an action lookup map from the spec, keyed by `{resource_module, action_name}`.
+  """
+  @spec action_lookup(t()) :: action_lookup()
+  def action_lookup(%__MODULE__{entrypoints: entrypoints}) do
+    Map.new(entrypoints, fn e -> {{e.resource, e.action.name}, e.action} end)
+  end
+
+  @doc """
+  Builds a type lookup map from the spec, keyed by named type module.
+
+  Each entry is the fully-resolved `%Ash.Info.Manifest.Type{}` for a named type
+  (Ash.Type.Enum implementations and Ash.Type.NewType subtypes) referenced
+  somewhere in the reachable type graph.
+  """
+  @spec type_lookup(t()) :: type_lookup()
+  def type_lookup(%__MODULE__{types: types}) do
+    Map.new(types, fn type -> {type.module, type} end)
+  end
+
+  @doc """
+  Generates a spec and returns the resource lookup map directly.
+  """
+  @spec generate_resource_lookup(keyword()) :: {:ok, resource_lookup()} | {:error, term()}
+  def generate_resource_lookup(opts) do
+    {:ok, spec} = generate(opts)
+    {:ok, resource_lookup(spec)}
+  end
+
+  @doc "Looks up a resource by module. Returns nil if not found."
+  @spec get_resource(resource_lookup(), atom()) :: Resource.t() | nil
+  def get_resource(resource_lookup, module) when is_map(resource_lookup) do
+    Map.get(resource_lookup, module)
+  end
+
+  @doc "Looks up a resource by module. Raises if not found."
+  @spec get_resource!(resource_lookup(), atom()) :: Resource.t()
+  def get_resource!(resource_lookup, module) when is_map(resource_lookup) do
+    case Map.get(resource_lookup, module) do
+      %Resource{} = r -> r
+      nil -> raise "Resource #{inspect(module)} not found in resource lookup"
+    end
+  end
+
+  @doc "Checks if a resource exists in the lookup."
+  @spec has_resource?(resource_lookup(), atom()) :: boolean()
+  def has_resource?(resource_lookup, module) when is_map(resource_lookup) do
+    Map.has_key?(resource_lookup, module)
+  end
+
+  @doc "Gets a field by resource module and field name."
+  @spec get_field(resource_lookup(), atom(), atom()) :: Ash.Info.Manifest.Field.t() | nil
+  def get_field(resource_lookup, resource_module, field_name) do
+    with %Resource{} = r <- Map.get(resource_lookup, resource_module) do
+      Resource.get_field(r, field_name)
+    end
+  end
+
+  @doc "Gets a relationship by resource module and relationship name."
+  @spec get_relationship(resource_lookup(), atom(), atom()) ::
+          Ash.Info.Manifest.Relationship.t() | nil
+  def get_relationship(resource_lookup, resource_module, rel_name) do
+    with %Resource{} = r <- Map.get(resource_lookup, resource_module) do
+      Resource.get_relationship(r, rel_name)
+    end
+  end
+
+  @doc """
+  Gets a field or relationship by name, checking fields first.
+
+  Returns `%Ash.Info.Manifest.Field{}`, `%Ash.Info.Manifest.Relationship{}`, or nil.
+  """
+  @spec get_field_or_relationship(resource_lookup(), atom(), atom()) ::
+          Ash.Info.Manifest.Field.t() | Ash.Info.Manifest.Relationship.t() | nil
+  def get_field_or_relationship(resource_lookup, resource_module, name) do
+    case get_field(resource_lookup, resource_module, name) do
+      %Ash.Info.Manifest.Field{} = field -> field
+      nil -> get_relationship(resource_lookup, resource_module, name)
+    end
+  end
+
+  @doc "Gets an action by resource module and action name from an action lookup."
+  @spec get_action(action_lookup(), atom(), atom()) :: Ash.Info.Manifest.Action.t() | nil
+  def get_action(action_lookup, resource_module, action_name) do
+    Map.get(action_lookup, {resource_module, action_name})
+  end
+
+  @doc "Looks up a named type's full definition by module. Returns nil if not found."
+  @spec get_type(type_lookup(), atom()) :: Ash.Info.Manifest.Type.t() | nil
+  def get_type(type_lookup, module) when is_map(type_lookup) and is_atom(module) do
+    Map.get(type_lookup, module)
+  end
+
+  @doc """
+  Looks up a named type's full definition by module. Raises if not found.
+
+  A miss indicates a reachability bug: the type was referenced via `:type_ref`
+  somewhere in the type graph but was never registered during spec generation.
+  Reachability analysis (`Ash.Info.Manifest.Generator.Reachability`) should have
+  collected it as a standalone type.
+  """
+  @spec get_type!(type_lookup(), atom()) :: Ash.Info.Manifest.Type.t()
+  def get_type!(type_lookup, module) when is_map(type_lookup) and is_atom(module) do
+    case Map.get(type_lookup, module) do
+      %Ash.Info.Manifest.Type{} = t ->
+        t
+
+      nil ->
+        raise """
+        Named type #{inspect(module)} not found in type lookup.
+
+        This indicates a reachability bug — the type was referenced via :type_ref
+        somewhere in the spec but was not collected as a standalone type during
+        generation. Check `Ash.Info.Manifest.Generator.Reachability.find_reachable/2`.
+        """
+    end
+  end
+
+  @doc "Gets an identity by resource module and identity name."
+  @spec get_identity(resource_lookup(), atom(), atom()) :: %{keys: [atom()]} | nil
+  def get_identity(resource_lookup, resource_module, identity_name) do
+    with %Resource{} = r <- Map.get(resource_lookup, resource_module) do
+      Resource.get_identity(r, identity_name)
+    end
+  end
+
+  @doc "Gets the primary key field names by resource module."
+  @spec primary_key(resource_lookup(), atom()) :: [atom()]
+  def primary_key(resource_lookup, resource_module) do
+    case Map.get(resource_lookup, resource_module) do
+      %Resource{primary_key: pk} -> pk
+      nil -> []
+    end
+  end
+end

--- a/lib/ash/info/manifest/action.ex
+++ b/lib/ash/info/manifest/action.ex
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Action do
+  @moduledoc """
+  Represents a resource action in the API specification.
+  """
+
+  @type action_type :: :read | :create | :update | :destroy | :action
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          type: action_type(),
+          description: String.t() | nil,
+          primary?: boolean(),
+          get?: boolean(),
+          arguments: [Ash.Info.Manifest.Argument.t()],
+          accept: [atom()] | nil,
+          require_attributes: [atom()] | nil,
+          allow_nil_input: [atom()] | nil,
+          metadata: [Ash.Info.Manifest.Metadata.t()],
+          returns: Ash.Info.Manifest.Type.t() | nil,
+          pagination: Ash.Info.Manifest.Pagination.t() | nil
+        }
+
+  defstruct [
+    :name,
+    :type,
+    :description,
+    :primary?,
+    :get?,
+    :arguments,
+    :accept,
+    :require_attributes,
+    :allow_nil_input,
+    :metadata,
+    :returns,
+    :pagination
+  ]
+end

--- a/lib/ash/info/manifest/argument.ex
+++ b/lib/ash/info/manifest/argument.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Argument do
+  @moduledoc """
+  Represents an action argument or calculation argument in the API specification.
+  """
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          type: Ash.Info.Manifest.Type.t(),
+          allow_nil?: boolean(),
+          has_default?: boolean(),
+          description: String.t() | nil,
+          sensitive?: boolean()
+        }
+
+  defstruct [
+    :name,
+    :type,
+    :allow_nil?,
+    :has_default?,
+    :description,
+    :sensitive?
+  ]
+end

--- a/lib/ash/info/manifest/entrypoint.ex
+++ b/lib/ash/info/manifest/entrypoint.ex
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Entrypoint do
+  @moduledoc """
+  Represents an action entrypoint in the API specification.
+
+  Each entrypoint pairs a resource module with an action definition,
+  representing an operation that clients can invoke.
+
+  The `config` map carries extension-specific metadata, namespaced by
+  extension key (e.g., `config.ash_typescript`). The generator passes
+  this through opaquely — only the extension that populated it reads it.
+  """
+
+  @type t :: %__MODULE__{
+          resource: atom(),
+          action: Ash.Info.Manifest.Action.t(),
+          config: map()
+        }
+
+  defstruct [:resource, :action, config: %{}]
+end

--- a/lib/ash/info/manifest/field.ex
+++ b/lib/ash/info/manifest/field.ex
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Field do
+  @moduledoc """
+  Represents a resource field (attribute, calculation, or aggregate) in the API specification.
+  """
+
+  @type kind :: :attribute | :calculation | :aggregate
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          kind: kind(),
+          type: Ash.Info.Manifest.Type.t(),
+          allow_nil?: boolean(),
+          writable?: boolean(),
+          has_default?: boolean(),
+          description: String.t() | nil,
+          filterable?: boolean(),
+          sortable?: boolean(),
+          primary_key?: boolean(),
+          sensitive?: boolean(),
+          select_by_default?: boolean(),
+          # For calculations only
+          arguments: [Ash.Info.Manifest.Argument.t()] | nil,
+          # For aggregates only
+          aggregate_kind: atom() | nil
+        }
+
+  defstruct [
+    :name,
+    :kind,
+    :type,
+    :allow_nil?,
+    :writable?,
+    :has_default?,
+    :description,
+    :filterable?,
+    :sortable?,
+    :primary_key?,
+    :sensitive?,
+    :select_by_default?,
+    :arguments,
+    :aggregate_kind
+  ]
+end

--- a/lib/ash/info/manifest/generator.ex
+++ b/lib/ash/info/manifest/generator.ex
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator do
+  @moduledoc """
+  Main pipeline for generating an `%Ash.Info.Manifest{}` from an OTP app's Ash domains.
+
+  Pipeline:
+  1. Discover domains and resources
+  2. Optionally filter to specified actions
+  3. Run reachability analysis
+  4. Build resource and type structs
+  5. Produce `%Ash.Info.Manifest{}`
+  """
+
+  alias Ash.Info.Manifest.Generator.{ActionBuilder, Reachability, ResourceBuilder, TypeResolver}
+  alias Ash.Info.Manifest.Validators
+
+  @doc """
+  Generate an API specification.
+
+  ## Options
+
+    * `:otp_app` - The OTP app to scan (required)
+    * `:action_entrypoints` - Optional list of action entrypoints. Each entry can be:
+      * `{resource_module, action_name}` — simple tuple (config defaults to `%{}`)
+      * `%{resource: module, action: atom, config: map}` — with extension-specific config
+      When omitted, all actions across all domains are included.
+    * `:overrides` - Optional keyword list of overrides:
+      * `:always` - Keyword list of items to always include regardless of reachability:
+        * `:resources` - List of resource modules. These are added as reachability roots
+          (with no action arguments traversed) so their field types and relationships
+          are also discovered.
+        * `:types` - List of Ash type modules to include as standalone types directly.
+
+  ## Visibility Options
+
+  By default, only items with `public?: true` are included. Set any of these to `true`
+  to also include private items:
+
+    * `:include_private_attributes?` - Include private attributes (default: `false`)
+    * `:include_private_calculations?` - Include private calculations (default: `false`)
+    * `:include_private_aggregates?` - Include private aggregates (default: `false`)
+    * `:include_private_relationships?` - Include private relationships (default: `false`)
+    * `:include_private_arguments?` - Include private action arguments (default: `false`)
+
+  ## Enforcement Options
+
+    * `:enforce_public_accept?` - When `true` (default), raises
+      `Ash.Info.Manifest.Error.NonPublicAccept` if any action entrypoint's accept
+      list contains non-public attributes. Set to `false` to disable this
+      check (e.g. for extensions that intentionally expose private
+      attributes to internal callers).
+  """
+  @visibility_keys [
+    :include_private_attributes?,
+    :include_private_calculations?,
+    :include_private_aggregates?,
+    :include_private_relationships?,
+    :include_private_arguments?
+  ]
+
+  @spec generate(keyword()) :: {:ok, Ash.Info.Manifest.t()} | {:error, term()}
+  def generate(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    action_filter = Keyword.get(opts, :action_entrypoints)
+    overrides = Keyword.get(opts, :overrides, [])
+    visibility_opts = Keyword.take(opts, @visibility_keys)
+    enforce_public_accept? = Keyword.get(opts, :enforce_public_accept?, true)
+
+    always_opts = Keyword.get(overrides, :always, [])
+    always_resources = Keyword.get(always_opts, :resources, [])
+    always_types = Keyword.get(always_opts, :types, [])
+
+    # Discover all domains and their resources
+    domains = Ash.Info.domains(otp_app)
+
+    # Normalize entrypoints and build resource → action_names map for reachability
+    normalized_entries = normalize_action_filter(action_filter)
+    resource_action_map = build_resource_action_map(domains, action_filter)
+
+    # Build reachability entries: when filtering by actions, pass {resource, action_names}
+    # so reachability only traverses arguments of included actions
+    reachability_entries =
+      if action_filter do
+        Enum.map(resource_action_map, fn {resource, action_names} ->
+          {resource, action_names || []}
+        end)
+      else
+        Map.keys(resource_action_map)
+      end
+
+    # Add always-resources as reachability roots with [] action names
+    # (include fields/relationships but no action arguments)
+    always_resource_entries = Enum.map(always_resources, &{&1, []})
+    reachability_entries = reachability_entries ++ always_resource_entries
+
+    # Run reachability analysis
+    {reachable_resources, standalone_types} =
+      Reachability.find_reachable(reachability_entries, visibility_opts)
+
+    # Merge always-resources and always-types into reachability results
+    reachable_resources = Enum.uniq(reachable_resources ++ always_resources)
+    standalone_types = Enum.uniq(standalone_types ++ always_types)
+
+    # Build resource specs (no actions — those live in entrypoints)
+    resources =
+      reachable_resources
+      |> Enum.sort_by(&Module.split/1)
+      |> Enum.map(fn resource ->
+        ResourceBuilder.build(resource, visibility_opts)
+      end)
+
+    # Build entrypoints — one per normalized entry (not per unique action)
+    entrypoints =
+      build_entrypoints(
+        normalized_entries,
+        resource_action_map,
+        visibility_opts,
+        enforce_public_accept?
+      )
+
+    # Build standalone type specs (full definitions, not references)
+    types =
+      standalone_types
+      |> Enum.sort_by(fn module ->
+        if is_atom(module) and Code.ensure_loaded?(module) == true do
+          Module.split(module)
+        else
+          [to_string(module)]
+        end
+      end)
+      |> Enum.map(fn type_module ->
+        TypeResolver.resolve_definition(type_module)
+      end)
+
+    {:ok,
+     %Ash.Info.Manifest{
+       resources: resources,
+       types: types,
+       entrypoints: entrypoints
+     }}
+  end
+
+  # Normalizes action_filter entries into {resource, action_name, config} triples.
+  # Returns nil when no filter (all actions included).
+  defp normalize_action_filter(nil), do: nil
+
+  defp normalize_action_filter(entries) when is_list(entries) do
+    Enum.map(entries, fn
+      {resource, action_name} ->
+        {resource, action_name, %{}}
+
+      %{resource: resource, action: action_name} = entry ->
+        {resource, action_name, Map.get(entry, :config, %{})}
+    end)
+  end
+
+  # Builds resource → unique action_names map for reachability.
+  defp build_resource_action_map(domains, nil) do
+    for domain <- domains,
+        resource <- Ash.Domain.Info.resources(domain),
+        reduce: %{} do
+      acc -> Map.put(acc, resource, nil)
+    end
+  end
+
+  defp build_resource_action_map(_domains, action_filter) when is_list(action_filter) do
+    Enum.reduce(action_filter, %{}, fn entry, map ->
+      {resource, action_name, _config} =
+        case entry do
+          {r, a} -> {r, a, %{}}
+          %{resource: r, action: a} -> {r, a, %{}}
+        end
+
+      Map.update(map, resource, [action_name], fn names ->
+        if action_name in names, do: names, else: [action_name | names]
+      end)
+    end)
+  end
+
+  # When no filter: one entrypoint per action on each resource
+  defp build_entrypoints(nil, resource_action_map, visibility_opts, enforce_public_accept?) do
+    resource_action_map
+    |> Enum.flat_map(fn {resource, _action_names} ->
+      resource
+      |> Ash.Resource.Info.actions()
+      |> Enum.map(fn action ->
+        if enforce_public_accept?, do: Validators.validate_entrypoint!(resource, action)
+
+        %Ash.Info.Manifest.Entrypoint{
+          resource: resource,
+          action: ActionBuilder.build(resource, action, visibility_opts)
+        }
+      end)
+    end)
+    |> Enum.sort_by(fn e -> {Module.split(e.resource), e.action.name} end)
+  end
+
+  # When filtered: one entrypoint per normalized entry (preserves duplicates with different configs)
+  defp build_entrypoints(
+         normalized_entries,
+         _resource_action_map,
+         visibility_opts,
+         enforce_public_accept?
+       ) do
+    normalized_entries
+    |> Enum.flat_map(fn {resource, action_name, config} ->
+      case Ash.Resource.Info.action(resource, action_name) do
+        nil ->
+          []
+
+        action ->
+          if enforce_public_accept?, do: Validators.validate_entrypoint!(resource, action)
+
+          [
+            %Ash.Info.Manifest.Entrypoint{
+              resource: resource,
+              action: ActionBuilder.build(resource, action, visibility_opts),
+              config: config
+            }
+          ]
+      end
+    end)
+    |> Enum.sort_by(fn e -> {Module.split(e.resource), e.action.name} end)
+  end
+end

--- a/lib/ash/info/manifest/generator/action_builder.ex
+++ b/lib/ash/info/manifest/generator/action_builder.ex
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.ActionBuilder do
+  @moduledoc """
+  Converts Ash action structs into `%Ash.Info.Manifest.Action{}` structs.
+  """
+
+  alias Ash.Info.Manifest.{Action, Argument, Metadata, Pagination}
+  alias Ash.Info.Manifest.Generator.TypeResolver
+
+  @doc """
+  Build an `%Ash.Info.Manifest.Action{}` from an Ash action struct.
+
+  ## Visibility Options
+
+    * `:include_private_arguments?` - Include private arguments (default: `false`)
+  """
+  @spec build(atom(), struct(), keyword()) :: Action.t()
+  def build(resource, action, visibility_opts \\ []) do
+    %Action{
+      name: action.name,
+      type: action.type,
+      description: Map.get(action, :description),
+      primary?: Map.get(action, :primary?, false),
+      get?: Map.get(action, :get?, false),
+      arguments: build_arguments(action, visibility_opts),
+      accept: build_accept(action),
+      require_attributes: build_require_attributes(action),
+      allow_nil_input: build_allow_nil_input(action),
+      metadata: build_metadata(resource, action),
+      returns: build_returns(action),
+      pagination: build_pagination(action)
+    }
+  end
+
+  defp build_arguments(action, visibility_opts) do
+    args =
+      if Keyword.get(visibility_opts, :include_private_arguments?, false) do
+        action.arguments
+      else
+        Enum.filter(action.arguments, & &1.public?)
+      end
+
+    Enum.map(args, &build_argument/1)
+  end
+
+  defp build_argument(arg) do
+    %Argument{
+      name: arg.name,
+      type: TypeResolver.resolve(arg.type, arg.constraints || []),
+      allow_nil?: arg.allow_nil?,
+      has_default?: not is_nil(arg.default),
+      description: Map.get(arg, :description),
+      sensitive?: Map.get(arg, :sensitive?, false)
+    }
+  end
+
+  defp build_accept(action) do
+    case Map.get(action, :accept) do
+      nil -> nil
+      accept when is_list(accept) -> accept
+    end
+  end
+
+  defp build_require_attributes(action) do
+    case Map.get(action, :require_attributes) do
+      nil -> nil
+      attrs when is_list(attrs) -> attrs
+    end
+  end
+
+  defp build_allow_nil_input(action) do
+    case Map.get(action, :allow_nil_input) do
+      nil -> nil
+      attrs when is_list(attrs) -> attrs
+    end
+  end
+
+  defp build_metadata(_resource, action) do
+    metadata_list = Map.get(action, :metadata, [])
+
+    Enum.map(metadata_list, fn meta ->
+      %Metadata{
+        name: meta.name,
+        type: TypeResolver.resolve(meta.type, meta.constraints || []),
+        allow_nil?: Map.get(meta, :allow_nil?, true),
+        description: Map.get(meta, :description)
+      }
+    end)
+  end
+
+  defp build_returns(%{type: :action} = action) do
+    case Map.get(action, :returns) do
+      nil ->
+        nil
+
+      return_type ->
+        TypeResolver.resolve(return_type, action.constraints || [])
+    end
+  end
+
+  defp build_returns(_action), do: nil
+
+  defp build_pagination(%{type: :read, get?: false} = action) do
+    case Map.get(action, :pagination) do
+      %{} = pagination ->
+        %Pagination{
+          offset?: Map.get(pagination, :offset?, false),
+          keyset?: Map.get(pagination, :keyset?, false),
+          required?: Map.get(pagination, :required?, false),
+          countable?: countable_to_boolean(Map.get(pagination, :countable, false)),
+          default_limit: Map.get(pagination, :default_limit),
+          max_page_size: Map.get(pagination, :max_page_size)
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp build_pagination(_action), do: nil
+
+  defp countable_to_boolean(true), do: true
+  defp countable_to_boolean(:by_default), do: true
+  defp countable_to_boolean(_), do: false
+end

--- a/lib/ash/info/manifest/generator/reachability.ex
+++ b/lib/ash/info/manifest/generator/reachability.ex
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.Reachability do
+  @moduledoc """
+  Discovers all reachable resources and standalone types by traversing the type graph
+  starting from a set of root resources.
+
+  Returns results in depth-first discovery order: dependencies appear before the
+  resources that reference them. This ordering is important for consumers that need
+  to declare types before they are referenced (e.g., Zod schema generation).
+
+  Handles cycle detection via a visited set to prevent infinite recursion.
+  """
+
+  alias Ash.Info.Manifest.Generator.TypeResolver
+
+  @doc """
+  Find all resources and standalone types reachable from the given resource modules.
+
+  Accepts either:
+  - A list of resource modules (traverses all fields, relationships, and public action arguments)
+  - A list of `{resource_module, [action_name]}` tuples (only traverses arguments of specified actions)
+
+  ## Visibility Options
+
+    * `:include_private_attributes?` - Traverse private attributes (default: `false`)
+    * `:include_private_calculations?` - Traverse private calculations (default: `false`)
+    * `:include_private_aggregates?` - Traverse private aggregates (default: `false`)
+    * `:include_private_relationships?` - Traverse private relationships (default: `false`)
+    * `:include_private_arguments?` - Traverse private action arguments (default: `false`)
+
+  Returns `{reachable_resources, standalone_types}` where both are lists of modules
+  in depth-first discovery order (dependencies before dependents).
+  """
+  @spec find_reachable([atom() | {atom(), [atom()]}], keyword()) :: {[atom()], [atom()]}
+  def find_reachable(resource_entries, visibility_opts \\ []) do
+    {resources, types, _visited} =
+      Enum.reduce(resource_entries, {[], [], MapSet.new()}, fn entry,
+                                                               {resources, types, visited} ->
+        {resource, action_names} = normalize_entry(entry)
+
+        if MapSet.member?(visited, resource) do
+          {resources, types, visited}
+        else
+          {found_resources, found_types, new_visited} =
+            traverse_resource(
+              resource,
+              MapSet.put(visited, resource),
+              action_names,
+              visibility_opts
+            )
+
+          {
+            resources ++ found_resources ++ [resource],
+            types ++ found_types,
+            new_visited
+          }
+        end
+      end)
+
+    {Enum.uniq(resources), Enum.uniq(types)}
+  end
+
+  defp normalize_entry({resource, action_names}) when is_atom(resource) and is_list(action_names),
+    do: {resource, action_names}
+
+  defp normalize_entry(resource) when is_atom(resource),
+    do: {resource, nil}
+
+  # action_names: nil means "traverse all public actions", list means "only these actions"
+  defp traverse_resource(resource, visited, action_names, visibility_opts) do
+    if is_resource?(resource) do
+      # Traverse fields (respecting visibility options)
+      fields = get_fields(resource, visibility_opts)
+
+      # Traverse relationships (respecting visibility options)
+      relationships = get_relationships(resource, visibility_opts)
+
+      # Walk fields
+      {field_resources, field_types, visited} =
+        Enum.reduce(fields, {[], [], visited}, fn field, {resources, types, visited} ->
+          {type, constraints} = get_field_type_and_constraints(field)
+
+          {found_r, found_t, new_visited} =
+            traverse_type(type, constraints, visited, visibility_opts)
+
+          {resources ++ found_r, types ++ found_t, new_visited}
+        end)
+
+      # Walk relationship destinations
+      {rel_resources, rel_types, visited} =
+        Enum.reduce(
+          relationships,
+          {field_resources, field_types, visited},
+          fn rel, {resources, types, visited} ->
+            destination = rel.destination
+
+            if MapSet.member?(visited, destination) do
+              {resources, types, visited}
+            else
+              new_visited = MapSet.put(visited, destination)
+              # Discovered resources only traverse fields/relationships, not action arguments
+              {found_r, found_t, newer_visited} =
+                traverse_resource(destination, new_visited, [], visibility_opts)
+
+              {
+                resources ++ found_r ++ [destination],
+                types ++ found_t,
+                newer_visited
+              }
+            end
+          end
+        )
+
+      # Walk action arguments
+      {arg_resources, arg_types, visited} =
+        traverse_action_arguments(
+          resource,
+          action_names,
+          rel_resources,
+          rel_types,
+          visited,
+          visibility_opts
+        )
+
+      {arg_resources, arg_types, visited}
+    else
+      {[], [], visited}
+    end
+  end
+
+  defp traverse_action_arguments(
+         resource,
+         action_names,
+         resources,
+         types,
+         visited,
+         visibility_opts
+       ) do
+    actions = get_actions_to_traverse(resource, action_names)
+    include_private_args? = Keyword.get(visibility_opts, :include_private_arguments?, false)
+
+    Enum.reduce(actions, {resources, types, visited}, fn action, {resources, types, visited} ->
+      args =
+        if include_private_args? do
+          action.arguments
+        else
+          Enum.filter(action.arguments, & &1.public?)
+        end
+
+      # Walk argument types
+      {resources, types, visited} =
+        Enum.reduce(args, {resources, types, visited}, fn arg, {resources, types, visited} ->
+          {type, constraints} = {arg.type, arg.constraints || []}
+
+          {found_r, found_t, new_visited} =
+            traverse_type(type, constraints, visited, visibility_opts)
+
+          {resources ++ found_r, types ++ found_t, new_visited}
+        end)
+
+      # Walk return type (generic actions declare a custom return type via :returns;
+      # CRUD actions return the resource itself, which is already reachable)
+      {resources, types, visited} =
+        traverse_action_returns(action, resources, types, visited, visibility_opts)
+
+      # Walk metadata field types (custom types in metadata fields need to be reachable)
+      traverse_action_metadata(action, resources, types, visited, visibility_opts)
+    end)
+  end
+
+  defp traverse_action_returns(action, resources, types, visited, visibility_opts) do
+    case Map.get(action, :returns) do
+      nil ->
+        {resources, types, visited}
+
+      return_type ->
+        return_constraints = Map.get(action, :constraints) || []
+
+        {found_r, found_t, new_visited} =
+          traverse_type(return_type, return_constraints, visited, visibility_opts)
+
+        {resources ++ found_r, types ++ found_t, new_visited}
+    end
+  end
+
+  defp traverse_action_metadata(action, resources, types, visited, visibility_opts) do
+    metadata = Map.get(action, :metadata) || []
+
+    Enum.reduce(metadata, {resources, types, visited}, fn meta, {resources, types, visited} ->
+      meta_type = Map.get(meta, :type)
+      meta_constraints = Map.get(meta, :constraints) || []
+
+      if meta_type do
+        {found_r, found_t, new_visited} =
+          traverse_type(meta_type, meta_constraints, visited, visibility_opts)
+
+        {resources ++ found_r, types ++ found_t, new_visited}
+      else
+        {resources, types, visited}
+      end
+    end)
+  end
+
+  defp get_actions_to_traverse(resource, nil) do
+    # nil means traverse all public actions
+    Ash.Resource.Info.actions(resource)
+    |> Enum.filter(&Map.get(&1, :public?, false))
+  end
+
+  defp get_actions_to_traverse(resource, action_names) when is_list(action_names) do
+    Enum.flat_map(action_names, fn name ->
+      case Ash.Resource.Info.action(resource, name) do
+        nil -> []
+        action -> [action]
+      end
+    end)
+  end
+
+  defp traverse_type(type, constraints, visited, visibility_opts) when is_list(constraints) do
+    {unwrapped_type, unwrapped_constraints} = TypeResolver.unwrap_new_type(type, constraints)
+
+    # Detect named type modules: NewTypes (type differs after unwrap) or enums
+    is_named = is_atom(type) and TypeResolver.named_type_module?(type)
+
+    if is_named and MapSet.member?(visited, type) do
+      # Cycle detected — stop traversal
+      {[], [], visited}
+    else
+      visited = if is_named, do: MapSet.put(visited, type), else: visited
+
+      {found_r, found_t, visited} =
+        traverse_unwrapped_type(unwrapped_type, unwrapped_constraints, visited, visibility_opts)
+
+      if is_named do
+        {found_r, [type | found_t], visited}
+      else
+        {found_r, found_t, visited}
+      end
+    end
+  end
+
+  defp traverse_type(_type, _constraints, visited, _visibility_opts) do
+    {[], [], visited}
+  end
+
+  defp traverse_unwrapped_type(unwrapped_type, constraints, visited, visibility_opts) do
+    case unwrapped_type do
+      {:array, inner_type} ->
+        items_constraints = Keyword.get(constraints, :items, [])
+        traverse_type(inner_type, items_constraints, visited, visibility_opts)
+
+      Ash.Type.Struct ->
+        instance_of = Keyword.get(constraints, :instance_of)
+
+        if instance_of && is_resource?(instance_of) do
+          traverse_resource_ref(instance_of, visited, visibility_opts)
+        else
+          traverse_field_constraints(constraints, visited, visibility_opts)
+        end
+
+      Ash.Type.Union ->
+        union_types = Keyword.get(constraints, :types, [])
+
+        Enum.reduce(union_types, {[], [], visited}, fn {_name, config},
+                                                       {resources, types, visited} ->
+          member_type = Keyword.get(config, :type)
+          member_constraints = Keyword.get(config, :constraints, [])
+
+          if member_type do
+            {found_r, found_t, new_visited} =
+              traverse_type(member_type, member_constraints, visited, visibility_opts)
+
+            {resources ++ found_r, types ++ found_t, new_visited}
+          else
+            {resources, types, visited}
+          end
+        end)
+
+      type when type in [Ash.Type.Map, Ash.Type.Keyword, Ash.Type.Tuple] ->
+        traverse_field_constraints(constraints, visited, visibility_opts)
+
+      type when is_atom(type) ->
+        cond do
+          is_resource?(type) ->
+            traverse_resource_ref(type, visited, visibility_opts)
+
+          Code.ensure_loaded?(type) == true ->
+            traverse_field_constraints(constraints, visited, visibility_opts)
+
+          true ->
+            {[], [], visited}
+        end
+
+      _ ->
+        {[], [], visited}
+    end
+  end
+
+  defp traverse_resource_ref(resource, visited, visibility_opts) do
+    if MapSet.member?(visited, resource) do
+      {[], [], visited}
+    else
+      new_visited = MapSet.put(visited, resource)
+      # Discovered resources only traverse fields/relationships, not action arguments
+      {found_r, found_t, newer_visited} =
+        traverse_resource(resource, new_visited, [], visibility_opts)
+
+      {found_r ++ [resource], found_t, newer_visited}
+    end
+  end
+
+  defp traverse_field_constraints(constraints, visited, visibility_opts) do
+    fields = Keyword.get(constraints, :fields)
+
+    if fields && is_list(fields) do
+      Enum.reduce(fields, {[], [], visited}, fn {_name, config}, {resources, types, visited} ->
+        field_type = Keyword.get(config, :type)
+        field_constraints = Keyword.get(config, :constraints, [])
+
+        if field_type do
+          {found_r, found_t, new_visited} =
+            traverse_type(field_type, field_constraints, visited, visibility_opts)
+
+          {resources ++ found_r, types ++ found_t, new_visited}
+        else
+          {resources, types, visited}
+        end
+      end)
+    else
+      {[], [], visited}
+    end
+  end
+
+  defp get_fields(resource, visibility_opts) do
+    include_private_attrs? = Keyword.get(visibility_opts, :include_private_attributes?, false)
+    include_private_calcs? = Keyword.get(visibility_opts, :include_private_calculations?, false)
+    include_private_aggs? = Keyword.get(visibility_opts, :include_private_aggregates?, false)
+
+    # If all three are the same (all public or all include-private), fetch in one call
+    if include_private_attrs? == include_private_calcs? and
+         include_private_calcs? == include_private_aggs? do
+      if include_private_attrs? do
+        Ash.Resource.Info.fields(resource, [:attributes, :aggregates, :calculations])
+      else
+        resource
+        |> Ash.Resource.Info.fields([:attributes, :aggregates, :calculations])
+        |> Enum.filter(& &1.public?)
+      end
+    else
+      # Mix-and-match: fetch each kind separately
+      attrs =
+        if include_private_attrs?,
+          do: Ash.Resource.Info.attributes(resource),
+          else: Ash.Resource.Info.public_attributes(resource)
+
+      calcs =
+        if include_private_calcs?,
+          do: Ash.Resource.Info.calculations(resource),
+          else: Ash.Resource.Info.public_calculations(resource)
+
+      aggs =
+        if include_private_aggs?,
+          do: Ash.Resource.Info.aggregates(resource),
+          else: Ash.Resource.Info.public_aggregates(resource)
+
+      Enum.concat([attrs, calcs, aggs])
+    end
+  end
+
+  defp get_relationships(resource, visibility_opts) do
+    if Keyword.get(visibility_opts, :include_private_relationships?, false) do
+      Ash.Resource.Info.relationships(resource)
+    else
+      Ash.Resource.Info.public_relationships(resource)
+    end
+  end
+
+  defp get_field_type_and_constraints(field) do
+    {Map.get(field, :type), Map.get(field, :constraints, []) || []}
+  end
+
+  defp is_resource?(module) when is_atom(module) do
+    Code.ensure_loaded?(module) == true and Ash.Resource.Info.resource?(module)
+  end
+
+  defp is_resource?(_), do: false
+end

--- a/lib/ash/info/manifest/generator/resource_builder.ex
+++ b/lib/ash/info/manifest/generator/resource_builder.ex
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.ResourceBuilder do
+  @moduledoc """
+  Converts an Ash resource module into an `%Ash.Info.Manifest.Resource{}` struct.
+  """
+
+  alias Ash.Info.Manifest.{Argument, Field, Relationship, Resource}
+  alias Ash.Info.Manifest.Generator.TypeResolver
+
+  @doc """
+  Build a `%Ash.Info.Manifest.Resource{}` from an Ash resource module.
+
+  Resources are pure type/shape definitions — actions live in entrypoints.
+
+  ## Visibility Options
+
+    * `:include_private_attributes?` - Include private attributes (default: `false`)
+    * `:include_private_calculations?` - Include private calculations (default: `false`)
+    * `:include_private_aggregates?` - Include private aggregates (default: `false`)
+    * `:include_private_relationships?` - Include private relationships (default: `false`)
+  """
+  @spec build(atom(), keyword()) :: Resource.t()
+  def build(resource, visibility_opts \\ []) do
+    %Resource{
+      name: resource_name(resource),
+      module: resource,
+      embedded?: Ash.Resource.Info.embedded?(resource),
+      primary_key: Ash.Resource.Info.primary_key(resource),
+      description: Ash.Resource.Info.description(resource),
+      fields: build_fields(resource, visibility_opts),
+      relationships: build_relationships(resource, visibility_opts),
+      identities: build_identities(resource),
+      multitenancy: build_multitenancy(resource)
+    }
+  end
+
+  defp build_fields(resource, visibility_opts) do
+    attributes = build_attributes(resource, visibility_opts)
+    calculations = build_calculations(resource, visibility_opts)
+    aggregates = build_aggregates(resource, visibility_opts)
+
+    Map.new(attributes ++ calculations ++ aggregates, fn field -> {field.name, field} end)
+  end
+
+  defp build_attributes(resource, visibility_opts) do
+    resource
+    |> get_attributes(visibility_opts)
+    |> Enum.map(fn attr ->
+      %Field{
+        name: attr.name,
+        kind: :attribute,
+        type: TypeResolver.resolve(attr.type, attr.constraints || []),
+        allow_nil?: attr.allow_nil?,
+        writable?: attr.writable?,
+        has_default?: not is_nil(attr.default),
+        description: Map.get(attr, :description),
+        filterable?: Map.get(attr, :filterable?, true),
+        sortable?: Map.get(attr, :sortable?, true),
+        primary_key?: attr.primary_key?,
+        sensitive?: Map.get(attr, :sensitive?, false),
+        select_by_default?: Map.get(attr, :select_by_default?, true)
+      }
+    end)
+  end
+
+  defp build_calculations(resource, visibility_opts) do
+    resource
+    |> get_calculations(visibility_opts)
+    |> Enum.filter(fn calc -> Map.get(calc, :field?, true) end)
+    |> Enum.map(fn calc ->
+      arguments =
+        Enum.map(calc.arguments, fn arg ->
+          %Argument{
+            name: arg.name,
+            type: TypeResolver.resolve(arg.type, arg.constraints || []),
+            allow_nil?: arg.allow_nil?,
+            has_default?: not is_nil(arg.default),
+            description: Map.get(arg, :description),
+            sensitive?: Map.get(arg, :sensitive?, false)
+          }
+        end)
+
+      %Field{
+        name: calc.name,
+        kind: :calculation,
+        type: TypeResolver.resolve(calc.type, calc.constraints || []),
+        allow_nil?: calc.allow_nil?,
+        writable?: false,
+        has_default?: false,
+        description: Map.get(calc, :description),
+        filterable?: Map.get(calc, :filterable?, true),
+        sortable?: Map.get(calc, :sortable?, true),
+        primary_key?: false,
+        sensitive?: Map.get(calc, :sensitive?, false),
+        select_by_default?: Map.get(calc, :select_by_default?, true),
+        arguments: arguments
+      }
+    end)
+  end
+
+  defp build_aggregates(resource, visibility_opts) do
+    resource
+    |> get_aggregates(visibility_opts)
+    |> Enum.map(fn aggregate ->
+      {type, constraints} = resolve_aggregate_type(resource, aggregate)
+
+      %Field{
+        name: aggregate.name,
+        kind: :aggregate,
+        type: TypeResolver.resolve(type, constraints),
+        allow_nil?: Map.get(aggregate, :include_nil?, false),
+        writable?: false,
+        has_default?: false,
+        description: Map.get(aggregate, :description),
+        filterable?: Map.get(aggregate, :filterable?, true),
+        sortable?: Map.get(aggregate, :sortable?, true),
+        primary_key?: false,
+        sensitive?: false,
+        select_by_default?: Map.get(aggregate, :select_by_default?, true),
+        aggregate_kind: aggregate.kind
+      }
+    end)
+  end
+
+  defp resolve_aggregate_type(resource, aggregate) do
+    field =
+      if aggregate.field do
+        related = Ash.Resource.Info.related(resource, aggregate.relationship_path)
+
+        if related do
+          Ash.Resource.Info.attribute(related, aggregate.field) ||
+            Ash.Resource.Info.calculation(related, aggregate.field)
+        end
+      end
+
+    field_type = if field, do: field.type
+    field_constraints = if field, do: Map.get(field, :constraints, []), else: []
+
+    case Ash.Query.Aggregate.kind_to_type(aggregate.kind, field_type, field_constraints) do
+      {:ok, type, constraints} -> {type, constraints}
+      _other -> {aggregate.type, aggregate.constraints || []}
+    end
+  end
+
+  defp build_relationships(resource, visibility_opts) do
+    resource
+    |> get_relationships(visibility_opts)
+    |> Map.new(fn rel ->
+      relationship = %Relationship{
+        name: rel.name,
+        type: relationship_type(rel),
+        cardinality: relationship_cardinality(rel),
+        destination: rel.destination,
+        allow_nil?: Map.get(rel, :allow_nil?, true),
+        description: Map.get(rel, :description),
+        filterable?: Map.get(rel, :filterable?, true),
+        sortable?: Map.get(rel, :sortable?, true)
+      }
+
+      {rel.name, relationship}
+    end)
+  end
+
+  defp relationship_type(%Ash.Resource.Relationships.HasMany{}), do: :has_many
+  defp relationship_type(%Ash.Resource.Relationships.HasOne{}), do: :has_one
+  defp relationship_type(%Ash.Resource.Relationships.BelongsTo{}), do: :belongs_to
+  defp relationship_type(%Ash.Resource.Relationships.ManyToMany{}), do: :many_to_many
+
+  defp relationship_cardinality(%Ash.Resource.Relationships.HasMany{}), do: :many
+  defp relationship_cardinality(%Ash.Resource.Relationships.ManyToMany{}), do: :many
+  defp relationship_cardinality(_), do: :one
+
+  defp build_identities(resource) do
+    resource
+    |> Ash.Resource.Info.identities()
+    |> Map.new(fn identity ->
+      {identity.name, %{keys: identity.keys}}
+    end)
+  end
+
+  defp build_multitenancy(resource) do
+    strategy = Ash.Resource.Info.multitenancy_strategy(resource)
+
+    if strategy do
+      %{
+        strategy: strategy,
+        global?: Ash.Resource.Info.multitenancy_global?(resource),
+        attribute: Ash.Resource.Info.multitenancy_attribute(resource)
+      }
+    else
+      nil
+    end
+  end
+
+  defp get_attributes(resource, visibility_opts) do
+    if Keyword.get(visibility_opts, :include_private_attributes?, false) do
+      Ash.Resource.Info.attributes(resource)
+    else
+      Ash.Resource.Info.public_attributes(resource)
+    end
+  end
+
+  defp get_calculations(resource, visibility_opts) do
+    if Keyword.get(visibility_opts, :include_private_calculations?, false) do
+      Ash.Resource.Info.calculations(resource)
+    else
+      Ash.Resource.Info.public_calculations(resource)
+    end
+  end
+
+  defp get_aggregates(resource, visibility_opts) do
+    if Keyword.get(visibility_opts, :include_private_aggregates?, false) do
+      Ash.Resource.Info.aggregates(resource)
+    else
+      Ash.Resource.Info.public_aggregates(resource)
+    end
+  end
+
+  defp get_relationships(resource, visibility_opts) do
+    if Keyword.get(visibility_opts, :include_private_relationships?, false) do
+      Ash.Resource.Info.relationships(resource)
+    else
+      Ash.Resource.Info.public_relationships(resource)
+    end
+  end
+
+  defp resource_name(module) do
+    module
+    |> Module.split()
+    |> List.last()
+  end
+end

--- a/lib/ash/info/manifest/generator/type_resolver.ex
+++ b/lib/ash/info/manifest/generator/type_resolver.ex
@@ -1,0 +1,419 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.TypeResolver do
+  @moduledoc """
+  Resolves Ash types into `%Ash.Info.Manifest.Type{}` structs.
+
+  Handles all Ash type variants: primitives, NewTypes, arrays, enums, unions,
+  embedded resources, structs, maps, keywords, tuples, and custom types.
+  """
+
+  alias Ash.Info.Manifest.Type
+
+  # Primitive type mapping: Ash module → {kind, name}
+  @primitives %{
+    Ash.Type.String => {:string, "String"},
+    Ash.Type.CiString => {:ci_string, "CiString"},
+    Ash.Type.Integer => {:integer, "Integer"},
+    Ash.Type.Float => {:float, "Float"},
+    Ash.Type.Decimal => {:decimal, "Decimal"},
+    Ash.Type.Boolean => {:boolean, "Boolean"},
+    Ash.Type.UUID => {:uuid, "UUID"},
+    Ash.Type.UUIDv7 => {:uuid, "UUIDv7"},
+    Ash.Type.Date => {:date, "Date"},
+    Ash.Type.Time => {:time, "Time"},
+    Ash.Type.TimeUsec => {:time_usec, "TimeUsec"},
+    Ash.Type.DateTime => {:datetime, "DateTime"},
+    Ash.Type.UtcDatetime => {:utc_datetime, "UtcDateTime"},
+    Ash.Type.UtcDatetimeUsec => {:utc_datetime_usec, "UtcDateTimeUsec"},
+    Ash.Type.NaiveDatetime => {:naive_datetime, "NaiveDateTime"},
+    Ash.Type.Duration => {:duration, "Duration"},
+    Ash.Type.Binary => {:binary, "Binary"},
+    Ash.Type.UrlEncodedBinary => {:binary, "UrlEncodedBinary"},
+    Ash.Type.Term => {:term, "Term"},
+    Ash.Type.Atom => {:atom, "Atom"},
+    Ash.Type.Module => {:atom, "Module"},
+    Ash.Type.File => {:term, "File"},
+    Ash.Type.Function => {:term, "Function"},
+    Ash.Type.Vector => {:term, "Vector"}
+  }
+
+  @doc """
+  Resolve an Ash type and its constraints into an `%Ash.Info.Manifest.Type{}`.
+
+  Named type modules (Ash.Type.Enum implementations and Ash.Type.NewType subtypes)
+  are resolved as `kind: :type_ref` references. Use `resolve_definition/1` to get
+  the full type definition for `spec.types`.
+  """
+  @spec resolve(term(), term()) :: Type.t()
+  def resolve(type, constraints \\ [])
+
+  def resolve(nil, _constraints) do
+    %Type{kind: :unknown, name: "Unknown", module: nil, constraints: []}
+  end
+
+  def resolve({:array, inner_type}, constraints) do
+    items_constraints = Keyword.get(constraints, :items, [])
+
+    %Type{
+      kind: :array,
+      name: "Array",
+      module: nil,
+      constraints: constraints,
+      item_type: resolve(inner_type, items_constraints)
+    }
+  end
+
+  def resolve(type, constraints) when is_atom(type) do
+    # Canonicalize atom shorthands (e.g. `:string`) to their module form
+    # (`Ash.Type.String`). For modules and unrecognized atoms, get_type/1
+    # returns the input unchanged.
+    type = Ash.Type.get_type(type)
+
+    case Map.get(@primitives, type) do
+      {:atom, name} ->
+        atom_or_enum(type, name, constraints)
+
+      {kind, name} ->
+        %Type{kind: kind, name: name, module: type, constraints: constraints}
+
+      nil ->
+        # Named type modules (enums and NewTypes) become references.
+        # Their full definitions live in spec.types.
+        if named_type_module?(type) do
+          %Type{
+            kind: :type_ref,
+            name: type_name_from_module(type),
+            module: type,
+            constraints: constraints
+          }
+        else
+          resolve_complex(type, constraints)
+        end
+    end
+  end
+
+  def resolve(_type, constraints) do
+    %Type{kind: :unknown, name: "Unknown", module: nil, constraints: constraints}
+  end
+
+  @doc """
+  Resolve a named type module into its full definition for `spec.types`.
+
+  Unlike `resolve/2`, which emits `kind: :type_ref` for named type modules,
+  this function expands the top-level type. Nested named type references
+  within the definition still become `:type_ref`.
+  """
+  @spec resolve_definition(atom()) :: Type.t()
+  def resolve_definition(type_module) when is_atom(type_module) do
+    cond do
+      is_enum_type?(type_module) ->
+        resolve_enum(type_module, [])
+
+      Ash.Type.NewType.new_type?(type_module) ->
+        {unwrapped, constraints} = unwrap_new_type(type_module, [])
+        resolved = resolve(unwrapped, constraints)
+        %{resolved | module: type_module, name: type_name_from_module(type_module)}
+
+      true ->
+        resolve(type_module, [])
+    end
+  end
+
+  @doc """
+  Returns true if the given type is a named type module (Ash.Type.Enum or Ash.Type.NewType).
+  """
+  @spec named_type_module?(term()) :: boolean()
+  def named_type_module?(type) when is_atom(type) do
+    Code.ensure_loaded?(type) == true and
+      (is_enum_type?(type) or Ash.Type.NewType.new_type?(type))
+  end
+
+  def named_type_module?(_), do: false
+
+  # Builds either an `:atom` or an `:enum` Type depending on whether
+  # `:one_of` constraints are present. Shared between the atom shorthand
+  # path and the module path.
+  defp atom_or_enum(module_or_atom, name, constraints) do
+    case Keyword.get(constraints, :one_of) do
+      values when is_list(values) and values != [] ->
+        %Type{
+          kind: :enum,
+          name: "Enum",
+          module: module_or_atom,
+          constraints: constraints,
+          values: values
+        }
+
+      _ ->
+        %Type{kind: :atom, name: name, module: module_or_atom, constraints: constraints}
+    end
+  end
+
+  defp resolve_complex(type, constraints) when is_atom(type) do
+    cond do
+      # Enums
+      is_enum_type?(type) ->
+        resolve_enum(type, constraints)
+
+      # Unions
+      type == Ash.Type.Union ->
+        resolve_union(constraints)
+
+      # Embedded resources (direct module reference)
+      is_embedded_resource?(type) ->
+        %Type{
+          kind: :embedded_resource,
+          name: resource_name(type),
+          module: type,
+          constraints: constraints,
+          resource_module: type
+        }
+
+      # Struct with instance_of pointing to a resource
+      type == Ash.Type.Struct ->
+        resolve_struct(constraints)
+
+      # Map with fields
+      type == Ash.Type.Map ->
+        resolve_container(:map, "Map", constraints)
+
+      # Keyword with fields
+      type == Ash.Type.Keyword ->
+        resolve_container(:keyword, "Keyword", constraints)
+
+      # Tuple with fields
+      type == Ash.Type.Tuple ->
+        resolve_tuple(constraints)
+
+      # Non-embedded resource
+      is_resource?(type) ->
+        %Type{
+          kind: :resource,
+          name: resource_name(type),
+          module: type,
+          constraints: constraints,
+          resource_module: type
+        }
+
+      # Fallback: unknown
+      true ->
+        %Type{
+          kind: :unknown,
+          name: type_name_from_module(type),
+          module: type,
+          constraints: constraints
+        }
+    end
+  end
+
+  defp resolve_enum(type, constraints) do
+    values =
+      if Code.ensure_loaded?(type) and function_exported?(type, :values, 0) do
+        type.values()
+      else
+        []
+      end
+
+    %Type{
+      kind: :enum,
+      name: type_name_from_module(type),
+      module: type,
+      constraints: constraints,
+      values: values
+    }
+  end
+
+  defp resolve_union(constraints) do
+    union_types = Keyword.get(constraints, :types, [])
+
+    members =
+      Enum.map(union_types, fn {name, config} ->
+        member_type = Keyword.get(config, :type)
+        member_constraints = Keyword.get(config, :constraints, [])
+
+        member = %{
+          name: name,
+          type: resolve(member_type, member_constraints)
+        }
+
+        # Include tag info when present (for tagged unions)
+        member =
+          case Keyword.get(config, :tag) do
+            nil -> member
+            tag -> Map.put(member, :tag, tag)
+          end
+
+        case Keyword.get(config, :tag_value) do
+          nil -> member
+          tag_value -> Map.put(member, :tag_value, tag_value)
+        end
+      end)
+
+    %Type{
+      kind: :union,
+      name: "Union",
+      module: Ash.Type.Union,
+      constraints: constraints,
+      members: members
+    }
+  end
+
+  defp resolve_struct(constraints) do
+    instance_of = Keyword.get(constraints, :instance_of)
+    fields = Keyword.get(constraints, :fields)
+
+    cond do
+      instance_of && is_resource?(instance_of) ->
+        kind = if is_embedded_resource?(instance_of), do: :embedded_resource, else: :resource
+
+        %Type{
+          kind: kind,
+          name: resource_name(instance_of),
+          module: Ash.Type.Struct,
+          constraints: constraints,
+          resource_module: instance_of,
+          instance_of: instance_of
+        }
+
+      instance_of && fields ->
+        %Type{
+          kind: :struct,
+          name: type_name_from_module(instance_of),
+          module: Ash.Type.Struct,
+          constraints: constraints,
+          instance_of: instance_of,
+          fields: resolve_field_constraints(fields)
+        }
+
+      fields ->
+        %Type{
+          kind: :struct,
+          name: "Struct",
+          module: Ash.Type.Struct,
+          constraints: constraints,
+          fields: resolve_field_constraints(fields)
+        }
+
+      instance_of ->
+        %Type{
+          kind: :struct,
+          name: type_name_from_module(instance_of),
+          module: Ash.Type.Struct,
+          constraints: constraints,
+          instance_of: instance_of
+        }
+
+      true ->
+        %Type{kind: :struct, name: "Struct", module: Ash.Type.Struct, constraints: constraints}
+    end
+  end
+
+  defp resolve_container(kind, name, constraints) do
+    fields = Keyword.get(constraints, :fields)
+
+    if fields do
+      %Type{
+        kind: kind,
+        name: name,
+        module: container_module(kind),
+        constraints: constraints,
+        fields: resolve_field_constraints(fields)
+      }
+    else
+      %Type{kind: kind, name: name, module: container_module(kind), constraints: constraints}
+    end
+  end
+
+  defp resolve_tuple(constraints) do
+    fields = Keyword.get(constraints, :fields)
+
+    if fields do
+      %Type{
+        kind: :tuple,
+        name: "Tuple",
+        module: Ash.Type.Tuple,
+        constraints: constraints,
+        element_types: resolve_field_constraints(fields)
+      }
+    else
+      %Type{kind: :tuple, name: "Tuple", module: Ash.Type.Tuple, constraints: constraints}
+    end
+  end
+
+  defp resolve_field_constraints(fields) when is_list(fields) do
+    Enum.map(fields, fn {name, config} ->
+      field_type = Keyword.get(config, :type)
+      field_constraints = Keyword.get(config, :constraints, [])
+      allow_nil? = Keyword.get(config, :allow_nil?, true)
+
+      %{
+        name: name,
+        type: resolve(field_type, field_constraints),
+        allow_nil?: allow_nil?
+      }
+    end)
+  end
+
+  defp resolve_field_constraints(_), do: []
+
+  @doc false
+  def unwrap_new_type(type, constraints) when is_atom(type) do
+    if Code.ensure_loaded?(type) == true and
+         Ash.Type.NewType.new_type?(type) do
+      subtype = Ash.Type.NewType.subtype_of(type)
+
+      constraints =
+        case type.do_init(constraints) do
+          {:ok, merged_constraints} -> merged_constraints
+          {:error, _} -> constraints
+        end
+
+      {subtype, constraints}
+    else
+      {type, constraints}
+    end
+  end
+
+  def unwrap_new_type(type, constraints), do: {type, constraints}
+
+  defp is_embedded_resource?(module) when is_atom(module) do
+    is_resource?(module) and Ash.Resource.Info.embedded?(module)
+  end
+
+  defp is_embedded_resource?(_), do: false
+
+  defp is_resource?(module) when is_atom(module) do
+    Code.ensure_loaded?(module) == true and Ash.Resource.Info.resource?(module)
+  end
+
+  defp is_resource?(_), do: false
+
+  defp is_enum_type?(type) when is_atom(type) do
+    Code.ensure_loaded?(type) == true and
+      Spark.implements_behaviour?(type, Ash.Type.Enum)
+  end
+
+  defp resource_name(module) do
+    module
+    |> Module.split()
+    |> List.last()
+  end
+
+  defp type_name_from_module(module) when is_atom(module) do
+    if Code.ensure_loaded?(module) == true do
+      module
+      |> Module.split()
+      |> List.last()
+    else
+      to_string(module)
+    end
+  end
+
+  defp type_name_from_module(other), do: inspect(other)
+
+  defp container_module(:map), do: Ash.Type.Map
+  defp container_module(:keyword), do: Ash.Type.Keyword
+end

--- a/lib/ash/info/manifest/json_serializer.ex
+++ b/lib/ash/info/manifest/json_serializer.ex
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.JsonSerializer do
+  @moduledoc """
+  Serializes `%Ash.Info.Manifest{}` structs to JSON.
+
+  Recursively converts structs to maps, converting module atoms to strings
+  and omitting nil fields.
+  """
+
+  @doc """
+  Serialize an `%Ash.Info.Manifest{}` to a JSON string.
+  """
+  @spec to_json(Ash.Info.Manifest.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def to_json(%Ash.Info.Manifest{} = spec, opts \\ []) do
+    pretty? = Keyword.get(opts, :pretty, false)
+
+    map = to_map(spec)
+
+    json_opts = if pretty?, do: [pretty: true], else: []
+
+    {:ok, Jason.encode!(map, json_opts)}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @doc """
+  Convert an `%Ash.Info.Manifest{}` to a plain map (suitable for JSON encoding).
+  """
+  @spec to_map(Ash.Info.Manifest.t()) :: map()
+  def to_map(%Ash.Info.Manifest{} = spec) do
+    %{
+      "schema_version" => Ash.Info.Manifest.schema_version(),
+      "resources" => Enum.map(spec.resources, &serialize_resource/1),
+      "types" => Enum.map(spec.types, &serialize_type/1),
+      "entrypoints" => Enum.map(spec.entrypoints, &serialize_entrypoint/1)
+    }
+  end
+
+  defp serialize_resource(%Ash.Info.Manifest.Resource{} = resource) do
+    %{
+      "name" => resource.name,
+      "module" => module_to_string(resource.module),
+      "embedded" => resource.embedded?,
+      "primary_key" => Enum.map(resource.primary_key || [], &to_string/1),
+      "fields" => serialize_named_map(resource.fields, &serialize_field/1),
+      "relationships" => serialize_named_map(resource.relationships, &serialize_relationship/1)
+    }
+    |> put_if_present("description", resource.description)
+    |> put_if_present("multitenancy", serialize_multitenancy(resource.multitenancy))
+  end
+
+  defp serialize_entrypoint(%Ash.Info.Manifest.Entrypoint{} = entrypoint) do
+    # config is omitted from JSON — it carries internal extension-specific structs
+    %{
+      "resource" => module_to_string(entrypoint.resource),
+      "action" => serialize_action(entrypoint.action)
+    }
+  end
+
+  defp serialize_field(%Ash.Info.Manifest.Field{} = field) do
+    base = %{
+      "kind" => to_string(field.kind),
+      "type" => serialize_type(field.type),
+      "allow_nil" => field.allow_nil?,
+      "writable" => field.writable?,
+      "has_default" => field.has_default?,
+      "filterable" => field.filterable?,
+      "sortable" => field.sortable?,
+      "primary_key" => field.primary_key?,
+      "sensitive" => field.sensitive?,
+      "select_by_default" => field.select_by_default?
+    }
+
+    base
+    |> put_if_present("description", field.description)
+    |> put_if_present("arguments", serialize_arguments_list(field.arguments))
+    |> put_if_present("aggregate_kind", serialize_atom(field.aggregate_kind))
+  end
+
+  defp serialize_relationship(%Ash.Info.Manifest.Relationship{} = rel) do
+    %{
+      "type" => to_string(rel.type),
+      "cardinality" => to_string(rel.cardinality),
+      "destination" => module_to_string(rel.destination),
+      "allow_nil" => rel.allow_nil?,
+      "filterable" => rel.filterable?,
+      "sortable" => rel.sortable?
+    }
+    |> put_if_present("description", rel.description)
+  end
+
+  defp serialize_action(%Ash.Info.Manifest.Action{} = action) do
+    %{
+      "type" => to_string(action.type),
+      "primary" => action.primary?,
+      "get" => action.get?,
+      "arguments" => Enum.map(action.arguments || [], &serialize_argument/1),
+      "metadata" => Enum.map(action.metadata || [], &serialize_metadata/1)
+    }
+    |> put_if_present("description", action.description)
+    |> put_if_present("accept", serialize_atom_list(action.accept))
+    |> put_if_present("require_attributes", serialize_atom_list(action.require_attributes))
+    |> put_if_present("allow_nil_input", serialize_atom_list(action.allow_nil_input))
+    |> put_if_present("returns", serialize_type(action.returns))
+    |> put_if_present("pagination", serialize_pagination(action.pagination))
+  end
+
+  defp serialize_type(nil), do: nil
+
+  defp serialize_type(%Ash.Info.Manifest.Type{} = type) do
+    base = %{
+      "kind" => to_string(type.kind),
+      "name" => type.name,
+      "allow_nil" => type.allow_nil?
+    }
+
+    base
+    |> put_if_present("module", module_to_string(type.module))
+    |> put_if_present("values", serialize_atom_list(type.values))
+    |> put_if_present("members", serialize_members(type.members))
+    |> put_if_present("resource_module", module_to_string(type.resource_module))
+    |> put_if_present("fields", serialize_type_fields(type.fields))
+    |> put_if_present("instance_of", module_to_string(type.instance_of))
+    |> put_if_present("item_type", serialize_type(type.item_type))
+    |> put_if_present("element_types", serialize_type_fields(type.element_types))
+  end
+
+  defp serialize_argument(%Ash.Info.Manifest.Argument{} = arg) do
+    %{
+      "name" => to_string(arg.name),
+      "type" => serialize_type(arg.type),
+      "allow_nil" => arg.allow_nil?,
+      "has_default" => arg.has_default?,
+      "sensitive" => arg.sensitive?
+    }
+    |> put_if_present("description", arg.description)
+  end
+
+  defp serialize_metadata(%Ash.Info.Manifest.Metadata{} = meta) do
+    %{
+      "name" => to_string(meta.name),
+      "type" => serialize_type(meta.type),
+      "allow_nil" => meta.allow_nil?
+    }
+    |> put_if_present("description", meta.description)
+  end
+
+  defp serialize_pagination(nil), do: nil
+
+  defp serialize_pagination(%Ash.Info.Manifest.Pagination{} = page) do
+    %{
+      "offset" => page.offset?,
+      "keyset" => page.keyset?,
+      "required" => page.required?,
+      "countable" => page.countable?,
+      "default_limit" => page.default_limit,
+      "max_page_size" => page.max_page_size
+    }
+  end
+
+  defp serialize_multitenancy(nil), do: nil
+
+  defp serialize_multitenancy(%{} = mt) do
+    %{
+      "strategy" => to_string(mt.strategy),
+      "global" => mt.global?,
+      "attribute" => serialize_atom(mt.attribute)
+    }
+  end
+
+  defp serialize_named_map(map, serialize_fn) when is_map(map) do
+    Map.new(map, fn {name, value} ->
+      {to_string(name), serialize_fn.(value)}
+    end)
+  end
+
+  defp serialize_arguments_list(nil), do: nil
+  defp serialize_arguments_list([]), do: nil
+  defp serialize_arguments_list(args), do: Enum.map(args, &serialize_argument/1)
+
+  defp serialize_members(nil), do: nil
+
+  defp serialize_members(members) do
+    Enum.map(members, fn member ->
+      %{
+        "name" => to_string(member.name),
+        "type" => serialize_type(member.type)
+      }
+    end)
+  end
+
+  defp serialize_type_fields(nil), do: nil
+
+  defp serialize_type_fields(fields) do
+    Enum.map(fields, fn field ->
+      %{
+        "name" => to_string(field.name),
+        "type" => serialize_type(field.type),
+        "allow_nil" => field.allow_nil?
+      }
+    end)
+  end
+
+  defp serialize_atom_list(nil), do: nil
+  defp serialize_atom_list(list), do: Enum.map(list, &to_string/1)
+
+  defp serialize_atom(nil), do: nil
+  defp serialize_atom(atom) when is_atom(atom), do: to_string(atom)
+
+  defp module_to_string(nil), do: nil
+
+  defp module_to_string(module) when is_atom(module) do
+    case Atom.to_string(module) do
+      "Elixir." <> _ -> module |> Module.split() |> Enum.join(".")
+      other -> other
+    end
+  end
+
+  defp module_to_string(other), do: inspect(other)
+
+  defp put_if_present(map, _key, nil), do: map
+  defp put_if_present(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/ash/info/manifest/metadata.ex
+++ b/lib/ash/info/manifest/metadata.ex
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Metadata do
+  @moduledoc """
+  Represents action metadata in the API specification.
+  """
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          type: Ash.Info.Manifest.Type.t(),
+          allow_nil?: boolean(),
+          description: String.t() | nil
+        }
+
+  defstruct [
+    :name,
+    :type,
+    :allow_nil?,
+    :description
+  ]
+end

--- a/lib/ash/info/manifest/pagination.ex
+++ b/lib/ash/info/manifest/pagination.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Pagination do
+  @moduledoc """
+  Represents pagination configuration for a read action.
+  """
+
+  @type t :: %__MODULE__{
+          offset?: boolean(),
+          keyset?: boolean(),
+          required?: boolean(),
+          countable?: boolean(),
+          default_limit: non_neg_integer() | nil,
+          max_page_size: non_neg_integer() | nil
+        }
+
+  defstruct [
+    :offset?,
+    :keyset?,
+    :required?,
+    :countable?,
+    :default_limit,
+    :max_page_size
+  ]
+end

--- a/lib/ash/info/manifest/relationship.ex
+++ b/lib/ash/info/manifest/relationship.ex
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Relationship do
+  @moduledoc """
+  Represents a resource relationship in the API specification.
+  """
+
+  @type relationship_type :: :has_many | :has_one | :belongs_to | :many_to_many
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          type: relationship_type(),
+          cardinality: :one | :many,
+          destination: atom(),
+          allow_nil?: boolean(),
+          description: String.t() | nil,
+          filterable?: boolean(),
+          sortable?: boolean()
+        }
+
+  defstruct [
+    :name,
+    :type,
+    :cardinality,
+    :destination,
+    :allow_nil?,
+    :description,
+    :filterable?,
+    :sortable?
+  ]
+end

--- a/lib/ash/info/manifest/resource.ex
+++ b/lib/ash/info/manifest/resource.ex
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Resource do
+  @moduledoc """
+  Represents a resource in the API specification.
+
+  Resources are pure type/shape definitions. Fields and relationships are
+  stored as maps keyed by atom name for O(1) lookup. Actions live separately
+  in `%Ash.Info.Manifest{}.entrypoints`.
+  """
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          module: atom(),
+          embedded?: boolean(),
+          primary_key: [atom()],
+          description: String.t() | nil,
+          fields: %{atom() => Ash.Info.Manifest.Field.t()},
+          relationships: %{atom() => Ash.Info.Manifest.Relationship.t()},
+          identities: %{atom() => %{keys: [atom()]}},
+          multitenancy: %{strategy: atom(), global?: boolean(), attribute: atom()} | nil
+        }
+
+  defstruct [
+    :name,
+    :module,
+    :embedded?,
+    :primary_key,
+    :description,
+    :multitenancy,
+    fields: %{},
+    relationships: %{},
+    identities: %{}
+  ]
+
+  @doc "Gets a field (attribute, calculation, or aggregate) by name."
+  @spec get_field(t(), atom()) :: Ash.Info.Manifest.Field.t() | nil
+  def get_field(%__MODULE__{fields: fields}, name), do: Map.get(fields, name)
+
+  @doc "Gets a relationship by name."
+  @spec get_relationship(t(), atom()) :: Ash.Info.Manifest.Relationship.t() | nil
+  def get_relationship(%__MODULE__{relationships: rels}, name), do: Map.get(rels, name)
+
+  @doc "Gets an identity by name."
+  @spec get_identity(t(), atom()) :: %{keys: [atom()]} | nil
+  def get_identity(%__MODULE__{identities: identities}, name), do: Map.get(identities, name)
+
+  @doc "Checks if a field or relationship exists by name."
+  @spec has_field?(t(), atom()) :: boolean()
+  def has_field?(%__MODULE__{fields: fields, relationships: rels}, name) do
+    Map.has_key?(fields, name) || Map.has_key?(rels, name)
+  end
+
+  @doc """
+  Returns all fields as a list, sorted by name.
+
+  Sorting ensures codegen output is deterministic across runs (Erlang map
+  iteration order is unstable for maps with more than 32 keys).
+  """
+  @spec all_fields(t()) :: [Ash.Info.Manifest.Field.t()]
+  def all_fields(%__MODULE__{fields: fields}), do: sort_by_name(Map.values(fields))
+
+  @doc "Returns all fields of a given kind (:attribute, :calculation, or :aggregate), sorted by name."
+  @spec fields_by_kind(t(), Ash.Info.Manifest.Field.kind()) :: [Ash.Info.Manifest.Field.t()]
+  def fields_by_kind(%__MODULE__{fields: fields}, kind) do
+    fields |> Map.values() |> Enum.filter(&(&1.kind == kind)) |> sort_by_name()
+  end
+
+  @doc "Returns all relationships as a list, sorted by name."
+  @spec all_relationships(t()) :: [Ash.Info.Manifest.Relationship.t()]
+  def all_relationships(%__MODULE__{relationships: rels}),
+    do: sort_by_name(Map.values(rels))
+
+  @doc "Returns all field names (attributes, calculations, aggregates), sorted."
+  @spec field_names(t()) :: [atom()]
+  def field_names(%__MODULE__{fields: fields}), do: fields |> Map.keys() |> Enum.sort()
+
+  @doc "Returns all relationship names, sorted."
+  @spec relationship_names(t()) :: [atom()]
+  def relationship_names(%__MODULE__{relationships: rels}),
+    do: rels |> Map.keys() |> Enum.sort()
+
+  @doc "Returns relationships whose destination is in the allowed list, sorted by name."
+  @spec accessible_relationships(t(), [atom()] | MapSet.t()) :: [
+          Ash.Info.Manifest.Relationship.t()
+        ]
+  def accessible_relationships(%__MODULE__{relationships: rels}, allowed_resources) do
+    allowed =
+      if is_list(allowed_resources), do: MapSet.new(allowed_resources), else: allowed_resources
+
+    rels
+    |> Map.values()
+    |> Enum.filter(&MapSet.member?(allowed, &1.destination))
+    |> sort_by_name()
+  end
+
+  defp sort_by_name(items), do: Enum.sort_by(items, & &1.name)
+
+  @doc "Returns fields for accepted attributes of an action."
+  @spec accepted_fields(t(), map()) :: [Ash.Info.Manifest.Field.t()]
+  def accepted_fields(%__MODULE__{fields: fields}, action) do
+    case Map.get(action, :accept) || [] do
+      [] ->
+        []
+
+      accept_list ->
+        accept_list
+        |> Enum.map(&Map.get(fields, &1))
+        |> Enum.reject(&is_nil/1)
+    end
+  end
+end

--- a/lib/ash/info/manifest/type.ex
+++ b/lib/ash/info/manifest/type.ex
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Type do
+  @moduledoc """
+  Represents a resolved type in the API specification.
+
+  Named type modules (Ash.Type.Enum implementations and Ash.Type.NewType subtypes)
+  are referenced via `kind: :type_ref` inline, with their full definitions in
+  `%Ash.Info.Manifest{}.types`. This prevents circular references and mirrors how resources
+  are referenced via `kind: :resource` with definitions in `%Ash.Info.Manifest{}.resources`.
+
+  Primitive types (string, integer, etc.) and anonymous containers (map/keyword/tuple
+  without a named module) are still resolved inline.
+  """
+
+  @type kind ::
+          :string
+          | :integer
+          | :boolean
+          | :float
+          | :decimal
+          | :uuid
+          | :date
+          | :datetime
+          | :utc_datetime
+          | :utc_datetime_usec
+          | :naive_datetime
+          | :time
+          | :time_usec
+          | :duration
+          | :binary
+          | :atom
+          | :ci_string
+          | :term
+          | :enum
+          | :union
+          | :resource
+          | :embedded_resource
+          | :map
+          | :struct
+          | :array
+          | :tuple
+          | :keyword
+          | :type_ref
+          | :any
+          | :unknown
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          name: String.t(),
+          module: atom() | nil,
+          constraints: keyword() | nil,
+          allow_nil?: boolean() | nil,
+          # For :enum
+          values: [atom()] | nil,
+          # For :union
+          members: [%{name: atom(), type: t()}] | nil,
+          # For :resource / :embedded_resource
+          resource_module: atom() | nil,
+          # For :map / :struct / :keyword
+          fields: [%{name: atom(), type: t(), allow_nil?: boolean()}] | nil,
+          # For :struct
+          instance_of: atom() | nil,
+          # For :array
+          item_type: t() | nil,
+          # For :tuple
+          element_types: [%{name: atom(), type: t(), allow_nil?: boolean()}] | nil
+        }
+
+  defstruct [
+    :kind,
+    :name,
+    :module,
+    :constraints,
+    :allow_nil?,
+    :values,
+    :members,
+    :resource_module,
+    :fields,
+    :instance_of,
+    :item_type,
+    :element_types
+  ]
+
+  @doc """
+  Returns the effective module for a type — `instance_of` if set, otherwise `module`.
+
+  For struct types wrapping a module (NewTypes, TypedStructs), `instance_of` points
+  to the original module. For other types, `module` is the Ash type module.
+  """
+  @spec effective_module(t()) :: atom() | nil
+  def effective_module(%__MODULE__{instance_of: inst}) when not is_nil(inst), do: inst
+  def effective_module(%__MODULE__{module: mod}), do: mod
+
+  @doc """
+  Returns the effective resource module for a type.
+
+  For resource/embedded_resource types, returns `resource_module`.
+  Falls back to `effective_module/1`.
+  """
+  @spec effective_resource(t()) :: atom() | nil
+  def effective_resource(%__MODULE__{resource_module: rm}) when not is_nil(rm), do: rm
+  def effective_resource(%__MODULE__{} = t), do: effective_module(t)
+
+  @doc """
+  Returns true if the type represents a resource (`:resource` or `:embedded_resource`).
+  """
+  @spec resource_kind?(t()) :: boolean()
+  def resource_kind?(%__MODULE__{kind: kind}) when kind in [:resource, :embedded_resource],
+    do: true
+
+  def resource_kind?(_), do: false
+
+  @doc """
+  Returns true if the type has nested field descriptors (`.fields` or `.element_types`).
+  """
+  @spec has_fields?(t()) :: boolean()
+  def has_fields?(%__MODULE__{fields: fields}) when is_list(fields) and fields != [], do: true
+
+  def has_fields?(%__MODULE__{element_types: ets}) when is_list(ets) and ets != [], do: true
+
+  def has_fields?(_), do: false
+
+  @doc """
+  Returns the list of field descriptors for a type.
+
+  Checks `.fields` first (for map/struct/keyword), then `.element_types` (for tuple).
+  Returns an empty list if neither is populated.
+
+  Each field is a map with `:name`, `:type` (`%Ash.Info.Manifest.Type{}`), and `:allow_nil?`.
+  """
+  @spec get_fields(t()) :: [%{name: atom(), type: t(), allow_nil?: boolean()}]
+  def get_fields(%__MODULE__{fields: fields}) when is_list(fields) and fields != [], do: fields
+
+  def get_fields(%__MODULE__{element_types: ets}) when is_list(ets) and ets != [], do: ets
+
+  def get_fields(_), do: []
+
+  @doc """
+  Finds a sub-field by name from the type's field descriptors.
+
+  Returns the field map (`%{name, type, allow_nil?}`) or nil if not found.
+  """
+  @spec find_field(t(), atom()) :: %{name: atom(), type: t(), allow_nil?: boolean()} | nil
+  def find_field(%__MODULE__{} = type, field_name) when is_atom(field_name) do
+    type
+    |> get_fields()
+    |> Enum.find(fn f -> f.name == field_name end)
+  end
+
+  def find_field(_, _), do: nil
+
+  @doc """
+  Finds the type of a sub-field by name.
+
+  Returns the `%Ash.Info.Manifest.Type{}` of the field, or nil if not found.
+  """
+  @spec find_field_type(t(), atom()) :: t() | nil
+  def find_field_type(%__MODULE__{} = type, field_name) do
+    case find_field(type, field_name) do
+      %{type: field_type} -> field_type
+      nil -> nil
+    end
+  end
+
+  @doc """
+  Finds a union member by name from the type's members.
+
+  Returns the member map (`%{name, type, tag, tag_value}`) or nil.
+  """
+  @spec find_member(t(), atom()) :: map() | nil
+  def find_member(%__MODULE__{members: members}, member_name)
+      when is_list(members) and is_atom(member_name) do
+    Enum.find(members, fn m -> m.name == member_name end)
+  end
+
+  def find_member(_, _), do: nil
+end

--- a/lib/ash/info/manifest/validators.ex
+++ b/lib/ash/info/manifest/validators.ex
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Error.NonPublicAccept do
+  @moduledoc """
+  Raised by `Ash.Info.Manifest.Generator` when an action entrypoint's accept list
+  includes one or more non-public attributes.
+
+  An API specification describes a public surface; accepting a non-public
+  attribute via a public entrypoint would silently expose data the resource
+  author marked `public?: false`.
+  """
+  defexception [:resource, :action, :attributes, :message]
+
+  @impl true
+  def exception(opts) do
+    resource = Keyword.fetch!(opts, :resource)
+    action = Keyword.fetch!(opts, :action)
+    attributes = Keyword.fetch!(opts, :attributes)
+
+    message =
+      "Action #{inspect(action)} on #{inspect(resource)} is exposed as an API entrypoint, " <>
+        "but its accept list includes non-public attribute(s): #{inspect(attributes)}. " <>
+        "Only `public?: true` attributes may appear in the accept list of a public entrypoint. " <>
+        "Either mark the attribute(s) as `public? true`, remove them from the action's accept list, " <>
+        "or do not expose the action as an entrypoint."
+
+    %__MODULE__{
+      resource: resource,
+      action: action,
+      attributes: attributes,
+      message: message
+    }
+  end
+end
+
+defmodule Ash.Info.Manifest.Validators do
+  @moduledoc """
+  Validation helpers for resources and actions that are exposed via a
+  public-facing API (e.g. AshTypescript RPC, AshJsonApi routes, AshGraphql
+  mutations).
+
+  These checks describe rules that hold for any public API surface and are
+  enforced by `Ash.Info.Manifest.Generator` when building a spec, so every
+  extension that consumes the spec gets the same guarantees.
+  """
+
+  alias Ash.Info.Manifest.Error.NonPublicAccept
+
+  @doc """
+  Returns `:ok` if every attribute in `action`'s accept list is `public?: true`
+  on `resource`. Returns `{:error, non_public_attrs}` otherwise.
+
+  `action` may be an Ash action struct, an `%Ash.Info.Manifest.Action{}`, or any
+  map with an `:accept` key. An empty or absent accept list is `:ok`.
+  """
+  @spec validate_accept_public(atom(), map()) :: :ok | {:error, [atom()]}
+  def validate_accept_public(resource, action) when is_atom(resource) and is_map(action) do
+    accept_list = Map.get(action, :accept) || []
+
+    non_public =
+      Enum.reject(accept_list, fn attr_name ->
+        Ash.Resource.Info.public_attribute(resource, attr_name) != nil
+      end)
+
+    case non_public do
+      [] -> :ok
+      attrs -> {:error, attrs}
+    end
+  end
+
+  @doc """
+  Raises `Ash.Info.Manifest.Error.NonPublicAccept` if `action`'s accept list contains
+  any non-public attributes on `resource`. Used by `Ash.Info.Manifest.Generator` to
+  enforce the public-surface invariant when building entrypoints.
+  """
+  @spec validate_entrypoint!(atom(), map()) :: :ok
+  def validate_entrypoint!(resource, action) when is_atom(resource) and is_map(action) do
+    case validate_accept_public(resource, action) do
+      :ok ->
+        :ok
+
+      {:error, attrs} ->
+        raise NonPublicAccept,
+          resource: resource,
+          action: Map.get(action, :name),
+          attributes: attrs
+    end
+  end
+end

--- a/lib/mix/tasks/ash.manifest.dump.ex
+++ b/lib/mix/tasks/ash.manifest.dump.ex
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Mix.Tasks.Ash.Manifest.Dump do
+  @shortdoc "Dump the Ash app manifest as JSON"
+  @moduledoc """
+  Generates a JSON manifest of the application's public Ash surface
+  (resources, types, and action entrypoints).
+
+      mix ash.manifest.dump [--output FILE] [--format json]
+
+  ## Options
+
+    * `--output` / `-o` - Output file path (default: stdout)
+    * `--format` - Output format, currently only "json" (default: "json")
+
+  ## Examples
+
+      mix ash.manifest.dump
+      mix ash.manifest.dump --output manifest.json
+      mix ash.manifest.dump -o manifest.json --format json
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("compile")
+
+    {opts, _remaining, _invalid} =
+      OptionParser.parse(args,
+        switches: [output: :string, format: :string],
+        aliases: [o: :output]
+      )
+
+    otp_app = Mix.Project.config()[:app]
+    format = Keyword.get(opts, :format, "json")
+    output = Keyword.get(opts, :output)
+
+    case format do
+      "json" ->
+        generate_json(otp_app, output)
+
+      other ->
+        Mix.raise("Unsupported format: #{other}. Currently only \"json\" is supported.")
+    end
+  end
+
+  defp generate_json(otp_app, output) do
+    {:ok, spec} = Ash.Info.Manifest.generate(otp_app: otp_app)
+
+    case Ash.Info.Manifest.JsonSerializer.to_json(spec, pretty: true) do
+      {:ok, json} ->
+        if output do
+          File.write!(output, json)
+          Mix.shell().info("Manifest written to #{output}")
+        else
+          Mix.shell().info(json)
+        end
+
+      {:error, error} ->
+        Mix.raise("Failed to serialize manifest: #{error}")
+    end
+  end
+end

--- a/test/ash/info/manifest/action_builder_test.exs
+++ b/test/ash/info/manifest/action_builder_test.exs
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.ActionBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.{Action, Argument, Pagination}
+  alias Ash.Info.Manifest.Generator.ActionBuilder
+
+  defp get_action(resource, action_name) do
+    Ash.Resource.Info.action(resource, action_name)
+  end
+
+  describe "build/2" do
+    test "builds read action" do
+      action = get_action(Ash.Test.Manifest.Todo, :read)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert %Action{} = result
+      assert result.name == :read
+      assert result.type == :read
+      assert result.primary? == true
+    end
+
+    test "builds create action with accept list" do
+      action = get_action(Ash.Test.Manifest.Todo, :create)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert result.type == :create
+      assert is_list(result.accept)
+      assert :title in result.accept
+    end
+
+    test "builds action with public arguments only" do
+      action = get_action(Ash.Test.Manifest.Todo, :read)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert is_list(result.arguments)
+      assert Enum.all?(result.arguments, &is_atom(&1.name))
+    end
+
+    test "builds argument with type resolution" do
+      action = get_action(Ash.Test.Manifest.Todo, :create)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      user_id_arg = Enum.find(result.arguments, &(&1.name == :user_id))
+
+      if user_id_arg do
+        assert %Argument{} = user_id_arg
+        assert user_id_arg.allow_nil? == false
+        assert user_id_arg.type.kind == :uuid
+      end
+    end
+
+    test "builds read action with pagination" do
+      action = get_action(Ash.Test.Manifest.Todo, :read)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert %Pagination{} = result.pagination
+      assert result.pagination.offset? == true
+      assert result.pagination.keyset? == true
+      assert result.pagination.countable? == true
+      assert result.pagination.required? == false
+      assert result.pagination.default_limit == 20
+      assert result.pagination.max_page_size == 100
+    end
+
+    test "builds read action without pagination" do
+      action = get_action(Ash.Test.Manifest.Todo, :list_high_priority)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert result.pagination == nil
+    end
+
+    test "builds generic action with returns type" do
+      action = get_action(Ash.Test.Manifest.Todo, :bulk_complete)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert result.type == :action
+      assert result.returns != nil
+      assert result.returns.kind == :array
+      assert result.returns.item_type.kind == :uuid
+    end
+
+    test "builds generic action with map return type" do
+      action = get_action(Ash.Test.Manifest.Todo, :get_statistics)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert result.type == :action
+      assert result.returns != nil
+      assert result.returns.kind == :map
+      assert is_list(result.returns.fields)
+    end
+
+    test "builds destroy action" do
+      action = get_action(Ash.Test.Manifest.Todo, :destroy)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert result.type == :destroy
+    end
+
+    test "builds action with metadata" do
+      action = get_action(Ash.Test.Manifest.Task, :read_with_metadata)
+
+      if action do
+        result = ActionBuilder.build(Ash.Test.Manifest.Task, action)
+        assert is_list(result.metadata)
+      end
+    end
+
+    test "get? action has get? set to true" do
+      action = get_action(Ash.Test.Manifest.Todo, :get_by_id)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      assert result.get? == true
+    end
+  end
+end

--- a/test/ash/info/manifest/generator_test.exs
+++ b/test/ash/info/manifest/generator_test.exs
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.GeneratorTest do
+  use ExUnit.Case, async: true
+
+  describe "generate/1" do
+    test "generates spec for otp_app" do
+      assert {:ok, %Ash.Info.Manifest{} = spec} =
+               Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      assert is_list(spec.resources)
+      assert spec.resources != []
+    end
+
+    test "all resources have names and modules" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      for resource <- spec.resources do
+        assert is_binary(resource.name)
+        assert is_atom(resource.module)
+        assert is_boolean(resource.embedded?)
+        assert is_map(resource.fields)
+        assert is_map(resource.relationships)
+      end
+
+      assert is_list(spec.entrypoints)
+      assert spec.entrypoints != []
+    end
+
+    test "includes Todo resource" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      todo = Enum.find(spec.resources, &(&1.module == Ash.Test.Manifest.Todo))
+      assert todo != nil
+      assert todo.name == "Todo"
+
+      # Should have fields
+      assert Map.has_key?(todo.fields, :id)
+      assert Map.has_key?(todo.fields, :title)
+    end
+
+    test "includes User resource" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      user = Enum.find(spec.resources, &(&1.module == Ash.Test.Manifest.User))
+      assert user != nil
+    end
+
+    test "with action filter narrows entrypoints to specified actions" do
+      {:ok, spec} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: [{Ash.Test.Manifest.Todo, :read}]
+        )
+
+      assert Enum.any?(spec.entrypoints, fn e ->
+               e.resource == Ash.Test.Manifest.Todo and e.action.name == :read
+             end)
+
+      # Only one entrypoint for Todo :read
+      assert length(spec.entrypoints) == 1
+    end
+
+    test "with action filter, reachable resources have no entrypoints" do
+      {:ok, spec} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: [{Ash.Test.Manifest.Todo, :read}]
+        )
+
+      # User is reachable via Todo's belongs_to but was not explicitly listed
+      user = Enum.find(spec.resources, &(&1.module == Ash.Test.Manifest.User))
+      assert user != nil
+      refute Enum.any?(spec.entrypoints, &(&1.resource == Ash.Test.Manifest.User))
+    end
+
+    test "resources have properly resolved field types" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      todo = Enum.find(spec.resources, &(&1.module == Ash.Test.Manifest.Todo))
+      assert todo.fields[:title].type.kind == :string
+    end
+
+    test "named type fields use type_ref, spec.types has full definitions" do
+      {:ok, spec} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: [{Ash.Test.Manifest.Todo, :read}]
+        )
+
+      todo = Enum.find(spec.resources, &(&1.module == Ash.Test.Manifest.Todo))
+
+      # Status field should be a type_ref inline
+      status_type = todo.fields[:status].type
+      assert status_type.kind == :type_ref
+      assert status_type.module == Ash.Test.Manifest.Todo.Status
+
+      # spec.types should have the full definition
+      status_def = Enum.find(spec.types, &(&1.module == Ash.Test.Manifest.Todo.Status))
+      assert status_def != nil
+      assert status_def.kind == :enum
+      assert :pending in status_def.values
+    end
+
+    test "resources are sorted by module name" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      module_names = Enum.map(spec.resources, &Module.split(&1.module))
+      assert module_names == Enum.sort(module_names)
+    end
+  end
+
+  describe "overrides" do
+    # Use NoRelationshipsResource as a narrow entrypoint — it has no relationships
+    # and only primitive fields (id, name), so its reachable set is minimal.
+    @narrow_entrypoints [{Ash.Test.Manifest.NoRelationshipsResource, :read}]
+
+    test "always_resources forces inclusion of unreachable resources" do
+      {:ok, spec_without} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: @narrow_entrypoints
+        )
+
+      refute Enum.any?(spec_without.resources, &(&1.module == Ash.Test.Manifest.User))
+
+      {:ok, spec_with} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: @narrow_entrypoints,
+          overrides: [always: [resources: [Ash.Test.Manifest.User]]]
+        )
+
+      user = Enum.find(spec_with.resources, &(&1.module == Ash.Test.Manifest.User))
+      assert user != nil
+      # Always-resources have no entrypoints
+      refute Enum.any?(spec_with.entrypoints, &(&1.resource == Ash.Test.Manifest.User))
+    end
+
+    test "always_resources also discovers their field types via reachability" do
+      {:ok, spec} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: @narrow_entrypoints,
+          overrides: [always: [resources: [Ash.Test.Manifest.NotExposed]]]
+        )
+
+      # NotExposed has a belongs_to :todo relationship, so Todo should also be reachable
+      assert Enum.any?(spec.resources, &(&1.module == Ash.Test.Manifest.Todo))
+    end
+
+    test "always_types forces inclusion of standalone types" do
+      {:ok, spec_without} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: @narrow_entrypoints
+        )
+
+      type_modules_without = Enum.map(spec_without.types, & &1.module)
+
+      {:ok, spec_with} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: @narrow_entrypoints,
+          overrides: [always: [types: [Ash.Test.Manifest.Todo.Status]]]
+        )
+
+      type_modules_with = Enum.map(spec_with.types, & &1.module)
+
+      refute Ash.Test.Manifest.Todo.Status in type_modules_without
+      assert Ash.Test.Manifest.Todo.Status in type_modules_with
+    end
+
+    test "empty overrides has no effect" do
+      {:ok, spec_without} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: [{Ash.Test.Manifest.Todo, :read}]
+        )
+
+      {:ok, spec_with} =
+        Ash.Info.Manifest.generate(
+          otp_app: :ash_manifest_test,
+          action_entrypoints: [{Ash.Test.Manifest.Todo, :read}],
+          overrides: []
+        )
+
+      assert length(spec_without.resources) == length(spec_with.resources)
+      assert length(spec_without.types) == length(spec_with.types)
+    end
+  end
+end

--- a/test/ash/info/manifest/json_serializer_test.exs
+++ b/test/ash/info/manifest/json_serializer_test.exs
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.JsonSerializerTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.JsonSerializer
+
+  describe "to_json/2" do
+    test "serializes a full spec to valid JSON" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+
+      assert is_binary(json)
+      assert {:ok, decoded} = Jason.decode(json)
+      assert decoded["schema_version"] == "1.0.0"
+      assert is_list(decoded["resources"])
+    end
+
+    test "pretty option produces formatted JSON" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec, pretty: true)
+
+      assert String.contains?(json, "\n")
+    end
+
+    test "resources have expected structure" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo = Enum.find(decoded["resources"], &(&1["name"] == "Todo"))
+      assert todo != nil
+      assert is_binary(todo["module"])
+      assert is_boolean(todo["embedded"])
+      assert is_list(todo["primary_key"])
+      assert is_map(todo["fields"])
+      assert is_map(todo["relationships"])
+      refute Map.has_key?(todo, "actions")
+    end
+
+    test "fields have expected structure" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo = Enum.find(decoded["resources"], &(&1["name"] == "Todo"))
+      title = todo["fields"]["title"]
+
+      assert title["kind"] == "attribute"
+      assert title["type"]["kind"] == "string"
+      assert title["allow_nil"] == false
+      assert is_boolean(title["writable"])
+      assert is_boolean(title["primary_key"])
+    end
+
+    test "relationships have expected structure" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo = Enum.find(decoded["resources"], &(&1["name"] == "Todo"))
+      user_rel = todo["relationships"]["user"]
+
+      assert user_rel["type"] == "belongs_to"
+      assert user_rel["cardinality"] == "one"
+      assert is_binary(user_rel["destination"])
+    end
+
+    test "entrypoints have expected structure" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      assert is_list(decoded["entrypoints"])
+      assert decoded["entrypoints"] != []
+
+      todo_read =
+        Enum.find(decoded["entrypoints"], fn e ->
+          String.ends_with?(e["resource"], "Todo") and e["action"]["type"] == "read"
+        end)
+
+      assert todo_read != nil
+      assert is_binary(todo_read["resource"])
+      assert is_boolean(todo_read["action"]["primary"])
+      assert is_list(todo_read["action"]["arguments"])
+    end
+
+    test "pagination is serialized in entrypoints" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo_read =
+        Enum.find(decoded["entrypoints"], fn e ->
+          String.ends_with?(e["resource"], ".Todo") and
+            e["action"]["type"] == "read" and
+            e["action"]["primary"] == true
+        end)
+
+      assert todo_read != nil
+      assert todo_read["action"]["pagination"] != nil
+      assert is_boolean(todo_read["action"]["pagination"]["offset"])
+      assert is_boolean(todo_read["action"]["pagination"]["keyset"])
+    end
+
+    test "generic action returns type is serialized" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo = Enum.find(decoded["resources"], &(&1["name"] == "Todo"))
+      bulk_complete = todo["actions"]["bulk_complete"]
+
+      if bulk_complete do
+        assert bulk_complete["returns"] != nil
+        assert bulk_complete["returns"]["kind"] == "array"
+      end
+    end
+
+    test "nil fields are omitted from JSON" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo = Enum.find(decoded["resources"], &(&1["name"] == "Todo"))
+
+      # Attribute fields should not have "arguments" key (only calculations have that)
+      title = todo["fields"]["title"]
+      refute Map.has_key?(title, "arguments")
+    end
+
+    test "module atoms are converted to strings" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json} = JsonSerializer.to_json(spec)
+      {:ok, decoded} = Jason.decode(json)
+
+      todo = Enum.find(decoded["resources"], &(&1["name"] == "Todo"))
+      assert is_binary(todo["module"])
+      assert String.contains?(todo["module"], "Todo")
+    end
+  end
+
+  describe "to_map/1" do
+    test "converts spec to plain map" do
+      {:ok, spec} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      map = JsonSerializer.to_map(spec)
+
+      assert is_map(map)
+      assert map["schema_version"] == "1.0.0"
+      assert is_list(map["resources"])
+    end
+  end
+end

--- a/test/ash/info/manifest/reachability_test.exs
+++ b/test/ash/info/manifest/reachability_test.exs
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.ReachabilityTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.Generator.Reachability
+
+  describe "find_reachable/1" do
+    test "finds directly referenced resources" do
+      {resources, _types} = Reachability.find_reachable([Ash.Test.Manifest.Todo])
+      resource_set = MapSet.new(resources)
+
+      # Todo has relationships to User and TodoComment
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.Todo)
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.User)
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.TodoComment)
+    end
+
+    test "finds transitively referenced resources" do
+      {resources, _types} = Reachability.find_reachable([Ash.Test.Manifest.Todo])
+      resource_set = MapSet.new(resources)
+
+      # Todo -> User -> UserSettings (if User has a relationship to UserSettings)
+      # At minimum, Todo itself and its direct relationships
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.Todo)
+    end
+
+    test "handles cycles without infinite recursion" do
+      # Todo -> TodoComment -> Todo (via belongs_to)
+      {resources, _types} = Reachability.find_reachable([Ash.Test.Manifest.Todo])
+      assert is_list(resources)
+      assert resources != []
+    end
+
+    test "finds standalone enum types" do
+      {_resources, types} = Reachability.find_reachable([Ash.Test.Manifest.Todo])
+
+      # Todo has a Status enum attribute — its module should appear in the
+      # reachable type set so the generator emits its full definition.
+      assert Ash.Test.Manifest.Todo.Status in types
+    end
+
+    test "multiple root resources are all included" do
+      {resources, _types} =
+        Reachability.find_reachable([
+          Ash.Test.Manifest.Todo,
+          Ash.Test.Manifest.User
+        ])
+
+      resource_set = MapSet.new(resources)
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.Todo)
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.User)
+    end
+
+    test "empty input returns empty results" do
+      {resources, types} = Reachability.find_reachable([])
+      assert resources == []
+      assert types == []
+    end
+
+    test "finds embedded resources referenced by attributes" do
+      {resources, _types} = Reachability.find_reachable([Ash.Test.Manifest.Todo])
+      resource_set = MapSet.new(resources)
+
+      # Todo has :metadata attribute of type TodoMetadata (embedded resource)
+      assert MapSet.member?(resource_set, Ash.Test.Manifest.TodoMetadata)
+    end
+  end
+end

--- a/test/ash/info/manifest/resource_builder_test.exs
+++ b/test/ash/info/manifest/resource_builder_test.exs
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.ResourceBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.{Field, Relationship, Resource}
+  alias Ash.Info.Manifest.Generator.ResourceBuilder
+
+  describe "build/2" do
+    test "builds a resource from Todo" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+      assert %Resource{} = resource
+      assert resource.name == "Todo"
+      assert resource.module == Ash.Test.Manifest.Todo
+      assert resource.embedded? == false
+      assert :id in resource.primary_key
+    end
+
+    test "includes public attributes as fields" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      assert Map.has_key?(resource.fields, :title)
+      assert Map.has_key?(resource.fields, :description)
+      assert Map.has_key?(resource.fields, :completed)
+      assert Map.has_key?(resource.fields, :status)
+    end
+
+    test "marks attribute field properties correctly" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+      title_field = resource.fields[:title]
+
+      assert %Field{} = title_field
+      assert title_field.kind == :attribute
+      assert title_field.allow_nil? == false
+      assert title_field.primary_key? == false
+    end
+
+    test "includes id as primary key field" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+      id_field = resource.fields[:id]
+
+      assert %Field{} = id_field
+      assert id_field.primary_key? == true
+      assert id_field.type.kind == :uuid
+    end
+
+    test "includes calculations as fields" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+      calc_fields = resource.fields |> Map.values() |> Enum.filter(&(&1.kind == :calculation))
+
+      calc_names = Enum.map(calc_fields, & &1.name)
+      assert :is_overdue in calc_names
+      assert :days_until_due in calc_names
+    end
+
+    test "calculation fields include arguments" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      self_calc = resource.fields[:self]
+      assert self_calc != nil
+      assert self_calc.kind == :calculation
+      assert is_list(self_calc.arguments)
+      assert self_calc.arguments != []
+
+      arg_names = Enum.map(self_calc.arguments, & &1.name)
+      assert :prefix in arg_names
+    end
+
+    test "includes aggregates as fields" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+      agg_fields = resource.fields |> Map.values() |> Enum.filter(&(&1.kind == :aggregate))
+
+      agg_names = Enum.map(agg_fields, & &1.name)
+      assert :comment_count in agg_names
+      assert :has_comments in agg_names
+    end
+
+    test "aggregate fields have aggregate_kind" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      comment_count = resource.fields[:comment_count]
+      assert comment_count.aggregate_kind == :count
+    end
+
+    test "includes relationships" do
+      assert Map.has_key?(ResourceBuilder.build(Ash.Test.Manifest.Todo).relationships, :user)
+      assert Map.has_key?(ResourceBuilder.build(Ash.Test.Manifest.Todo).relationships, :comments)
+    end
+
+    test "relationship properties are correct" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      user_rel = resource.relationships[:user]
+      assert %Relationship{} = user_rel
+      assert user_rel.type == :belongs_to
+      assert user_rel.cardinality == :one
+      assert user_rel.destination == Ash.Test.Manifest.User
+
+      comments_rel = resource.relationships[:comments]
+      assert %Relationship{} = comments_rel
+      assert comments_rel.type == :has_many
+      assert comments_rel.cardinality == :many
+    end
+
+    test "builds embedded resource" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.TodoMetadata)
+      assert resource.embedded? == true
+    end
+
+    test "builds resource with multitenancy" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.OrgTodo)
+
+      if resource.multitenancy do
+        assert is_atom(resource.multitenancy.strategy)
+      end
+    end
+  end
+end

--- a/test/ash/info/manifest/type_resolver_test.exs
+++ b/test/ash/info/manifest/type_resolver_test.exs
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.TypeResolverTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.Generator.TypeResolver
+  alias Ash.Info.Manifest.Type
+
+  describe "resolve/2 primitives" do
+    test "resolves Ash.Type.String" do
+      result = TypeResolver.resolve(Ash.Type.String, [])
+      assert %Type{kind: :string, name: "String"} = result
+    end
+
+    test "resolves Ash.Type.Integer" do
+      result = TypeResolver.resolve(Ash.Type.Integer, [])
+      assert %Type{kind: :integer, name: "Integer"} = result
+    end
+
+    test "resolves Ash.Type.Boolean" do
+      result = TypeResolver.resolve(Ash.Type.Boolean, [])
+      assert %Type{kind: :boolean, name: "Boolean"} = result
+    end
+
+    test "resolves Ash.Type.UUID" do
+      result = TypeResolver.resolve(Ash.Type.UUID, [])
+      assert %Type{kind: :uuid, name: "UUID"} = result
+    end
+
+    test "resolves Ash.Type.Date" do
+      result = TypeResolver.resolve(Ash.Type.Date, [])
+      assert %Type{kind: :date, name: "Date"} = result
+    end
+
+    test "resolves Ash.Type.UtcDatetime" do
+      result = TypeResolver.resolve(Ash.Type.UtcDatetime, [])
+      assert %Type{kind: :utc_datetime, name: "UtcDateTime"} = result
+    end
+
+    test "resolves Ash.Type.Decimal" do
+      result = TypeResolver.resolve(Ash.Type.Decimal, [])
+      assert %Type{kind: :decimal, name: "Decimal"} = result
+    end
+
+    test "resolves Ash.Type.Float" do
+      result = TypeResolver.resolve(Ash.Type.Float, [])
+      assert %Type{kind: :float, name: "Float"} = result
+    end
+  end
+
+  describe "resolve/2 atom shorthands" do
+    test "resolves :string" do
+      assert %Type{kind: :string} = TypeResolver.resolve(:string, [])
+    end
+
+    test "resolves :integer" do
+      assert %Type{kind: :integer} = TypeResolver.resolve(:integer, [])
+    end
+
+    test "resolves :boolean" do
+      assert %Type{kind: :boolean} = TypeResolver.resolve(:boolean, [])
+    end
+
+    test "resolves :uuid" do
+      assert %Type{kind: :uuid} = TypeResolver.resolve(:uuid, [])
+    end
+
+    # Regression: each of these used to resolve to `kind: :unknown` because
+    # they were missing from @atom_primitives. `:file` and `:function` also
+    # crashed `Module.split/1` in the fallback path because they are loaded
+    # Erlang modules.
+    test "resolves every atom shorthand Ash exposes" do
+      assert %Type{kind: :uuid, name: "UUIDv7"} = TypeResolver.resolve(:uuid_v7, [])
+      assert %Type{kind: :time_usec, name: "TimeUsec"} = TypeResolver.resolve(:time_usec, [])
+
+      assert %Type{kind: :binary, name: "UrlEncodedBinary"} =
+               TypeResolver.resolve(:url_encoded_binary, [])
+
+      assert %Type{kind: :atom, name: "Module"} = TypeResolver.resolve(:module, [])
+      assert %Type{kind: :term, name: "File"} = TypeResolver.resolve(:file, [])
+      assert %Type{kind: :term, name: "Function"} = TypeResolver.resolve(:function, [])
+      assert %Type{kind: :term, name: "Vector"} = TypeResolver.resolve(:vector, [])
+    end
+
+    test "atom shorthand and module form resolve to the same kind/name" do
+      pairs = [
+        {:uuid_v7, Ash.Type.UUIDv7},
+        {:time_usec, Ash.Type.TimeUsec},
+        {:url_encoded_binary, Ash.Type.UrlEncodedBinary},
+        {:module, Ash.Type.Module},
+        {:file, Ash.Type.File},
+        {:function, Ash.Type.Function},
+        {:vector, Ash.Type.Vector}
+      ]
+
+      for {shorthand, module} <- pairs do
+        from_shorthand = TypeResolver.resolve(shorthand, [])
+        from_module = TypeResolver.resolve(module, [])
+
+        assert from_shorthand.kind == from_module.kind,
+               "kind mismatch for #{inspect(shorthand)} vs #{inspect(module)}"
+
+        assert from_shorthand.name == from_module.name,
+               "name mismatch for #{inspect(shorthand)} vs #{inspect(module)}"
+      end
+    end
+  end
+
+  describe "resolve/2 arrays" do
+    test "resolves {:array, :string}" do
+      result = TypeResolver.resolve({:array, :string}, [])
+      assert %Type{kind: :array, item_type: %Type{kind: :string}} = result
+    end
+
+    test "resolves {:array, Ash.Type.Integer}" do
+      result = TypeResolver.resolve({:array, Ash.Type.Integer}, [])
+      assert %Type{kind: :array, item_type: %Type{kind: :integer}} = result
+    end
+
+    test "passes items constraints to inner type" do
+      result =
+        TypeResolver.resolve({:array, Ash.Type.Integer}, items: [min: 0])
+
+      assert %Type{kind: :array, item_type: %Type{kind: :integer, constraints: [min: 0]}} =
+               result
+    end
+  end
+
+  describe "resolve/2 enums" do
+    test "resolves named enum type as type_ref" do
+      result = TypeResolver.resolve(Ash.Test.Manifest.Todo.Status, [])
+      assert %Type{kind: :type_ref, module: Ash.Test.Manifest.Todo.Status} = result
+    end
+
+    test "resolves atom with one_of constraint as inline enum" do
+      result = TypeResolver.resolve(Ash.Type.Atom, one_of: [:low, :medium, :high])
+      assert %Type{kind: :enum, values: [:low, :medium, :high]} = result
+    end
+  end
+
+  describe "resolve/2 unions" do
+    test "resolves union type" do
+      constraints = [
+        types: [
+          text: [type: :string],
+          number: [type: :integer]
+        ]
+      ]
+
+      result = TypeResolver.resolve(Ash.Type.Union, constraints)
+      assert %Type{kind: :union, members: members} = result
+      assert length(members) == 2
+      assert Enum.any?(members, &(&1.name == :text))
+      assert Enum.any?(members, &(&1.name == :number))
+    end
+  end
+
+  describe "resolve/2 maps" do
+    test "resolves map with fields" do
+      constraints = [
+        fields: [
+          name: [type: :string, allow_nil?: false],
+          age: [type: :integer, allow_nil?: true]
+        ]
+      ]
+
+      result = TypeResolver.resolve(Ash.Type.Map, constraints)
+      assert %Type{kind: :map, fields: fields} = result
+      assert length(fields) == 2
+      name_field = Enum.find(fields, &(&1.name == :name))
+      assert name_field.allow_nil? == false
+      assert %Type{kind: :string} = name_field.type
+    end
+
+    test "resolves map without fields" do
+      result = TypeResolver.resolve(Ash.Type.Map, [])
+      assert %Type{kind: :map, fields: nil} = result
+    end
+  end
+
+  describe "resolve/2 keyword" do
+    test "resolves keyword with fields" do
+      constraints = [
+        fields: [
+          priority: [type: :integer, allow_nil?: false],
+          category: [type: :string, allow_nil?: true]
+        ]
+      ]
+
+      result = TypeResolver.resolve(Ash.Type.Keyword, constraints)
+      assert %Type{kind: :keyword, fields: fields} = result
+      assert length(fields) == 2
+    end
+  end
+
+  describe "resolve/2 tuple" do
+    test "resolves tuple with fields" do
+      constraints = [
+        fields: [
+          latitude: [type: :float, allow_nil?: false],
+          longitude: [type: :float, allow_nil?: false]
+        ]
+      ]
+
+      result = TypeResolver.resolve(Ash.Type.Tuple, constraints)
+      assert %Type{kind: :tuple, element_types: elements} = result
+      assert length(elements) == 2
+    end
+  end
+
+  describe "resolve/2 struct" do
+    test "resolves struct with resource instance_of" do
+      constraints = [instance_of: Ash.Test.Manifest.User]
+      result = TypeResolver.resolve(Ash.Type.Struct, constraints)
+      assert %Type{kind: :resource, resource_module: Ash.Test.Manifest.User} = result
+    end
+
+    test "resolves struct with embedded resource instance_of" do
+      constraints = [instance_of: Ash.Test.Manifest.TodoMetadata]
+      result = TypeResolver.resolve(Ash.Type.Struct, constraints)
+      assert %Type{resource_module: Ash.Test.Manifest.TodoMetadata} = result
+      assert result.kind in [:resource, :embedded_resource]
+    end
+  end
+
+  describe "resolve/2 embedded resources" do
+    test "resolves embedded resource directly" do
+      result = TypeResolver.resolve(Ash.Test.Manifest.TodoMetadata, [])
+      assert %Type{resource_module: Ash.Test.Manifest.TodoMetadata} = result
+    end
+  end
+
+  describe "resolve/2 additional primitives" do
+    test "resolves Ash.Type.UrlEncodedBinary as binary" do
+      result = TypeResolver.resolve(Ash.Type.UrlEncodedBinary, [])
+      assert %Type{kind: :binary, name: "UrlEncodedBinary"} = result
+    end
+
+    test "resolves Ash.Type.Module as atom" do
+      result = TypeResolver.resolve(Ash.Type.Module, [])
+      assert %Type{kind: :atom, name: "Module"} = result
+    end
+
+    test "resolves Ash.Type.File as term" do
+      result = TypeResolver.resolve(Ash.Type.File, [])
+      assert %Type{kind: :term, name: "File"} = result
+    end
+
+    test "resolves Ash.Type.Function as term" do
+      result = TypeResolver.resolve(Ash.Type.Function, [])
+      assert %Type{kind: :term, name: "Function"} = result
+    end
+
+    test "resolves Ash.Type.Vector as term" do
+      result = TypeResolver.resolve(Ash.Type.Vector, [])
+      assert %Type{kind: :term, name: "Vector"} = result
+    end
+
+    test "resolves Ash.Type.DurationName as type_ref" do
+      result = TypeResolver.resolve(Ash.Type.DurationName, [])
+      assert %Type{kind: :type_ref, module: Ash.Type.DurationName} = result
+    end
+  end
+
+  describe "resolve/2 nil and unknown" do
+    test "resolves nil as unknown" do
+      result = TypeResolver.resolve(nil, [])
+      assert %Type{kind: :unknown} = result
+    end
+  end
+
+  describe "unwrap_new_type/2" do
+    test "unwraps NewType to subtype" do
+      # Todo.Status is a NewType of Ash.Type.Atom
+      {unwrapped, _constraints} =
+        TypeResolver.unwrap_new_type(Ash.Test.Manifest.Todo.Status, [])
+
+      # Should unwrap to the underlying type
+      assert is_atom(unwrapped)
+    end
+
+    test "non-NewType returns unchanged" do
+      {unwrapped, constraints} = TypeResolver.unwrap_new_type(Ash.Type.String, [])
+      assert unwrapped == Ash.Type.String
+      assert constraints == []
+    end
+  end
+
+  describe "resolve_definition/1" do
+    test "resolves enum to full definition with values" do
+      result = TypeResolver.resolve_definition(Ash.Test.Manifest.Todo.Status)
+      assert %Type{kind: :enum, module: Ash.Test.Manifest.Todo.Status, values: values} = result
+      assert is_list(values)
+      assert :pending in values
+    end
+
+    test "resolves Ash.Type.DurationName to full enum definition" do
+      result = TypeResolver.resolve_definition(Ash.Type.DurationName)
+      assert %Type{kind: :enum, module: Ash.Type.DurationName} = result
+      assert :year in result.values
+    end
+  end
+
+  describe "named_type_module?/1" do
+    test "returns true for enum types" do
+      assert TypeResolver.named_type_module?(Ash.Test.Manifest.Todo.Status)
+    end
+
+    test "returns true for Ash.Type.DurationName" do
+      assert TypeResolver.named_type_module?(Ash.Type.DurationName)
+    end
+
+    test "returns false for primitives" do
+      refute TypeResolver.named_type_module?(Ash.Type.String)
+      refute TypeResolver.named_type_module?(Ash.Type.Integer)
+    end
+
+    test "returns false for resources" do
+      refute TypeResolver.named_type_module?(Ash.Test.Manifest.Todo)
+    end
+
+    test "returns false for non-atoms" do
+      refute TypeResolver.named_type_module?({:array, :string})
+    end
+  end
+end

--- a/test/ash/info/manifest/validators_test.exs
+++ b/test/ash/info/manifest/validators_test.exs
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.ValidatorsTest.MixedAcceptResource do
+  @moduledoc false
+  use Ash.Resource, domain: nil
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+    attribute :internal_token, :string, public?: false
+    attribute :other_private, :string, public?: false
+  end
+
+  actions do
+    create :create_all do
+      accept [:name, :internal_token, :other_private]
+    end
+
+    create :create_public_only do
+      accept [:name]
+    end
+
+    create :create_no_accept
+
+    update :update_internal do
+      accept [:internal_token]
+    end
+  end
+end
+
+defmodule Ash.Test.Info.Manifest.ValidatorsTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.Validators
+  alias Ash.Test.Info.Manifest.ValidatorsTest.MixedAcceptResource
+
+  defp action(name), do: Ash.Resource.Info.action(MixedAcceptResource, name)
+
+  describe "validate_accept_public/2" do
+    test "returns :ok when accept contains only public attributes" do
+      assert :ok =
+               Validators.validate_accept_public(MixedAcceptResource, action(:create_public_only))
+    end
+
+    test "returns :ok when accept is nil" do
+      assert :ok =
+               Validators.validate_accept_public(MixedAcceptResource, action(:create_no_accept))
+    end
+
+    test "returns :ok for a plain map with no :accept key" do
+      assert :ok = Validators.validate_accept_public(MixedAcceptResource, %{})
+    end
+
+    test "returns {:error, attrs} listing every non-public attribute in accept" do
+      result = Validators.validate_accept_public(MixedAcceptResource, action(:create_all))
+
+      assert {:error, attrs} = result
+      assert Enum.sort(attrs) == [:internal_token, :other_private]
+    end
+
+    test "works with %Ash.Info.Manifest.Action{}-shaped maps" do
+      spec_action = %{accept: [:name, :internal_token]}
+
+      assert {:error, [:internal_token]} =
+               Validators.validate_accept_public(MixedAcceptResource, spec_action)
+    end
+
+    test "flags non-public attributes on update actions too" do
+      assert {:error, [:internal_token]} =
+               Validators.validate_accept_public(MixedAcceptResource, action(:update_internal))
+    end
+  end
+
+  describe "validate_entrypoint!/2" do
+    test "returns :ok when all accepted attributes are public" do
+      assert :ok =
+               Validators.validate_entrypoint!(MixedAcceptResource, action(:create_public_only))
+    end
+
+    test "returns :ok when accept is nil" do
+      assert :ok = Validators.validate_entrypoint!(MixedAcceptResource, action(:create_no_accept))
+    end
+
+    test "raises NonPublicAccept with resource, action, and offending attrs" do
+      err =
+        assert_raise Ash.Info.Manifest.Error.NonPublicAccept, fn ->
+          Validators.validate_entrypoint!(MixedAcceptResource, action(:create_all))
+        end
+
+      assert err.resource == MixedAcceptResource
+      assert err.action == :create_all
+      assert Enum.sort(err.attributes) == [:internal_token, :other_private]
+      assert err.message =~ "create_all"
+      assert err.message =~ "internal_token"
+      assert err.message =~ "public?: true"
+    end
+  end
+end

--- a/test/support/manifest/domain.ex
+++ b/test/support/manifest/domain.ex
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Domain do
+  @moduledoc """
+  Test domain for Ash.Info.Manifest integration testing.
+  """
+  use Ash.Domain,
+    otp_app: :ash_manifest_test
+
+  resources do
+    resource Ash.Test.Manifest.Todo
+    resource Ash.Test.Manifest.TodoComment
+    resource Ash.Test.Manifest.User
+    resource Ash.Test.Manifest.UserSettings
+    resource Ash.Test.Manifest.OrgTodo
+    resource Ash.Test.Manifest.Task
+    resource Ash.Test.Manifest.NotExposed
+    resource Ash.Test.Manifest.Post
+    resource Ash.Test.Manifest.PostComment
+    resource Ash.Test.Manifest.NoRelationshipsResource
+    resource Ash.Test.Manifest.EmptyResource
+    resource Ash.Test.Manifest.MapFieldResource
+    resource Ash.Test.Manifest.Content
+    resource Ash.Test.Manifest.Article
+    resource Ash.Test.Manifest.Subscription
+    resource Ash.Test.Manifest.TenantSetting
+    resource Ash.Test.Manifest.InputParsing.Resource
+    resource Ash.Test.Manifest.NestedMapResource
+  end
+end

--- a/test/support/manifest/resources/article.ex
+++ b/test/support/manifest/resources/article.ex
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Article do
+  @moduledoc """
+  Test resource representing article content with details.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :hero_image_url, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :hero_image_alt, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :summary, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :body, :string do
+      allow_nil? false
+      public? true
+    end
+
+    create_timestamp :created_at do
+      public? true
+    end
+
+    update_timestamp :updated_at do
+      public? true
+    end
+  end
+
+  relationships do
+    belongs_to :content, Ash.Test.Manifest.Content do
+      allow_nil? false
+      attribute_writable? true
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+
+      accept [
+        :content_id,
+        :hero_image_url,
+        :hero_image_alt,
+        :summary,
+        :body
+      ]
+    end
+
+    update :update do
+      primary? true
+
+      accept [
+        :hero_image_url,
+        :hero_image_alt,
+        :summary,
+        :body
+      ]
+    end
+
+    create :create_with_optional_hero_image do
+      accept [
+        :content_id,
+        :hero_image_url,
+        :hero_image_alt,
+        :summary,
+        :body
+      ]
+
+      # hero_image_url has allow_nil?: false on the attribute,
+      # but this action allows nil input for it
+      allow_nil_input [:hero_image_url]
+    end
+
+    update :update_with_required_hero_image_alt do
+      accept [
+        :hero_image_url,
+        :hero_image_alt,
+        :summary,
+        :body
+      ]
+
+      # hero_image_alt is optional for normal updates,
+      # but this action requires it
+      require_attributes [:hero_image_alt]
+    end
+
+    action :get_important_dates, {:array, :date} do
+      run fn _input, _context ->
+        {:ok, [~D[2025-01-15], ~D[2025-02-20], ~D[2025-03-25]]}
+      end
+    end
+
+    action :get_publication_date, :date do
+      run fn _input, _context ->
+        {:ok, ~D[2025-01-15]}
+      end
+    end
+  end
+end

--- a/test/support/manifest/resources/calculations/item_calculation.ex
+++ b/test/support/manifest/resources/calculations/item_calculation.ex
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.ItemCalculation do
+  @moduledoc """
+  Item calculation that returns the content's article as a union type.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    [:article]
+  end
+
+  @impl true
+  def strict_loads?, do: false
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    Enum.map(records, fn record ->
+      if record.article do
+        %Ash.Union{type: :article, value: record.article}
+      else
+        nil
+      end
+    end)
+  end
+end

--- a/test/support/manifest/resources/calculations/self_calculation.ex
+++ b/test/support/manifest/resources/calculations/self_calculation.ex
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.SelfCalculation do
+  @moduledoc """
+  Self-reference calculation for testing.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    []
+  end
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    # Just return the records unchanged for testing purposes
+    # In a real implementation, you might modify based on the prefix argument
+    records
+  end
+end

--- a/test/support/manifest/resources/calculations/summary_calculation.ex
+++ b/test/support/manifest/resources/calculations/summary_calculation.ex
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.SummaryCalculation do
+  @moduledoc """
+  Summary calculation for todos.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    []
+  end
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    Enum.map(records, fn _record ->
+      # Return a sample TodoStatistics struct for testing
+      %Ash.Test.Manifest.TodoStatistics{
+        view_count: 42,
+        edit_count: 7,
+        completion_time_seconds: 1800,
+        difficulty_rating: 3.5,
+        all_completed?: false,
+        performance_metrics: %{
+          focus_time_seconds: 900,
+          interruption_count: 3,
+          efficiency_score: 0.85,
+          task_complexity: "medium"
+        }
+      }
+    end)
+  end
+end

--- a/test/support/manifest/resources/content.ex
+++ b/test/support/manifest/resources/content.ex
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Content do
+  @moduledoc """
+  Test resource representing content items (articles, videos, etc) in a CMS.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :type, :atom do
+      constraints one_of: [:article]
+      allow_nil? false
+      default :article
+      public? true
+    end
+
+    attribute :title, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :thumbnail_url, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :thumbnail_alt, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :published_at, :utc_datetime do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :category, :atom do
+      constraints one_of: [:fitness, :nutrition, :mindset, :progress]
+      allow_nil? false
+      default :nutrition
+      public? true
+    end
+
+    create_timestamp :created_at do
+      public? true
+    end
+
+    update_timestamp :updated_at do
+      public? true
+    end
+  end
+
+  calculations do
+    calculate :item, Ash.Test.Manifest.ContentItem, Ash.Test.Manifest.ItemCalculation do
+      public? true
+    end
+  end
+
+  relationships do
+    has_one :article, Ash.Test.Manifest.Article do
+      public? true
+    end
+
+    belongs_to :author, Ash.Test.Manifest.User do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:destroy]
+
+    read :read do
+      primary? true
+
+      pagination required?: false,
+                 offset?: true,
+                 keyset?: true
+
+      argument :include_unpublished, :boolean do
+        allow_nil? true
+        default false
+      end
+    end
+
+    read :get_by_id do
+      get_by :id
+
+      argument :include_unpublished, :boolean do
+        allow_nil? true
+        default false
+      end
+    end
+
+    create :create do
+      primary? true
+
+      accept [
+        :type,
+        :title,
+        :thumbnail_url,
+        :thumbnail_alt,
+        :published_at,
+        :category,
+        :author_id
+      ]
+
+      argument :item, :map do
+        allow_nil? false
+
+        constraints fields: [
+                      hero_image_url: [type: :string],
+                      hero_image_alt: [type: :string],
+                      summary: [type: :string],
+                      body: [type: :string, allow_nil?: false]
+                    ]
+      end
+
+      argument :user_id, :uuid do
+        allow_nil? false
+      end
+
+      change manage_relationship(:item, :article, type: :create)
+      change manage_relationship(:user_id, :author, type: :append)
+    end
+
+    update :update do
+      primary? true
+      require_atomic? false
+
+      accept [
+        :type,
+        :title,
+        :thumbnail_url,
+        :thumbnail_alt,
+        :published_at,
+        :category
+      ]
+
+      argument :item, :map do
+        allow_nil? true
+      end
+
+      change manage_relationship(:item, :article, type: :direct_control)
+    end
+  end
+end

--- a/test/support/manifest/resources/embedded/task_metadata.ex
+++ b/test/support/manifest/resources/embedded/task_metadata.ex
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TaskMetadata do
+  @moduledoc """
+  Test embedded resource.
+
+  This resource exercises:
+  - `created_by?` -> `created_by` (removing question mark)
+  - `is_public?` -> `is_public` (removing question mark)
+  """
+
+  use Ash.Resource,
+    data_layer: :embedded,
+    domain: nil
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :notes, :string do
+      public? true
+      allow_nil? true
+    end
+
+    attribute :created_by?, :string do
+      public? true
+      allow_nil? false
+    end
+
+    attribute :is_public?, :boolean do
+      public? true
+      allow_nil? false
+      default false
+    end
+
+    attribute :priority_level, :integer do
+      public? true
+      allow_nil? true
+      constraints min: 1, max: 5
+    end
+  end
+end

--- a/test/support/manifest/resources/embedded/todo_content/checklist_content.ex
+++ b/test/support/manifest/resources/embedded/todo_content/checklist_content.ex
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoContent.ChecklistContent do
+  @moduledoc """
+  Test embedded resource for checklist content (union type member).
+  """
+  use Ash.Resource,
+    data_layer: :embedded,
+    domain: nil
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :title, :string, public?: true, allow_nil?: false
+
+    attribute :items, {:array, :map},
+      public?: true,
+      default: [],
+      constraints: [
+        items: [
+          fields: [
+            text: [type: :string, allow_nil?: false],
+            completed: [type: :boolean],
+            created_at: [type: :utc_datetime]
+          ]
+        ]
+      ]
+
+    attribute :is_active?, :boolean, public?: true, default: true
+
+    attribute :allow_reordering, :boolean, public?: true, default: true
+    attribute :content_type, :string, public?: true, default: "checklist"
+  end
+
+  calculations do
+    calculate :total_items, :integer, expr(length(items)) do
+      public? true
+    end
+
+    calculate :completed_count, :integer, expr(0) do
+      # In a real implementation, this would count completed items
+      public? true
+    end
+
+    calculate :progress_percentage, :float, expr(0.0) do
+      # In a real implementation, this would calculate percentage
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :update, :destroy]
+
+    read :read_with_arg do
+      argument :is_active?, :boolean
+    end
+
+    create :create do
+      primary? true
+      accept [:title, :items, :allow_reordering]
+    end
+  end
+end

--- a/test/support/manifest/resources/embedded/todo_content/link_content.ex
+++ b/test/support/manifest/resources/embedded/todo_content/link_content.ex
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoContent.LinkContent do
+  @moduledoc """
+  Test embedded resource for link content (union type member).
+  """
+  use Ash.Resource,
+    data_layer: :embedded,
+    domain: nil
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :url, :string,
+      public?: true,
+      allow_nil?: false,
+      constraints: [match: ~r/^https?:\/\//]
+
+    attribute :title, :string, public?: true
+    attribute :description, :string, public?: true
+    attribute :preview_image_url, :string, public?: true
+    attribute :is_external, :boolean, public?: true, default: true
+    attribute :last_checked_at, :utc_datetime, public?: true
+    attribute :content_type, :string, public?: true, default: "link"
+  end
+
+  calculations do
+    calculate :display_title, :string, expr(if(is_nil(title), url, title)) do
+      public? true
+    end
+
+    calculate :domain, :string, expr("example.com") do
+      # In a real implementation, this would extract the domain from URL
+      public? true
+    end
+
+    calculate :is_accessible, :boolean, expr(true) do
+      # In a real implementation, this would check if URL is accessible
+      public? true
+    end
+  end
+
+  validations do
+    validate present(:url), message: "URL is required"
+
+    validate match(:url, ~r/^https?:\/\//) do
+      message "URL must start with http or https"
+    end
+  end
+
+  actions do
+    defaults [:read, :update, :destroy]
+
+    create :create do
+      primary? true
+
+      accept [
+        :url,
+        :title,
+        :description,
+        :preview_image_url,
+        :is_external,
+        :last_checked_at,
+        :content_type
+      ]
+    end
+  end
+end

--- a/test/support/manifest/resources/embedded/todo_content/text_content.ex
+++ b/test/support/manifest/resources/embedded/todo_content/text_content.ex
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoContent.TextContent do
+  @moduledoc """
+  Test embedded resource for text content (union type member).
+  """
+  use Ash.Resource,
+    data_layer: :embedded,
+    domain: nil
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :text, :string, public?: true, allow_nil?: false
+
+    attribute :formatting, :atom,
+      public?: true,
+      constraints: [one_of: [:plain, :markdown, :html]],
+      default: :plain
+
+    attribute :word_count, :integer, public?: true, default: 0
+    attribute :content_type, :string, public?: true, default: "text"
+  end
+
+  calculations do
+    calculate :display_text, :string, expr(text) do
+      public? true
+    end
+
+    calculate :is_formatted, :boolean, expr(formatting != :plain) do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :update, :destroy]
+
+    create :create do
+      primary? true
+      accept [:text, :formatting, :word_count]
+    end
+  end
+end

--- a/test/support/manifest/resources/embedded/todo_metadata.ex
+++ b/test/support/manifest/resources/embedded/todo_metadata.ex
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoMetadata do
+  @moduledoc """
+  Test embedded resource for todo metadata with calculations and relationships.
+  """
+  use Ash.Resource,
+    data_layer: :embedded,
+    domain: nil
+
+  attributes do
+    # Primary key for identity testing
+    uuid_primary_key :id
+
+    # String types with constraints
+    attribute :category, :string, public?: true, allow_nil?: false
+    # Optional
+    attribute :subcategory, :string, public?: true
+
+    attribute :external_reference, :string,
+      public?: true,
+      constraints: [match: ~r/^[A-Z]{2}-\d{4}$/]
+
+    # Numeric types
+    attribute :priority_score, :integer,
+      public?: true,
+      default: 0,
+      constraints: [min: 0, max: 100]
+
+    attribute :estimated_hours, :float, public?: true
+    attribute :budget, :decimal, public?: true
+
+    # Boolean and atom types
+    attribute :is_urgent, :boolean, public?: true, default: false
+
+    attribute :status, :atom,
+      public?: true,
+      constraints: [one_of: [:draft, :active, :archived]],
+      default: :draft
+
+    # Date/time types
+    attribute :deadline, :date, public?: true
+    attribute :created_at, :utc_datetime, public?: true, default: &DateTime.utc_now/0
+    attribute :reminder_time, :naive_datetime, public?: true
+    attribute :estimated_duration, :duration, public?: true
+
+    # Collection types
+    attribute :tags, {:array, :string}, public?: true, default: []
+    attribute :labels, {:array, :atom}, public?: true, default: []
+    attribute :custom_fields, :map, public?: true, default: %{}
+
+    attribute :settings, :map,
+      public?: true,
+      constraints: [
+        fields: [
+          notifications: [type: :boolean],
+          auto_archive: [type: :boolean],
+          reminder_frequency: [type: :integer]
+        ]
+      ]
+
+    # Deeply nested TypedMap (TypedMap with nested TypedMap)
+    attribute :advanced_settings, :map,
+      public?: true,
+      constraints: [
+        fields: [
+          theme: [type: :string, allow_nil?: false],
+          display: [
+            type: :map,
+            constraints: [
+              fields: [
+                font_size: [type: :integer],
+                color_scheme: [type: :string],
+                compact_mode: [type: :boolean]
+              ]
+            ]
+          ],
+          sync: [
+            type: :map,
+            constraints: [
+              fields: [
+                enabled: [type: :boolean],
+                interval_minutes: [type: :integer],
+                last_sync: [type: :utc_datetime]
+              ]
+            ]
+          ]
+        ]
+      ]
+
+    # Union type attribute for stress testing
+    attribute :priority_info, :union,
+      public?: true,
+      constraints: [
+        types: [
+          simple: [type: :string],
+          detailed: [
+            type: :map,
+            constraints: [
+              fields: [
+                level: [type: :integer, allow_nil?: false],
+                reason: [type: :string],
+                assigned_by: [type: :string]
+              ]
+            ]
+          ]
+        ]
+      ]
+
+    # UUID types
+    attribute :creator_id, :uuid, public?: true
+    attribute :project_id, :uuid, public?: true
+
+    # Private attribute for testing visibility
+    attribute :internal_notes, :string, public?: false
+  end
+
+  calculations do
+    # Simple calculation (no arguments)
+    calculate :display_category, :string, expr(category || "Uncategorized") do
+      public? true
+    end
+
+    # Calculation with arguments
+    calculate :adjusted_priority,
+              :integer,
+              Ash.Test.Manifest.TodoMetadata.AdjustedPriorityCalculation do
+      public? true
+      argument :urgency_multiplier, :float, default: 1.0, allow_nil?: false
+      argument :deadline_factor, :boolean, default: true
+      argument :user_bias, :integer, default: 0, constraints: [min: -10, max: 10]
+    end
+
+    # Boolean calculation
+    calculate :is_overdue,
+              :boolean,
+              expr(if(is_nil(deadline), false, deadline < ^Date.utc_today())) do
+      public? true
+    end
+
+    # Calculation with format arguments
+    calculate :formatted_summary,
+              :string,
+              Ash.Test.Manifest.TodoMetadata.FormattedSummaryCalculation do
+      public? true
+      argument :format, :atom, constraints: [one_of: [:short, :detailed, :json]], default: :short
+      argument :include_metadata, :boolean, default: false
+    end
+
+    # Private calculation
+    calculate :internal_score, :integer, expr(priority_score * 2) do
+      public? false
+    end
+  end
+
+  validations do
+    validate present(:category), message: "Category is required"
+    validate compare(:priority_score, greater_than_or_equal_to: 0)
+  end
+
+  identities do
+    identity :unique_external_reference, [:external_reference]
+  end
+
+  actions do
+    defaults [:read, :update, :destroy]
+
+    create :create do
+      primary? true
+
+      accept [
+        :category,
+        :subcategory,
+        :external_reference,
+        :priority_score,
+        :estimated_hours,
+        :budget,
+        :is_urgent,
+        :status,
+        :deadline,
+        :created_at,
+        :reminder_time,
+        :tags,
+        :labels,
+        :custom_fields,
+        :settings,
+        :creator_id,
+        :project_id
+      ]
+    end
+
+    create :create_with_defaults do
+      accept [:category, :priority_score]
+    end
+
+    update :archive do
+      accept []
+      change set_attribute(:status, :archived)
+    end
+  end
+end

--- a/test/support/manifest/resources/embedded/todo_metadata/adjusted_priority_calculation.ex
+++ b/test/support/manifest/resources/embedded/todo_metadata/adjusted_priority_calculation.ex
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoMetadata.AdjustedPriorityCalculation do
+  @moduledoc """
+  Adjusted priority calculation for todo metadata.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    [:priority_score, :is_urgent, :deadline]
+  end
+
+  @impl true
+  def calculate(records, opts, _context) do
+    urgency_multiplier = opts[:urgency_multiplier] || 1.0
+    deadline_factor = opts[:deadline_factor] || true
+    user_bias = opts[:user_bias] || 0
+
+    Enum.map(records, fn record ->
+      base_priority = record.priority_score || 0
+
+      # Apply urgency multiplier
+      adjusted =
+        if record.is_urgent do
+          round(base_priority * urgency_multiplier)
+        else
+          base_priority
+        end
+
+      # Apply deadline factor
+      adjusted =
+        if deadline_factor && record.deadline do
+          days_until_deadline = Date.diff(record.deadline, Date.utc_today())
+
+          case days_until_deadline do
+            # Very urgent
+            days when days <= 1 -> adjusted + 20
+            # Urgent
+            days when days <= 7 -> adjusted + 10
+            # Somewhat urgent
+            days when days <= 30 -> adjusted + 5
+            _ -> adjusted
+          end
+        else
+          adjusted
+        end
+
+      # Apply user bias
+      final_priority = adjusted + user_bias
+
+      # Ensure within bounds [0, 100]
+      max(0, min(100, final_priority))
+    end)
+  end
+
+  # Workaround for Ash framework compatibility issue with calculations that have arguments
+  # in embedded resources. This should not be needed but is required in Ash 3.5.33
+  def merge_load(_left, _right, _constraints, _context) do
+    # For simple calculations that return basic types like :integer,
+    # there's no complex loading to merge, so we just return success
+    {:ok, []}
+  end
+
+  def get_rewrites(_merged_load, _calculation, _path, _constraints) do
+    # No rewrites needed for this simple calculation
+    []
+  end
+end

--- a/test/support/manifest/resources/embedded/todo_metadata/formatted_summary_calculation.ex
+++ b/test/support/manifest/resources/embedded/todo_metadata/formatted_summary_calculation.ex
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoMetadata.FormattedSummaryCalculation do
+  @moduledoc """
+  Formatted summary calculation for todo metadata.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    [
+      :category,
+      :subcategory,
+      :priority_score,
+      :status,
+      :is_urgent,
+      :deadline,
+      :tags,
+      :custom_fields
+    ]
+  end
+
+  @impl true
+  def calculate(records, opts, _context) do
+    format = opts[:format] || :short
+    include_metadata = opts[:include_metadata] || false
+
+    Enum.map(records, fn record ->
+      case format do
+        :short ->
+          build_short_summary(record, include_metadata)
+
+        :detailed ->
+          build_detailed_summary(record, include_metadata)
+
+        :json ->
+          build_json_summary(record, include_metadata)
+
+        _ ->
+          "Unknown format"
+      end
+    end)
+  end
+
+  defp build_short_summary(record, include_metadata) do
+    base = record.category || "Uncategorized"
+
+    base =
+      if record.subcategory do
+        "#{base} > #{record.subcategory}"
+      else
+        base
+      end
+
+    base =
+      if record.is_urgent do
+        "🚨 #{base}"
+      else
+        base
+      end
+
+    if include_metadata do
+      "#{base} (Priority: #{record.priority_score || 0})"
+    else
+      base
+    end
+  end
+
+  defp build_detailed_summary(record, include_metadata) do
+    parts = []
+
+    # Category info
+    category_part = record.category || "Uncategorized"
+
+    category_part =
+      if record.subcategory do
+        "#{category_part} > #{record.subcategory}"
+      else
+        category_part
+      end
+
+    parts = [category_part | parts]
+
+    # Status and urgency
+    status_part = "Status: #{record.status || :draft}"
+
+    status_part =
+      if record.is_urgent do
+        "#{status_part} (URGENT)"
+      else
+        status_part
+      end
+
+    parts = [status_part | parts]
+
+    # Priority
+    parts =
+      if record.priority_score do
+        ["Priority: #{record.priority_score}/100" | parts]
+      else
+        parts
+      end
+
+    # Deadline
+    parts =
+      if record.deadline do
+        days_until = Date.diff(record.deadline, Date.utc_today())
+
+        deadline_text =
+          case days_until do
+            days when days < 0 -> "Overdue by #{abs(days)} days"
+            0 -> "Due today"
+            days when days <= 7 -> "Due in #{days} days"
+            _days -> "Due #{Date.to_string(record.deadline)}"
+          end
+
+        ["Deadline: #{deadline_text}" | parts]
+      else
+        parts
+      end
+
+    # Tags
+    parts =
+      if (record.tags || []) != [] do
+        ["Tags: #{Enum.join(record.tags, ", ")}" | parts]
+      else
+        parts
+      end
+
+    # Metadata
+    parts =
+      if include_metadata && record.custom_fields && map_size(record.custom_fields) > 0 do
+        metadata_count = map_size(record.custom_fields)
+        ["Custom fields: #{metadata_count}" | parts]
+      else
+        parts
+      end
+
+    Enum.reverse(parts) |> Enum.join(" | ")
+  end
+
+  defp build_json_summary(record, include_metadata) do
+    base_data = %{
+      category: record.category,
+      subcategory: record.subcategory,
+      status: record.status,
+      is_urgent: record.is_urgent,
+      priority_score: record.priority_score
+    }
+
+    data_with_deadline =
+      if record.deadline do
+        Map.put(base_data, :deadline, Date.to_string(record.deadline))
+      else
+        base_data
+      end
+
+    data_with_tags =
+      if (record.tags || []) != [] do
+        Map.put(data_with_deadline, :tags, record.tags)
+      else
+        data_with_deadline
+      end
+
+    final_data =
+      if include_metadata && record.custom_fields && map_size(record.custom_fields) > 0 do
+        Map.put(data_with_tags, :custom_fields, record.custom_fields)
+      else
+        data_with_tags
+      end
+
+    Jason.encode!(final_data)
+  rescue
+    _ -> "{\"error\": \"Failed to encode JSON\"}"
+  end
+end

--- a/test/support/manifest/resources/empty_resource.ex
+++ b/test/support/manifest/resources/empty_resource.ex
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.EmptyResource do
+  @moduledoc """
+  Test resource with minimal configuration.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id, public?: false
+  end
+
+  actions do
+    defaults [:read]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/attachment_file.ex
+++ b/test/support/manifest/resources/input_parsing/attachment_file.ex
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.AttachmentFile do
+  @moduledoc """
+  Embedded resource for array of unions testing - file attachment type.
+
+  Embedded resource used as a union member inside an array.
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :attachment_type, :string do
+      allow_nil? false
+      default "file"
+      public? true
+    end
+
+    attribute :filename, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :mime_type, :string do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :is_public_1?, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :size_bytes_1, :integer do
+      allow_nil? true
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/attachment_link.ex
+++ b/test/support/manifest/resources/input_parsing/attachment_link.ex
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.AttachmentLink do
+  @moduledoc """
+  Embedded resource for array of unions testing - link attachment type.
+
+  Embedded resource used as a union member inside an array.
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :attachment_type, :string do
+      allow_nil? false
+      default "link"
+      public? true
+    end
+
+    attribute :url, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :title, :string do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :is_external_1?, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :click_count_1, :integer do
+      default 0
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/data_content_map.ex
+++ b/test/support/manifest/resources/input_parsing/data_content_map.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.DataContentMap do
+  @moduledoc """
+  NewType for the 'data' union member with constrained fields.
+
+  Maps is_cached? to isCached to satisfy verifier requirements.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        item_count: [type: :integer, allow_nil?: false],
+        is_cached?: [type: :boolean, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/deep_nested_settings.ex
+++ b/test/support/manifest/resources/input_parsing/deep_nested_settings.ex
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.DeepNestedSettings do
+  @moduledoc """
+  NewType for testing deeply nested typed maps, constrained at each level.
+
+  Tests: outer_map (constrained fields) → inner_config (NewType with constrained fields)
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        display_name: [type: :string, allow_nil?: false],
+        is_enabled_1?: [type: :boolean, allow_nil?: true],
+        inner_config: [
+          type: Ash.Test.Manifest.InputParsing.InnerConfig,
+          allow_nil?: true
+        ]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/history_entry.ex
+++ b/test/support/manifest/resources/input_parsing/history_entry.ex
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.HistoryEntry do
+  @moduledoc """
+  Embedded resource for testing arrays of embedded resources.
+
+  Used to verify that arrays of embedded resources correctly apply
+  how embedded-resource arguments appear in the manifest.
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :action_name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :timestamp, :utc_datetime do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :change_count_1, :integer do
+      default 1
+      public? true
+    end
+
+    attribute :was_reverted?, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :details, :map do
+      allow_nil? true
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/inner_config.ex
+++ b/test/support/manifest/resources/input_parsing/inner_config.ex
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.InnerConfig do
+  @moduledoc """
+  NewType for inner config with constrained fields.
+
+  Used to exercise nested typed maps where both outer and inner are constrained.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        max_retries_1: [type: :integer, allow_nil?: false],
+        is_cached?: [type: :boolean, allow_nil?: true],
+        timeout_ms: [type: :integer, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/input_data_map.ex
+++ b/test/support/manifest/resources/input_parsing/input_data_map.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.InputDataMap do
+  @moduledoc """
+  NewType for the process_data action's input_data argument.
+
+  Maps is_valid? to isValid to satisfy verifier requirements.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        item_name: [type: :string, allow_nil?: false],
+        is_valid?: [type: :boolean, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/location_tuple.ex
+++ b/test/support/manifest/resources/input_parsing/location_tuple.ex
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.LocationTuple do
+  @moduledoc """
+  NewType tuple with constrained fields for the manifest type resolver.
+
+  Exercises a `:tuple` NewType with element names that include trailing
+  `?` and trailing `_N` to ensure the manifest resolves tuple shapes
+  correctly.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :tuple,
+    constraints: [
+      fields: [
+        lat_1: [type: :float, allow_nil?: false],
+        lng_1: [type: :float, allow_nil?: false],
+        is_verified?: [type: :boolean, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/nested_profile.ex
+++ b/test/support/manifest/resources/input_parsing/nested_profile.ex
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.NestedProfile do
+  @moduledoc """
+  Embedded resource containing another embedded resource for deep nesting tests.
+
+  Tests 3-level nesting: Resource → NestedProfile → Profile (embedded)
+  Each level has its own constrained fields.
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :section_name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :level_1?, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :has_details?, :boolean do
+      default true
+      public? true
+    end
+
+    # Embedded resource within embedded resource - creates 3-level nesting
+    attribute :detail_profile, Ash.Test.Manifest.InputParsing.Profile do
+      allow_nil? true
+      public? true
+    end
+
+    # NewType with constrained fields nested in an embedded resource
+    attribute :detail_stats, Ash.Test.Manifest.InputParsing.Stats do
+      allow_nil? true
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/nested_settings.ex
+++ b/test/support/manifest/resources/input_parsing/nested_settings.ex
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.NestedSettings do
+  @moduledoc """
+  NewType for testing nested typed maps (map containing another typed map).
+
+  Tests deep nesting: outer_map → inner_map, each constrained.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        display_name: [type: :string, allow_nil?: false],
+        is_enabled_1?: [type: :boolean, allow_nil?: true],
+        inner_config: [
+          type: :map,
+          allow_nil?: true,
+          constraints: [
+            fields: [
+              max_retries_1: [type: :integer, allow_nil?: false],
+              is_cached?: [type: :boolean, allow_nil?: true],
+              timeout_ms: [type: :integer, allow_nil?: true]
+            ]
+          ]
+        ]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/options.ex
+++ b/test/support/manifest/resources/input_parsing/options.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.Options do
+  @moduledoc """
+  NewType for the manifest type resolver with action arguments.
+
+  Tests constrained fields with argument types.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        cache_enabled_1?: [type: :boolean, allow_nil?: true],
+        retry_limit: [type: :integer, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/preferences_keyword.ex
+++ b/test/support/manifest/resources/input_parsing/preferences_keyword.ex
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.PreferencesKeyword do
+  @moduledoc """
+  NewType keyword with constrained fields for the manifest type resolver.
+
+  Exercises a `:keyword` NewType with field names that include trailing
+  `?` and trailing `_N` to ensure the manifest resolves keyword shapes
+  correctly.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :keyword,
+    constraints: [
+      fields: [
+        theme_1: [type: :string, allow_nil?: false],
+        font_size: [type: :integer, allow_nil?: true],
+        is_dark_mode?: [type: :boolean, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/process_profile_result.ex
+++ b/test/support/manifest/resources/input_parsing/process_profile_result.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.ProcessProfileResult do
+  @moduledoc """
+  NewType for process_profile action return type with constrained fields.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        profile_name: [type: :string, allow_nil?: false],
+        is_processed?: [type: :boolean, allow_nil?: false]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/profile.ex
+++ b/test/support/manifest/resources/input_parsing/profile.ex
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.Profile do
+  @moduledoc """
+  Embedded resource for the manifest type resolver with nested resources.
+
+  Contains plain attributes alongside attributes with unusual
+  identifiers (trailing `?`).
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :display_name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :bio_text_1, :string do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :is_public?, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :follower_count, :integer do
+      default 0
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/resource.ex
+++ b/test/support/manifest/resources/input_parsing/resource.ex
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.Resource do
+  @moduledoc """
+  Stress-test resource exercising the manifest type resolver on edge cases.
+
+  Exercises:
+  1. Plain attributes
+  2. Attribute names with unusual characters (trailing `?`, trailing `_N`)
+  3. Arguments with unusual names
+  4. Nested embedded resources with various field shapes
+  5. NewTypes with constrained map/keyword/tuple fields
+  6. Union types with various member shapes
+  7. Deeply nested typed maps (outer → inner)
+  8. 3-level embedded resource nesting (Resource → NestedProfile → Profile)
+  9. Union with `:map_with_tag` storage
+  10. Array of unions with embedded resource members
+  11. Generic action with embedded resource argument
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    # Plain attributes
+    attribute :user_name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :email_address, :string do
+      allow_nil? false
+      public? true
+    end
+
+    # Additional attribute
+    attribute :display_name, :string do
+      allow_nil? true
+      public? true
+    end
+
+    # Attributes with unusual identifiers (trailing `?`, trailing `_N`)
+    attribute :is_active?, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :has_data?, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :version_1, :integer do
+      default 1
+      public? true
+    end
+
+    # Typed map with field constraints
+    attribute :settings, :map do
+      public? true
+
+      constraints fields: [
+                    notification_enabled: [type: :boolean, allow_nil?: false],
+                    theme_name: [type: :string, allow_nil?: true],
+                    retry_count: [type: :integer, allow_nil?: true]
+                  ]
+    end
+
+    # Typed map using a NewType with constrained fields
+    attribute :stats, Ash.Test.Manifest.InputParsing.Stats do
+      public? true
+    end
+
+    # Embedded resource attribute
+    attribute :profile_data, Ash.Test.Manifest.InputParsing.Profile do
+      public? true
+    end
+
+    # Array of embedded resources
+    attribute :history, {:array, Ash.Test.Manifest.InputParsing.HistoryEntry} do
+      default []
+      public? true
+    end
+
+    # Union type with embedded resources and NewType map member
+    attribute :content, :union do
+      public? true
+
+      constraints types: [
+                    # Embedded resource member
+                    text: [
+                      type: Ash.Test.Manifest.InputParsing.TextContent,
+                      tag: :content_type,
+                      tag_value: "text"
+                    ],
+                    # NewType map member with constrained fields
+                    data: [
+                      type: Ash.Test.Manifest.InputParsing.DataContentMap,
+                      tag: :content_type,
+                      tag_value: "data"
+                    ],
+                    # Simple type member (no special handling needed)
+                    simple_value: [type: :string]
+                  ],
+                  storage: :type_and_value
+    end
+
+    # =========================================================================
+    # Additional attributes for exhaustive type resolver coverage
+    # =========================================================================
+
+    # Tuple type with constrained fields
+    attribute :location, Ash.Test.Manifest.InputParsing.LocationTuple do
+      public? true
+    end
+
+    # Keyword type with constrained fields
+    attribute :preferences, Ash.Test.Manifest.InputParsing.PreferencesKeyword do
+      public? true
+    end
+
+    # Deeply nested typed maps
+    attribute :deep_settings, Ash.Test.Manifest.InputParsing.DeepNestedSettings do
+      public? true
+    end
+
+    # 3-level embedded resource nesting
+    attribute :nested_profile, Ash.Test.Manifest.InputParsing.NestedProfile do
+      public? true
+    end
+
+    # Union with :map_with_tag storage (different from :type_and_value)
+    # Exercises union resolution for :map_with_tag storage
+    # Note: map_with_tag requires ALL members to have tags
+    attribute :tagged_status, :union do
+      public? true
+
+      constraints types: [
+                    active: [
+                      type: Ash.Test.Manifest.InputParsing.TaggedStatus,
+                      tag: :status_type,
+                      tag_value: "active"
+                    ],
+                    inactive: [
+                      type: Ash.Test.Manifest.InputParsing.TaggedStatus,
+                      tag: :status_type,
+                      tag_value: "inactive"
+                    ]
+                  ],
+                  storage: :map_with_tag
+    end
+
+    # Array of unions with embedded resource members
+    # Tests array union input
+    attribute :attachments, {:array, :union} do
+      public? true
+      default []
+
+      constraints items: [
+                    types: [
+                      file: [
+                        type: Ash.Test.Manifest.InputParsing.AttachmentFile,
+                        tag: :attachment_type,
+                        tag_value: "file"
+                      ],
+                      link: [
+                        type: Ash.Test.Manifest.InputParsing.AttachmentLink,
+                        tag: :attachment_type,
+                        tag_value: "link"
+                      ],
+                      # Simple string member for comparison
+                      note: [type: :string]
+                    ]
+                  ]
+    end
+
+    create_timestamp :created_at do
+      public? true
+    end
+
+    update_timestamp :updated_at
+  end
+
+  actions do
+    defaults [:destroy]
+
+    read :read do
+      primary? true
+    end
+
+    read :get_by_id do
+      get_by :id
+    end
+
+    # Search action with mapped argument names
+    read :search do
+      argument :query, :string, allow_nil?: false
+
+      argument :include_deleted?, :boolean do
+        default false
+      end
+
+      argument :filter_by_1?, :boolean do
+        default false
+      end
+
+      filter expr(contains(user_name, ^arg(:query)) or contains(email_address, ^arg(:query)))
+    end
+
+    create :create do
+      primary? true
+
+      accept [
+        :user_name,
+        :email_address,
+        :display_name,
+        :is_active?,
+        :has_data?,
+        :version_1,
+        :settings,
+        :stats,
+        :profile_data,
+        :history,
+        :content,
+        # New attributes for exhaustive coverage
+        :location,
+        :preferences,
+        :deep_settings,
+        :nested_profile,
+        :tagged_status,
+        :attachments
+      ]
+    end
+
+    # Create action with mapped argument names
+    create :create_with_args do
+      accept [
+        :user_name,
+        :email_address,
+        :is_active?,
+        :has_data?,
+        :settings
+      ]
+
+      argument :is_urgent?, :boolean do
+        default false
+      end
+
+      argument :priority_1, :integer do
+        default 1
+      end
+
+      argument :extra_data, :map do
+        allow_nil? true
+      end
+    end
+
+    update :update do
+      primary? true
+      require_atomic? false
+
+      accept [
+        :user_name,
+        :email_address,
+        :display_name,
+        :is_active?,
+        :has_data?,
+        :version_1,
+        :settings,
+        :stats,
+        :profile_data,
+        :history,
+        :content,
+        # New attributes for exhaustive coverage
+        :location,
+        :preferences,
+        :deep_settings,
+        :nested_profile,
+        :tagged_status,
+        :attachments
+      ]
+    end
+
+    # Generic action to test input/output with NewType argument
+    action :process_data, :map do
+      constraints fields: [
+                    processed: [type: :boolean, allow_nil?: false],
+                    result_count: [type: :integer, allow_nil?: false]
+                  ]
+
+      # Uses NewType with constrained fields
+      argument :input_data, Ash.Test.Manifest.InputParsing.InputDataMap do
+        allow_nil? false
+      end
+
+      # Uses NewType with constrained fields
+      argument :options, Ash.Test.Manifest.InputParsing.Options do
+        allow_nil? true
+      end
+
+      run fn input, _context ->
+        {:ok,
+         %{
+           processed: true,
+           result_count: 1
+         }}
+      end
+    end
+
+    # Generic action with embedded resource argument
+    # Action argument is a full embedded resource
+    action :process_profile, Ash.Test.Manifest.InputParsing.ProcessProfileResult do
+      # Embedded resource as action argument
+      argument :profile, Ash.Test.Manifest.InputParsing.Profile do
+        allow_nil? false
+      end
+
+      # Optional nested profile for deeper nesting test
+      argument :nested, Ash.Test.Manifest.InputParsing.NestedProfile do
+        allow_nil? true
+      end
+
+      run fn input, _context ->
+        profile = input.arguments.profile
+
+        {:ok,
+         %{
+           profile_name: profile.display_name,
+           is_processed?: true
+         }}
+      end
+    end
+  end
+end

--- a/test/support/manifest/resources/input_parsing/stats.ex
+++ b/test/support/manifest/resources/input_parsing/stats.ex
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.Stats do
+  @moduledoc """
+  NewType with constrained fields for the manifest type resolver.
+
+  Exercises field names that include unusual identifiers (trailing `?`,
+  trailing `_N`) to ensure they round-trip through the manifest as-is.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        total_count_1: [type: :integer, allow_nil?: false],
+        is_complete?: [type: :boolean, allow_nil?: true],
+        last_updated_at: [type: :utc_datetime, allow_nil?: true]
+      ]
+    ]
+end

--- a/test/support/manifest/resources/input_parsing/tagged_status.ex
+++ b/test/support/manifest/resources/input_parsing/tagged_status.ex
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.TaggedStatus do
+  @moduledoc """
+  Embedded resource for union member with map_with_tag storage.
+
+  Used to test union input with :map_with_tag storage mode.
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :status_type, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :message, :string do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :is_final?, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :priority_1, :integer do
+      default 0
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/input_parsing/text_content.ex
+++ b/test/support/manifest/resources/input_parsing/text_content.ex
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.InputParsing.TextContent do
+  @moduledoc """
+  Embedded resource used as a union member.
+
+  Used as a tagged union member to verify that union type inputs
+  correctly resolve embedded resource fields.
+  """
+  use Ash.Resource,
+    data_layer: :embedded
+
+  attributes do
+    attribute :content_type, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :body, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :word_count_1, :integer do
+      default 0
+      public? true
+    end
+
+    attribute :is_formatted?, :boolean do
+      default false
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/map_field_resource.ex
+++ b/test/support/manifest/resources/map_field_resource.ex
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.MapFieldResource do
+  @moduledoc false
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :metadata, Ash.Test.Manifest.CustomMetadata do
+      public? true
+    end
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end

--- a/test/support/manifest/resources/nested_map_resource.ex
+++ b/test/support/manifest/resources/nested_map_resource.ex
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.NestedMapResource do
+  @moduledoc """
+  Test resource exercising nested map fields inside array constraints.
+
+  Verifies that the manifest resolves nested field shapes inside an
+  `{:array, :map}` attribute and preserves them in the type IR.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    action :list_users_map, :map do
+      constraints fields: [
+                    results: [
+                      type: {:array, :map},
+                      constraints: [
+                        items: [
+                          fields: [
+                            id: [type: :string],
+                            email: [type: :string],
+                            first_name: [type: :string, allow_nil?: true],
+                            last_name: [type: :string, allow_nil?: true],
+                            phone: [type: :string, allow_nil?: true],
+                            is_admin: [type: :boolean, allow_nil?: true],
+                            confirmed_at: [type: :utc_datetime_usec, allow_nil?: true],
+                            inserted_at: [type: :utc_datetime_usec]
+                          ]
+                        ]
+                      ]
+                    ],
+                    total_count: [type: :integer]
+                  ]
+
+      run fn _input, _context ->
+        {:ok,
+         %{
+           results: [
+             %{
+               id: "user-1",
+               email: "test@example.com",
+               first_name: "Test",
+               last_name: "User",
+               phone: nil,
+               is_admin: false,
+               confirmed_at: nil,
+               inserted_at: ~U[2025-01-01 00:00:00Z]
+             }
+           ],
+           total_count: 1
+         }}
+      end
+    end
+
+    action :get_metrics, :map do
+      constraints fields: [
+                    total: [type: :integer],
+                    last_week: [type: :integer],
+                    last_month: [type: :integer],
+                    last_year: [type: :integer]
+                  ]
+
+      run fn _input, _context ->
+        {:ok,
+         %{
+           total: 100,
+           last_week: 10,
+           last_month: 40,
+           last_year: 100
+         }}
+      end
+    end
+
+    # Deeply nested map for additional testing
+    action :get_nested_stats, :map do
+      constraints fields: [
+                    user_stats: [
+                      type: :map,
+                      constraints: [
+                        fields: [
+                          active_users: [type: :integer],
+                          new_signups: [type: :integer],
+                          churn_rate: [type: :float]
+                        ]
+                      ]
+                    ],
+                    content_stats: [
+                      type: :map,
+                      constraints: [
+                        fields: [
+                          total_posts: [type: :integer],
+                          posts_this_week: [type: :integer],
+                          avg_engagement_rate: [type: :float]
+                        ]
+                      ]
+                    ]
+                  ]
+
+      run fn _input, _context ->
+        {:ok,
+         %{
+           user_stats: %{
+             active_users: 1000,
+             new_signups: 50,
+             churn_rate: 0.05
+           },
+           content_stats: %{
+             total_posts: 5000,
+             posts_this_week: 100,
+             avg_engagement_rate: 0.15
+           }
+         }}
+      end
+    end
+  end
+end

--- a/test/support/manifest/resources/no_relationships_resource.ex
+++ b/test/support/manifest/resources/no_relationships_resource.ex
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.NoRelationshipsResource do
+  @moduledoc """
+  Test resource without any relationships.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+  end
+
+  actions do
+    defaults [:read]
+  end
+end

--- a/test/support/manifest/resources/not_exposed.ex
+++ b/test/support/manifest/resources/not_exposed.ex
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.NotExposed do
+  @moduledoc """
+  Test resource not exposed to manifest generation.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :email, :string do
+      allow_nil? false
+      public? true
+    end
+  end
+
+  relationships do
+    belongs_to :todo, Ash.Test.Manifest.Todo do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:email, :name]
+    end
+
+    update :update do
+      accept [:name]
+    end
+
+    destroy :destroy do
+      accept []
+    end
+  end
+end

--- a/test/support/manifest/resources/org_todo.ex
+++ b/test/support/manifest/resources/org_todo.ex
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.OrgTodo do
+  @moduledoc """
+  Test resource for organization-level todos with multitenancy support.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  multitenancy do
+    strategy :context
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :title, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :description, :string do
+      public? true
+    end
+
+    attribute :completed, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :status, Ash.Test.Manifest.Todo.Status do
+      default :pending
+      public? true
+    end
+
+    attribute :priority, :atom do
+      constraints one_of: [:low, :medium, :high, :urgent]
+      default :medium
+      public? true
+    end
+
+    attribute :due_date, :date do
+      public? true
+    end
+
+    attribute :tags, {:array, :string} do
+      default []
+      public? true
+    end
+
+    attribute :metadata, :map do
+      public? true
+    end
+
+    create_timestamp :created_at do
+      public? true
+    end
+
+    update_timestamp :updated_at
+  end
+
+  relationships do
+    belongs_to :user, Ash.Test.Manifest.User do
+      allow_nil? false
+      public? true
+    end
+  end
+
+  aggregates do
+    # Aggregates removed as they referenced comment relationships
+    # which are not applicable for the simplified OrgTodo resource
+  end
+
+  calculations do
+    calculate :is_overdue, :boolean, Ash.Test.Manifest.IsOverdueCalculation do
+      public? true
+    end
+
+    calculate :days_until_due, :integer, Ash.Test.Manifest.Todo.SimpleDateCalculation do
+      public? true
+    end
+
+    calculate :self, :struct, Ash.Test.Manifest.SelfCalculation do
+      constraints instance_of: __MODULE__
+      public? true
+
+      argument :prefix, :string do
+        allow_nil? true
+        default nil
+      end
+    end
+  end
+
+  actions do
+    defaults [:destroy]
+
+    read :read do
+      primary? true
+      argument :filter_completed, :boolean
+
+      argument :priority_filter, :atom do
+        constraints one_of: [:low, :medium, :high, :urgent]
+      end
+
+      # Private argument for internal use - should NOT appear in the manifest
+      argument :internal_audit_mode, :boolean do
+        public? false
+        default false
+      end
+
+      filter expr(
+               if is_nil(^arg(:filter_completed)) do
+                 true
+               else
+                 completed == ^arg(:filter_completed)
+               end and
+                 if is_nil(^arg(:priority_filter)) do
+                   true
+                 else
+                   priority == ^arg(:priority_filter)
+                 end
+             )
+    end
+
+    read :get_by_id do
+      get_by [:id]
+    end
+
+    create :create do
+      primary? true
+      accept [:title, :description, :status, :priority, :due_date, :tags, :metadata]
+
+      argument :auto_complete, :boolean do
+        default false
+      end
+
+      argument :user_id, :uuid do
+        allow_nil? false
+      end
+
+      # Private argument for internal tracking - should NOT appear in the manifest
+      argument :internal_tracking_id, :string do
+        public? false
+        default nil
+      end
+
+      argument :number_of_employees, :integer do
+        allow_nil? false
+        constraints min: 1, max: 1000
+      end
+
+      argument :some_string, :string do
+        allow_nil? false
+        constraints min_length: 1, max_length: 100
+      end
+
+      # Regex constraint tests - various patterns
+      argument :email, :string do
+        allow_nil? false
+        constraints match: ~r/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+      end
+
+      argument :phone_number, :string do
+        allow_nil? false
+        constraints match: ~r/^\+?[1-9]\d{1,14}$/
+      end
+
+      argument :hex_color, :string do
+        allow_nil? false
+        constraints match: ~r/^#[0-9A-Fa-f]{6}$/
+      end
+
+      argument :slug, :string do
+        allow_nil? false
+        constraints match: ~r/^[a-z0-9]+(?:-[a-z0-9]+)*$/
+      end
+
+      argument :version, :string do
+        allow_nil? false
+        constraints match: ~r/^\d+\.\d+\.\d+$/
+      end
+
+      argument :case_insensitive_code, :string do
+        allow_nil? false
+        constraints match: ~r/^[A-Z]{3}-\d{4}$/i
+      end
+
+      argument :optional_url, :string do
+        allow_nil? true
+        constraints match: ~r/^https?:\/\/.+/
+      end
+
+      # Float constraint tests
+      argument :price, :float do
+        allow_nil? false
+        constraints min: 0.0, max: 999_999.99
+      end
+
+      argument :temperature, :float do
+        allow_nil? false
+        constraints greater_than: -273.15, less_than: 1_000_000.0
+      end
+
+      argument :percentage, :float do
+        allow_nil? false
+        constraints min: 0.0, max: 100.0
+      end
+
+      argument :optional_rating, :float do
+        allow_nil? true
+        constraints min: 0.0, max: 5.0
+      end
+
+      # CiString constraint tests
+      argument :username, :ci_string do
+        allow_nil? false
+        constraints min_length: 3, max_length: 20
+      end
+
+      argument :company_name, :ci_string do
+        allow_nil? false
+        constraints min_length: 2, max_length: 100, match: ~r/^[a-zA-Z0-9\s]+$/
+      end
+
+      argument :country_code, :ci_string do
+        allow_nil? false
+        constraints match: ~r/^[A-Z]{2}$/i
+      end
+
+      argument :optional_nickname, :ci_string do
+        allow_nil? true
+        constraints min_length: 2, max_length: 15
+      end
+
+      argument :address, :map do
+        constraints fields: [
+                      street_address: [
+                        type: :string,
+                        allow_nil?: false,
+                        description: "Street Address is required",
+                        constraints: [min_length: 5]
+                      ],
+                      location_id: [
+                        type: :string,
+                        allow_nil?: false,
+                        description: "Postal code is required",
+                        constraints: [min_length: 5]
+                      ],
+                      details: [type: :string, allow_nil?: true]
+                    ]
+
+        allow_nil? false
+      end
+
+      change set_attribute(:completed, arg(:auto_complete))
+      change manage_relationship(:user_id, :user, type: :append)
+    end
+
+    update :update do
+      primary? true
+      accept [:title, :description, :completed, :status, :priority, :due_date, :tags, :metadata]
+    end
+
+    update :complete do
+      accept []
+      change set_attribute(:completed, true)
+    end
+
+    update :set_priority do
+      argument :priority, :atom do
+        allow_nil? false
+        constraints one_of: [:low, :medium, :high, :urgent]
+      end
+
+      # Private argument for internal use - should NOT appear in the manifest
+      argument :bypass_validation, :boolean do
+        public? false
+        default false
+      end
+
+      change set_attribute(:priority, arg(:priority))
+    end
+
+    action :bulk_complete, {:array, :uuid} do
+      argument :todo_ids, {:array, :uuid}, allow_nil?: false
+
+      run fn input, _context ->
+        # This would normally update multiple todos, but for testing we'll just return the IDs
+        {:ok, input.arguments.todo_ids}
+      end
+    end
+
+    action :get_statistics, :map do
+      constraints fields: [
+                    total: [type: :integer, allow_nil?: false],
+                    completed: [type: :integer, allow_nil?: false],
+                    pending: [type: :integer, allow_nil?: false],
+                    overdue: [type: :integer, allow_nil?: false]
+                  ]
+
+      run fn _input, _context ->
+        {:ok,
+         %{
+           total: 10,
+           completed: 6,
+           pending: 4,
+           overdue: 2
+         }}
+      end
+    end
+
+    action :search, {:array, Ash.Type.Struct} do
+      constraints items: [instance_of: __MODULE__]
+
+      argument :query, :string, allow_nil?: false
+      argument :include_completed, :boolean, default: true
+
+      # Private argument for internal use - should NOT appear in the manifest
+      argument :debug_mode, :boolean do
+        public? false
+        default false
+      end
+
+      run fn _input, _context ->
+        # This would normally search todos, but for testing we'll return empty
+        {:ok, []}
+      end
+    end
+  end
+end

--- a/test/support/manifest/resources/post.ex
+++ b/test/support/manifest/resources/post.ex
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Post do
+  @moduledoc """
+  Test resource representing blog posts with comments.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, allow_nil?: false, public?: true
+    attribute :content, :string, public?: true
+    attribute :published, :boolean, default: false, public?: true
+    attribute :view_count, :integer, default: 0, public?: true
+    attribute :rating, :decimal, public?: true
+    attribute :published_at, :utc_datetime, public?: true
+    attribute :tags, {:array, :string}, public?: true
+
+    attribute :status, :atom do
+      constraints one_of: [:draft, :published, :archived]
+      public? true
+    end
+
+    attribute :metadata, :map, public?: true
+  end
+
+  relationships do
+    belongs_to :author, Ash.Test.Manifest.User, public?: true
+
+    has_many :comments, Ash.Test.Manifest.PostComment,
+      destination_attribute: :post_id,
+      public?: true
+  end
+
+  actions do
+    defaults [:create, :read, :update, :destroy]
+  end
+end

--- a/test/support/manifest/resources/post_comment.ex
+++ b/test/support/manifest/resources/post_comment.ex
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.PostComment do
+  @moduledoc """
+  Test resource for post comments.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :content, :string, allow_nil?: false, public?: true
+    attribute :approved, :boolean, default: false, public?: true
+  end
+
+  relationships do
+    belongs_to :post, Ash.Test.Manifest.Post, public?: true
+    belongs_to :author, Ash.Test.Manifest.User, public?: true
+  end
+
+  actions do
+    defaults [:create, :read, :update, :destroy]
+  end
+end

--- a/test/support/manifest/resources/subscription.ex
+++ b/test/support/manifest/resources/subscription.ex
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Subscription do
+  @moduledoc """
+  Test resource exercising identities that reference attributes with
+  unusual names (trailing `?`). The manifest should surface the identity
+  with its raw field-name keys intact.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  identities do
+    identity :by_user_and_status, [:user_id, :is_active?],
+      pre_check_with: Ash.Test.Manifest.Domain
+  end
+
+  attributes do
+    integer_primary_key :id
+
+    attribute :user_id, :uuid do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :plan, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :is_active?, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :is_trial?, :boolean do
+      default false
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    read :get_by_id do
+      get_by :id
+    end
+
+    create :create do
+      accept [:user_id, :plan, :is_active?, :is_trial?]
+
+      change fn changeset, _context ->
+        if Ash.Changeset.get_attribute(changeset, :id) do
+          changeset
+        else
+          Ash.Changeset.force_change_attribute(changeset, :id, System.unique_integer([:positive]))
+        end
+      end
+    end
+
+    update :update do
+      accept [:plan, :is_active?, :is_trial?]
+    end
+  end
+end

--- a/test/support/manifest/resources/task.ex
+++ b/test/support/manifest/resources/task.ex
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Task do
+  @moduledoc """
+  Test resource exercising attribute and argument names with unusual
+  identifiers (trailing `?`). The manifest should surface them as-is
+  in the IR.
+  """
+
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :title, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :completed, :boolean do
+      allow_nil? false
+      default false
+      public? true
+    end
+
+    attribute :archived?, :boolean do
+      allow_nil? false
+      default false
+      public? true
+    end
+
+    attribute :metadata, Ash.Test.Manifest.TaskMetadata do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :stats, Ash.Test.Manifest.TaskStats do
+      allow_nil? true
+      public? true
+    end
+
+    attribute :custom_id, Ash.Test.Manifest.CustomIdentifier do
+      allow_nil? true
+      public? true
+    end
+
+    timestamps()
+  end
+
+  actions do
+    defaults [:read]
+
+    read :read_with_metadata do
+      metadata :some_string, :string, allow_nil?: false, default: "default_value"
+      metadata :some_number, :integer, allow_nil?: false, default: 123
+      metadata :some_boolean, :boolean
+
+      prepare fn query, _context ->
+        Ash.Query.after_action(query, fn _query, results ->
+          # Set metadata on each result
+          results_with_metadata =
+            Enum.map(results, fn record ->
+              record
+              |> Ash.Resource.put_metadata(:some_string, "default_value")
+              |> Ash.Resource.put_metadata(:some_number, 123)
+              |> Ash.Resource.put_metadata(:title, 1)
+            end)
+
+          {:ok, results_with_metadata}
+        end)
+      end
+    end
+
+    read :read_with_invalid_metadata_names do
+      metadata :meta_1, :string, allow_nil?: false, default: "metadata_value"
+      metadata :is_valid?, :boolean, allow_nil?: false, default: true
+      metadata :field_2, :integer, allow_nil?: false, default: 999
+
+      prepare fn query, _context ->
+        Ash.Query.after_action(query, fn _query, results ->
+          # Set metadata on each result
+          results_with_metadata =
+            Enum.map(results, fn record ->
+              record
+              |> Ash.Resource.put_metadata(:meta_1, "metadata_value")
+              |> Ash.Resource.put_metadata(:is_valid?, true)
+              |> Ash.Resource.put_metadata(:field_2, 999)
+            end)
+
+          {:ok, results_with_metadata}
+        end)
+      end
+    end
+
+    create :create do
+      accept [:title]
+      primary? true
+      metadata :some_string, :string, allow_nil?: false
+      metadata :some_number, :integer, allow_nil?: false
+      metadata :some_boolean, :boolean
+
+      change fn changeset, _context ->
+        Ash.Changeset.after_action(changeset, fn _changeset, record ->
+          {:ok,
+           record
+           |> Ash.Resource.put_metadata(:some_string, "created")
+           |> Ash.Resource.put_metadata(:some_number, 456)
+           |> Ash.Resource.put_metadata(:some_boolean, false)}
+        end)
+      end
+    end
+
+    update :update do
+      accept [:title, :archived?, :stats]
+      primary? true
+      require_atomic? false
+      metadata :some_string, :string, allow_nil?: false
+      metadata :some_number, :integer, allow_nil?: false
+      metadata :some_boolean, :boolean
+
+      change fn changeset, _context ->
+        Ash.Changeset.after_action(changeset, fn _changeset, record ->
+          {:ok,
+           record
+           |> Ash.Resource.put_metadata(:some_string, "updated")
+           |> Ash.Resource.put_metadata(:some_number, 789)
+           |> Ash.Resource.put_metadata(:some_boolean, true)}
+        end)
+      end
+    end
+
+    update :mark_completed do
+      require_atomic? false
+      metadata :some_string, :string, allow_nil?: false
+      metadata :some_number, :integer, allow_nil?: false
+      metadata :some_boolean, :boolean
+
+      argument :is_task_completed_now?, :boolean do
+        allow_nil? false
+      end
+
+      change fn changeset, _context ->
+        completed_value = Ash.Changeset.get_argument(changeset, :is_task_completed_now?)
+
+        Ash.Changeset.change_attribute(changeset, :completed, completed_value)
+        |> Ash.Changeset.after_action(fn _changeset, record ->
+          {:ok,
+           record
+           |> Ash.Resource.put_metadata(:some_string, "some_value")
+           |> Ash.Resource.put_metadata(:some_number, 123)
+           |> Ash.Resource.put_metadata(:some_boolean, true)}
+        end)
+      end
+    end
+
+    destroy :destroy do
+      accept [:archived?]
+      primary? true
+      require_atomic? false
+      metadata :some_string, :string, allow_nil?: false
+      metadata :some_number, :integer, allow_nil?: false
+      metadata :some_boolean, :boolean
+
+      manual fn changeset, _context ->
+        # Manual destroy to ensure we can return the record with metadata
+        record = changeset.data
+
+        # Perform the actual deletion using the data layer
+        with :ok <- Ash.DataLayer.destroy(changeset.resource, changeset) do
+          # Create a struct with metadata to return
+          record_with_metadata =
+            record
+            |> Ash.Resource.put_metadata(:some_string, "destroyed")
+            |> Ash.Resource.put_metadata(:some_number, 999)
+            |> Ash.Resource.put_metadata(:some_boolean, nil)
+
+          {:ok, record_with_metadata}
+        end
+      end
+    end
+
+    action :get_task_stats, Ash.Test.Manifest.TaskStats do
+      argument :task_id, :uuid, allow_nil?: false
+
+      run fn input, _context ->
+        # Simulate returning task statistics
+        stats = %Ash.Test.Manifest.TaskStats{
+          total_count: 10,
+          completed?: true,
+          is_urgent?: false,
+          average_duration: 45.5
+        }
+
+        {:ok, stats}
+      end
+    end
+
+    action :list_task_stats, {:array, Ash.Test.Manifest.TaskStats} do
+      run fn _input, _context ->
+        # Simulate returning multiple task statistics
+        stats_list = [
+          %Ash.Test.Manifest.TaskStats{
+            total_count: 10,
+            completed?: true,
+            is_urgent?: false,
+            average_duration: 45.5
+          },
+          %Ash.Test.Manifest.TaskStats{
+            total_count: 5,
+            completed?: false,
+            is_urgent?: true,
+            average_duration: 30.0
+          }
+        ]
+
+        {:ok, stats_list}
+      end
+    end
+  end
+end

--- a/test/support/manifest/resources/tenant_setting.ex
+++ b/test/support/manifest/resources/tenant_setting.ex
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TenantSetting do
+  @moduledoc """
+  Test resource for verifying composite primary key handling.
+
+  This resource uses a composite primary key (tenant_id + setting_key) to test
+  that identity types are correctly generated for both regular action functions
+  (using actual types) and validation functions (using string types).
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    attribute :tenant_id, :uuid do
+      allow_nil? false
+      public? true
+      primary_key? true
+    end
+
+    attribute :setting_key, :string do
+      allow_nil? false
+      public? true
+      primary_key? true
+    end
+
+    attribute :value, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :description, :string do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      accept [:tenant_id, :setting_key, :value, :description]
+    end
+
+    update :update do
+      accept [:value, :description]
+    end
+  end
+end

--- a/test/support/manifest/resources/todo.ex
+++ b/test/support/manifest/resources/todo.ex
@@ -1,0 +1,823 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo do
+  @moduledoc """
+  Test resource representing a todo item with relationships and calculations.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :title, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :description, :string do
+      public? true
+    end
+
+    attribute :completed, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :status, Ash.Test.Manifest.Todo.Status do
+      default :pending
+      public? true
+    end
+
+    attribute :priority, :atom do
+      constraints one_of: [:low, :medium, :high, :urgent]
+      default :medium
+      public? true
+    end
+
+    attribute :due_date, :date do
+      public? true
+    end
+
+    attribute :priority_score, Ash.Test.Manifest.Todo.PriorityScore do
+      public? true
+    end
+
+    attribute :color_palette, Ash.Test.Manifest.Todo.ColorPalette do
+      public? true
+    end
+
+    attribute :percentage, Ash.Test.Manifest.Todo.Percentage do
+      public? true
+    end
+
+    attribute :tags, {:array, :string} do
+      default []
+      public? true
+    end
+
+    attribute :metadata, Ash.Test.Manifest.TodoMetadata do
+      public? true
+    end
+
+    attribute :metadata_history, {:array, Ash.Test.Manifest.TodoMetadata} do
+      default []
+      public? true
+    end
+
+    # Union type attribute demonstrating tagged union with embedded resources
+    attribute :content, :union do
+      public? true
+
+      constraints types: [
+                    text: [
+                      type: Ash.Test.Manifest.TodoContent.TextContent,
+                      tag: :content_type,
+                      tag_value: "text"
+                    ],
+                    checklist: [
+                      type: Ash.Test.Manifest.TodoContent.ChecklistContent,
+                      tag: :content_type,
+                      tag_value: "checklist"
+                    ],
+                    link: [
+                      type: Ash.Test.Manifest.TodoContent.LinkContent,
+                      tag: :content_type,
+                      tag_value: "link"
+                    ],
+                    # Simple types for testing untagged unions
+                    note: [
+                      type: :string
+                    ],
+                    priority_value: [
+                      type: :integer,
+                      constraints: [min: 1, max: 10]
+                    ]
+                  ],
+                  storage: :type_and_value
+    end
+
+    # Union type array for testing array union support
+    attribute :attachments, {:array, :union} do
+      public? true
+      default []
+
+      constraints items: [
+                    types: [
+                      file: [
+                        type: :map,
+                        tag: :attachment_type,
+                        tag_value: "file",
+                        constraints: [
+                          fields: [
+                            filename: [type: :string, allow_nil?: false],
+                            size: [type: :integer],
+                            mime_type: [type: :string]
+                          ]
+                        ]
+                      ],
+                      image: [
+                        type: :map,
+                        tag: :attachment_type,
+                        tag_value: "image",
+                        constraints: [
+                          fields: [
+                            filename: [type: :string, allow_nil?: false],
+                            width: [type: :integer],
+                            height: [type: :integer],
+                            alt_text: [type: :string]
+                          ]
+                        ]
+                      ],
+                      # Simple untagged union member
+                      url: [
+                        type: :string,
+                        constraints: [match: ~r/^https?:\/\//]
+                      ]
+                    ]
+                  ]
+    end
+
+    # Union type with :map_with_tag storage for testing alternative storage mode
+    attribute :status_info, :union do
+      public? true
+
+      constraints types: [
+                    simple: [
+                      type: :map,
+                      tag: :status_type,
+                      tag_value: "simple"
+                    ],
+                    detailed: [
+                      type: :map,
+                      tag: :status_type,
+                      tag_value: "detailed"
+                    ],
+                    automated: [
+                      type: :map,
+                      tag: :status_type,
+                      tag_value: "automated"
+                    ]
+                  ],
+                  storage: :map_with_tag
+    end
+
+    attribute :timestamp_info, Ash.Test.Manifest.TodoTimestamp do
+      public? true
+    end
+
+    attribute :statistics, Ash.Test.Manifest.TodoStatistics do
+      public? true
+    end
+
+    attribute :options, :keyword do
+      public? true
+      allow_nil? true
+
+      constraints fields: [
+                    priority: [
+                      type: :integer,
+                      allow_nil?: false,
+                      description: "Priority level (1-10)",
+                      constraints: [min: 1, max: 10]
+                    ],
+                    category: [
+                      type: :string,
+                      allow_nil?: true,
+                      description: "Todo category",
+                      constraints: [max_length: 50]
+                    ],
+                    notify: [
+                      type: :boolean,
+                      allow_nil?: true,
+                      description: "Whether to send notifications"
+                    ]
+                  ]
+    end
+
+    attribute :coordinates, :tuple do
+      public? true
+
+      constraints fields: [
+                    latitude: [
+                      type: :float,
+                      allow_nil?: false,
+                      description: "Latitude coordinate",
+                      constraints: [min: -90.0, max: 90.0]
+                    ],
+                    longitude: [
+                      type: :float,
+                      allow_nil?: false,
+                      description: "Longitude coordinate",
+                      constraints: [min: -180.0, max: 180.0]
+                    ]
+                  ]
+    end
+
+    # Untyped map attribute for testing untyped map support
+    attribute :custom_data, :map do
+      public? true
+    end
+
+    create_timestamp :created_at do
+      public? true
+    end
+
+    update_timestamp :updated_at
+  end
+
+  relationships do
+    belongs_to :user, Ash.Test.Manifest.User do
+      allow_nil? false
+      public? true
+    end
+
+    has_many :comments, Ash.Test.Manifest.TodoComment do
+      public? true
+    end
+
+    has_many :not_exposed_items, Ash.Test.Manifest.NotExposed do
+      public? true
+    end
+  end
+
+  aggregates do
+    count :comment_count, :comments do
+      public? true
+    end
+
+    count :helpful_comment_count, :comments do
+      public? true
+      filter expr(is_helpful == true)
+    end
+
+    exists :has_comments, :comments do
+      public? true
+    end
+
+    avg :average_rating, :comments, :rating do
+      public? true
+    end
+
+    max :highest_rating, :comments, :rating do
+      public? true
+    end
+
+    first :latest_comment_content, :comments, :content do
+      public? true
+      sort created_at: :desc
+    end
+
+    list :comment_authors, :comments, :author_name do
+      public? true
+    end
+
+    # Additional field-based aggregates
+    first :latest_comment_id, :comments, :id do
+      public? true
+      sort created_at: :desc
+    end
+
+    list :recent_comment_ids, :comments, :id do
+      public? true
+      sort created_at: :desc
+    end
+
+    # Aggregates over calculation fields (not attributes)
+    # These test the fix that allows aggregates to reference calculation fields
+    sum :total_weighted_score, :comments, :weighted_score do
+      public? true
+    end
+
+    list :weighted_scores, :comments, :weighted_score do
+      public? true
+    end
+
+    first :first_weighted_score, :comments, :weighted_score do
+      public? true
+    end
+
+    max :max_weighted_score, :comments, :weighted_score do
+      public? true
+    end
+
+    # First aggregates that return complex types for testing
+    # First aggregate returning an embedded resource
+    first :first_comment_metadata, :comments, :comment_metadata do
+      public? true
+      sort created_at: :desc
+    end
+
+    # First aggregate returning a union type
+    first :first_comment_author_info, :comments, :author_info do
+      public? true
+      sort created_at: :desc
+    end
+  end
+
+  calculations do
+    calculate :is_overdue, :boolean, Ash.Test.Manifest.IsOverdueCalculation do
+      public? true
+    end
+
+    calculate :days_until_due, :integer, Ash.Test.Manifest.Todo.SimpleDateCalculation do
+      public? true
+    end
+
+    calculate :self, :struct, Ash.Test.Manifest.SelfCalculation do
+      constraints instance_of: __MODULE__
+      public? true
+
+      argument :prefix, :string do
+        allow_nil? true
+        default nil
+      end
+
+      argument :count, :integer do
+        allow_nil? true
+        default nil
+      end
+
+      argument :enabled, :boolean do
+        allow_nil? true
+        default nil
+      end
+
+      argument :data, :map do
+        allow_nil? true
+        default nil
+      end
+    end
+
+    calculate :summary,
+              Ash.Test.Manifest.TodoStatistics,
+              Ash.Test.Manifest.SummaryCalculation do
+      public? true
+    end
+
+    # Calculation with arguments that use types requiring type aliases
+    # This tests that calculation argument types are discovered for type alias generation
+    calculate :filtered_data, :string, expr("filtered") do
+      public? true
+
+      argument :after_date, Ash.Type.Date do
+        allow_nil? true
+        default nil
+      end
+
+      argument :user_id, Ash.Type.UUID do
+        allow_nil? true
+        default nil
+      end
+    end
+  end
+
+  actions do
+    defaults [:destroy]
+
+    read :read do
+      primary? true
+      argument :filter_completed, :boolean
+
+      argument :priority_filter, :atom do
+        constraints one_of: [:low, :medium, :high, :urgent]
+      end
+
+      filter expr(
+               if is_nil(^arg(:filter_completed)) do
+                 true
+               else
+                 completed == ^arg(:filter_completed)
+               end and
+                 if is_nil(^arg(:priority_filter)) do
+                   true
+                 else
+                   priority == ^arg(:priority_filter)
+                 end
+             )
+
+      pagination offset?: true,
+                 keyset?: true,
+                 countable: true,
+                 required?: false,
+                 default_limit: 20,
+                 max_page_size: 100
+    end
+
+    read :get_by_id do
+      get_by :id
+    end
+
+    create :create do
+      primary? true
+
+      accept [
+        :title,
+        :description,
+        :status,
+        :priority,
+        :due_date,
+        :tags,
+        :metadata,
+        :metadata_history,
+        :content,
+        :attachments,
+        :status_info,
+        :priority_score,
+        :color_palette,
+        :timestamp_info,
+        :statistics,
+        :options,
+        :coordinates,
+        :custom_data
+      ]
+
+      argument :auto_complete, :boolean do
+        default false
+      end
+
+      argument :user_id, :uuid do
+        allow_nil? false
+      end
+
+      change set_attribute(:completed, arg(:auto_complete))
+      change manage_relationship(:user_id, :user, type: :append)
+    end
+
+    update :update do
+      primary? true
+      require_atomic? false
+
+      accept [
+        :title,
+        :description,
+        :completed,
+        :status,
+        :priority,
+        :due_date,
+        :tags,
+        :metadata,
+        :content,
+        :attachments,
+        :status_info,
+        :priority_score,
+        :color_palette,
+        :timestamp_info,
+        :statistics,
+        :options,
+        :coordinates,
+        :custom_data
+      ]
+    end
+
+    update :complete do
+      accept []
+      change set_attribute(:completed, true)
+    end
+
+    update :set_priority do
+      argument :priority, :atom do
+        allow_nil? false
+        constraints one_of: [:low, :medium, :high, :urgent]
+      end
+
+      change set_attribute(:priority, arg(:priority))
+    end
+
+    update :update_with_untyped_data do
+      require_atomic? false
+      accept [:custom_data]
+
+      argument :additional_data, :map do
+        allow_nil? false
+      end
+
+      argument :metadata_update, :map do
+        allow_nil? true
+      end
+
+      change fn changeset, _context ->
+        # Merge the argument data with the custom_data attribute
+        additional_data = Ash.Changeset.get_argument(changeset, :additional_data)
+        metadata_update = Ash.Changeset.get_argument(changeset, :metadata_update)
+
+        current_custom_data = Ash.Changeset.get_data(changeset, :custom_data) || %{}
+
+        merged_data = Map.merge(current_custom_data, additional_data)
+
+        merged_data =
+          if metadata_update,
+            do: Map.put(merged_data, "metadataUpdate", metadata_update),
+            else: merged_data
+
+        Ash.Changeset.change_attribute(changeset, :custom_data, merged_data)
+      end
+    end
+
+    action :bulk_complete, {:array, :uuid} do
+      argument :todo_ids, {:array, :uuid}, allow_nil?: false
+
+      run fn input, _context ->
+        # This would normally update multiple todos, but for testing we'll just return the IDs
+        {:ok, input.arguments.todo_ids}
+      end
+    end
+
+    action :get_statistics, :map do
+      constraints fields: [
+                    total: [type: :integer, allow_nil?: false],
+                    completed: [type: :integer, allow_nil?: false],
+                    pending: [type: :integer, allow_nil?: false],
+                    overdue: [type: :integer, allow_nil?: false]
+                  ]
+
+      run fn _input, _context ->
+        {:ok,
+         %{
+           total: 10,
+           completed: 6,
+           pending: 4,
+           overdue: 2
+         }}
+      end
+    end
+
+    action :search, {:array, Ash.Type.Struct} do
+      constraints items: [instance_of: __MODULE__]
+
+      argument :query, :string, allow_nil?: false
+      argument :include_completed, :boolean, default: true
+
+      run fn _input, _context ->
+        # This would normally search todos, but for testing we'll return empty
+        {:ok, []}
+      end
+    end
+
+    action :get_keyword_options, :keyword do
+      constraints fields: [
+                    priority: [
+                      type: :integer,
+                      allow_nil?: false,
+                      description: "Priority level (1-10)",
+                      constraints: [min: 1, max: 10]
+                    ],
+                    category: [
+                      type: :string,
+                      allow_nil?: false,
+                      description: "Todo category",
+                      constraints: [max_length: 50]
+                    ],
+                    notify: [
+                      type: :boolean,
+                      allow_nil?: false,
+                      description: "Whether to send notifications"
+                    ],
+                    theme: [
+                      type: :atom,
+                      allow_nil?: false,
+                      description: "UI theme preference",
+                      constraints: [one_of: [:light, :dark, :auto]]
+                    ]
+                  ]
+
+      run fn _input, _context ->
+        {:ok,
+         [
+           priority: 8,
+           category: "work",
+           notify: true,
+           theme: :dark
+         ]}
+      end
+    end
+
+    action :get_coordinates_info, :tuple do
+      constraints fields: [
+                    latitude: [
+                      type: :float,
+                      allow_nil?: false,
+                      description: "Latitude coordinate",
+                      constraints: [min: -90.0, max: 90.0]
+                    ],
+                    longitude: [
+                      type: :float,
+                      allow_nil?: false,
+                      description: "Longitude coordinate",
+                      constraints: [min: -180.0, max: 180.0]
+                    ],
+                    altitude: [
+                      type: :integer,
+                      allow_nil?: true,
+                      description: "Altitude in meters"
+                    ]
+                  ]
+
+      run fn _input, _context ->
+        {:ok, {37.7749, -122.4194, 50}}
+      end
+    end
+
+    action :get_custom_data, :map do
+      run fn _input, _context ->
+        {:ok,
+         %{
+           user_id: "123e4567-e89b-12d3-a456-426614174000",
+           status: "active",
+           metadata: %{
+             version: "1.0",
+             tags: ["important", "urgent"],
+             settings: %{
+               notifications: true,
+               theme: "dark"
+             }
+           },
+           count: 42,
+           timestamp: 1_640_995_200
+         }}
+      end
+    end
+
+    action :get_custom_data_list, {:array, :map} do
+      run fn _input, _context ->
+        {:ok,
+         [
+           %{user_id: "123e4567-e89b-12d3-a456-426614174000", status: "active"},
+           %{user_id: "223e4567-e89b-12d3-a456-426614174001", status: "pending"}
+         ]}
+      end
+    end
+
+    # Additional read action with different pagination configuration for testing
+    read :search_paginated do
+      argument :query, :string, allow_nil?: false
+      argument :include_completed, :boolean, default: true
+
+      filter expr(
+               if is_nil(^arg(:query)) do
+                 true
+               else
+                 contains(title, ^arg(:query)) or contains(description, ^arg(:query))
+               end and
+                 if ^arg(:include_completed) do
+                   true
+                 else
+                   completed != true
+                 end
+             )
+
+      pagination offset?: true,
+                 keyset?: false,
+                 countable: true,
+                 required?: true,
+                 default_limit: 10,
+                 max_page_size: 50
+    end
+
+    # Read action with keyset-only pagination
+    read :list_recent do
+      filter expr(created_at >= ago(7, :day))
+
+      pagination required?: false,
+                 offset?: false,
+                 keyset?: true,
+                 countable: false,
+                 default_limit: 25,
+                 max_page_size: 100
+    end
+
+    # Read action with no pagination (should not have page field)
+    read :list_high_priority do
+      filter expr(priority in [:high, :urgent])
+    end
+
+    action :assign_to_user, :map do
+      constraints fields: [
+                    assignee_id: [type: :uuid, allow_nil?: false],
+                    assignee_name: [type: :string, allow_nil?: false],
+                    reason: [type: :string, allow_nil?: true]
+                  ]
+
+      argument :assignee, :struct do
+        constraints instance_of: Ash.Test.Manifest.User
+        allow_nil? false
+      end
+
+      argument :reason, :string do
+        allow_nil? true
+      end
+
+      run fn input, _context ->
+        assignee = input.arguments.assignee
+        reason = Map.get(input.arguments, :reason)
+
+        # Verify the assignee is actually a User struct
+        if not is_struct(assignee, Ash.Test.Manifest.User) do
+          raise "Expected assignee to be a User struct, got: #{inspect(assignee)}"
+        end
+
+        # Return assignment info
+        {:ok,
+         %{
+           assignee_id: assignee.id,
+           assignee_name: assignee.name,
+           reason: reason
+         }}
+      end
+    end
+
+    # Action with an array of resource structs as argument
+    action :assign_to_users, {:array, :map} do
+      constraints items: [
+                    fields: [
+                      assignee_id: [type: :uuid, allow_nil?: false],
+                      assignee_name: [type: :string, allow_nil?: false]
+                    ]
+                  ]
+
+      argument :assignees, {:array, :struct} do
+        constraints items: [instance_of: Ash.Test.Manifest.User]
+        allow_nil? false
+      end
+
+      run fn input, _context ->
+        assignees = input.arguments.assignees
+
+        # Verify all assignees are User structs
+        Enum.each(assignees, fn assignee ->
+          if not is_struct(assignee, Ash.Test.Manifest.User) do
+            raise "Expected assignee to be a User struct, got: #{inspect(assignee)}"
+          end
+        end)
+
+        # Return assignment info for each assignee
+        results =
+          Enum.map(assignees, fn assignee ->
+            %{
+              assignee_id: assignee.id,
+              assignee_name: assignee.name
+            }
+          end)
+
+        {:ok, results}
+      end
+    end
+
+    action :process_metadata, :map do
+      constraints fields: [
+                    processed: [type: :boolean, allow_nil?: false],
+                    priority: [type: :integer, allow_nil?: true],
+                    source: [type: :string, allow_nil?: false]
+                  ]
+
+      argument :metadata, Ash.Test.Manifest.TodoMetadata, allow_nil?: false
+
+      argument :options, :map do
+        allow_nil? true
+      end
+
+      run fn input, _context ->
+        metadata = input.arguments.metadata
+
+        {:ok,
+         %{
+           processed: true,
+           priority: Map.get(metadata, :priority_score),
+           source: "direct_embedded_argument"
+         }}
+      end
+    end
+
+    action :process_metadata_batch, {:array, :map} do
+      constraints items: [
+                    fields: [
+                      processed: [type: :boolean, allow_nil?: false],
+                      priority: [type: :integer, allow_nil?: true]
+                    ]
+                  ]
+
+      argument :metadata_items, {:array, Ash.Test.Manifest.TodoMetadata}, allow_nil?: false
+
+      run fn input, _context ->
+        results =
+          input.arguments.metadata_items
+          |> Enum.map(fn metadata ->
+            %{
+              processed: true,
+              priority: Map.get(metadata, :priority_score)
+            }
+          end)
+
+        {:ok, results}
+      end
+    end
+  end
+end

--- a/test/support/manifest/resources/todo/color_palette.ex
+++ b/test/support/manifest/resources/todo/color_palette.ex
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo.ColorPalette do
+  @moduledoc """
+  A custom type that represents a color palette stored as a map.
+  Demonstrates how custom types can provide precise structural definitions
+  for complex data structures.
+  """
+  use Ash.Type
+
+  @impl true
+  def storage_type(_), do: :map
+
+  @impl true
+  def cast_input(nil, _), do: {:ok, nil}
+
+  # Accept atom keys
+  def cast_input(%{primary: primary, secondary: secondary, accent: accent} = value, _)
+      when is_binary(primary) and is_binary(secondary) and is_binary(accent) do
+    {:ok, value}
+  end
+
+  # Accept string keys (from client input without field constraints)
+  def cast_input(
+        %{"primary" => primary, "secondary" => secondary, "accent" => accent},
+        _
+      )
+      when is_binary(primary) and is_binary(secondary) and is_binary(accent) do
+    {:ok, %{primary: primary, secondary: secondary, accent: accent}}
+  end
+
+  def cast_input(_, _), do: {:error, "must be a map with primary, secondary, and accent colors"}
+
+  @impl true
+  def cast_stored(nil, _), do: {:ok, nil}
+  def cast_stored(value, _) when is_map(value), do: {:ok, value}
+  def cast_stored(_, _), do: {:error, "stored value must be a map"}
+
+  @impl true
+  def dump_to_native(nil, _), do: {:ok, nil}
+  def dump_to_native(value, _) when is_map(value), do: {:ok, value}
+  def dump_to_native(_, _), do: {:error, "dump value must be a map"}
+
+  @impl true
+  def apply_constraints(value, _constraints), do: {:ok, value}
+end

--- a/test/support/manifest/resources/todo/date_calculations.ex
+++ b/test/support/manifest/resources/todo/date_calculations.ex
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo.SimpleDateCalculation do
+  @moduledoc """
+  Simple date difference calculation for todos.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    [:due_date]
+  end
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    today = Date.utc_today()
+
+    Enum.map(records, fn record ->
+      if is_nil(record.due_date) do
+        nil
+      else
+        Date.diff(record.due_date, today)
+      end
+    end)
+  end
+end
+
+defmodule Ash.Test.Manifest.IsOverdueCalculation do
+  @moduledoc """
+  Calculation to determine if a todo is overdue.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    [:due_date]
+  end
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    today = Date.utc_today()
+
+    Enum.map(records, fn record ->
+      if is_nil(record.due_date) do
+        false
+      else
+        Date.compare(record.due_date, today) == :lt
+      end
+    end)
+  end
+end

--- a/test/support/manifest/resources/todo/owner_calculation.ex
+++ b/test/support/manifest/resources/todo/owner_calculation.ex
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo.OwnerCalculation do
+  @moduledoc """
+  Calculation for todo owner information.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context) do
+    [:user]
+  end
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    # Return the owner (user) for each todo
+    Enum.map(records, fn record ->
+      record.user
+    end)
+  end
+end

--- a/test/support/manifest/resources/todo/percentage.ex
+++ b/test/support/manifest/resources/todo/percentage.ex
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo.Percentage do
+  @moduledoc """
+  A NewType wrapping :float .
+  Demonstrates that NewTypes are resolved as type_refs.
+  """
+  use Ash.Type.NewType, subtype_of: :float
+end

--- a/test/support/manifest/resources/todo/priority_score.ex
+++ b/test/support/manifest/resources/todo/priority_score.ex
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo.PriorityScore do
+  @moduledoc """
+  A custom type that represents a priority score from 1-100.
+  Demonstrates custom type support in Ash.Info.Manifest.
+  """
+  use Ash.Type
+
+  @impl true
+  def storage_type(_), do: :integer
+
+  @impl true
+  def cast_input(nil, _), do: {:ok, nil}
+
+  def cast_input(value, _) when is_integer(value) and value >= 1 and value <= 100 do
+    {:ok, value}
+  end
+
+  def cast_input(value, _) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} when int >= 1 and int <= 100 -> {:ok, int}
+      _ -> {:error, "must be an integer between 1 and 100"}
+    end
+  end
+
+  def cast_input(_, _), do: {:error, "must be an integer between 1 and 100"}
+
+  @impl true
+  def cast_stored(nil, _), do: {:ok, nil}
+  def cast_stored(value, _) when is_integer(value), do: {:ok, value}
+  def cast_stored(_, _), do: {:error, "stored value must be an integer"}
+
+  @impl true
+  def dump_to_native(nil, _), do: {:ok, nil}
+  def dump_to_native(value, _) when is_integer(value), do: {:ok, value}
+  def dump_to_native(_, _), do: {:error, "dump value must be an integer"}
+
+  @impl true
+  def apply_constraints(value, _constraints), do: {:ok, value}
+end

--- a/test/support/manifest/resources/todo/status.ex
+++ b/test/support/manifest/resources/todo/status.ex
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Todo.Status do
+  @moduledoc """
+  Todo status enumeration.
+  """
+  use Ash.Type.Enum, values: [:pending, :ongoing, :finished, :cancelled]
+end

--- a/test/support/manifest/resources/todo_comment.ex
+++ b/test/support/manifest/resources/todo_comment.ex
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoComment do
+  @moduledoc """
+  Test resource representing comments on todo items.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :content, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :author_name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :rating, :integer do
+      constraints min: 1, max: 5
+      public? true
+    end
+
+    attribute :is_helpful, :boolean do
+      default false
+      public? true
+    end
+
+    # Embedded resource attribute for testing first aggregates with embedded types
+    attribute :comment_metadata, Ash.Test.Manifest.TodoMetadata do
+      public? true
+    end
+
+    # Union attribute with both embedded resource and regular Ash resource members
+    # for testing first aggregates with union types
+    attribute :author_info, :union do
+      public? true
+
+      constraints types: [
+                    # Embedded resource member
+                    metadata: [
+                      type: Ash.Test.Manifest.TodoMetadata,
+                      tag: :info_type,
+                      tag_value: "metadata"
+                    ],
+                    # Simple type member
+                    anonymous: [
+                      type: :string
+                    ]
+                  ]
+    end
+
+    create_timestamp :created_at
+    update_timestamp :updated_at
+  end
+
+  calculations do
+    # A weighted score calculation for testing sum aggregates over calculations
+    calculate :weighted_score, :integer, expr(rating * if(is_helpful, 2, 1)) do
+      public? true
+    end
+  end
+
+  relationships do
+    belongs_to :todo, Ash.Test.Manifest.Todo do
+      allow_nil? false
+      public? true
+    end
+
+    belongs_to :user, Ash.Test.Manifest.User do
+      allow_nil? false
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      accept [:content, :author_name, :rating, :is_helpful, :comment_metadata, :author_info]
+
+      argument :user_id, :uuid do
+        allow_nil? false
+        public? true
+      end
+
+      argument :todo_id, :uuid do
+        allow_nil? false
+        public? true
+      end
+
+      change manage_relationship(:user_id, :user, type: :append)
+      change manage_relationship(:todo_id, :todo, type: :append)
+    end
+
+    update :update do
+      require_atomic? false
+      accept [:content, :author_name, :rating, :is_helpful, :comment_metadata, :author_info]
+    end
+  end
+end

--- a/test/support/manifest/resources/typed_structs/task_stats.ex
+++ b/test/support/manifest/resources/typed_structs/task_stats.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TaskStats do
+  @moduledoc """
+  Test TypedStruct for task statistics.
+  TypedStruct fixture for the manifest test suite.
+  """
+  use Ash.TypedStruct
+
+  typed_struct do
+    field(:total_count, :integer, default: 0)
+    field(:completed?, :boolean)
+    field(:is_urgent?, :boolean, default: false)
+    field(:average_duration, :float)
+  end
+end

--- a/test/support/manifest/resources/typed_structs/todo_statistics.ex
+++ b/test/support/manifest/resources/typed_structs/todo_statistics.ex
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoStatistics do
+  @moduledoc """
+  Test TypedStruct for todo statistics and performance metrics.
+  """
+  use Ash.TypedStruct
+
+  typed_struct do
+    field(:view_count, :integer, default: 0)
+    field(:edit_count, :integer, default: 0)
+    field(:completion_time_seconds, :integer)
+    field(:difficulty_rating, :float)
+    field(:all_completed?, :boolean)
+
+    # Composite type field - map with constrained fields for performance metrics
+    field(:performance_metrics, :map,
+      constraints: [
+        fields: [
+          focus_time_seconds: [type: :integer, allow_nil?: false],
+          interruption_count: [type: :integer, allow_nil?: false],
+          efficiency_score: [type: :float, allow_nil?: false],
+          task_complexity: [type: :string, allow_nil?: true]
+        ]
+      ]
+    )
+  end
+end

--- a/test/support/manifest/resources/typed_structs/todo_timestamp.ex
+++ b/test/support/manifest/resources/typed_structs/todo_timestamp.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.TodoTimestamp do
+  @moduledoc """
+  Test TypedStruct for todo timestamp data.
+  """
+  use Ash.TypedStruct
+
+  typed_struct do
+    field(:created_by, :string, allow_nil?: false, description: "Test")
+    field(:created_at, :utc_datetime, allow_nil?: false, description: "Test")
+    field(:updated_by, :string, description: "Test")
+    field(:updated_at, :utc_datetime, description: "Test")
+  end
+end

--- a/test/support/manifest/resources/user.ex
+++ b/test/support/manifest/resources/user.ex
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.User do
+  @moduledoc """
+  Test resource representing a user with relationships to todos and settings.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  identities do
+    identity :unique_email, [:email], pre_check_with: Ash.Test.Manifest.Domain
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :name, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :email, :string do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :active, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :is_super_admin, :boolean do
+      default false
+      public? true
+    end
+
+    attribute :address_line_1, :string do
+      allow_nil? true
+      public? true
+    end
+  end
+
+  relationships do
+    has_many :comments, Ash.Test.Manifest.TodoComment do
+      public? true
+    end
+
+    has_many :todos, Ash.Test.Manifest.Todo do
+      public? true
+    end
+
+    has_many :posts, Ash.Test.Manifest.Post,
+      destination_attribute: :author_id,
+      public?: true
+  end
+
+  actions do
+    defaults [:read]
+
+    read :read_with_invalid_arg do
+      argument :is_active?, :boolean
+    end
+
+    read :get_by_id do
+      get_by :id
+    end
+
+    create :create do
+      accept [:email, :name, :is_super_admin, :address_line_1]
+    end
+
+    update :update do
+      accept [:name, :is_super_admin, :address_line_1]
+    end
+
+    update :update_me do
+      description "Update the authenticated user's own information. Actor-scoped action."
+      accept [:name, :address_line_1]
+      require_atomic? false
+      # This filter scopes the action to only update the actor's own record
+      filter expr(id == ^actor(:id))
+    end
+
+    destroy :destroy do
+      accept []
+    end
+
+    destroy :destroy_me do
+      description "Delete the authenticated user's own account. Actor-scoped action."
+      require_atomic? false
+      filter expr(id == ^actor(:id))
+    end
+  end
+
+  calculations do
+    calculate :self, :struct, Ash.Test.Manifest.SelfCalculation do
+      constraints instance_of: __MODULE__
+      public? true
+
+      argument :prefix, :string do
+        allow_nil? true
+        default nil
+      end
+    end
+
+    calculate :is_active?, :boolean, expr(true) do
+      public? true
+    end
+  end
+end

--- a/test/support/manifest/resources/user_settings.ex
+++ b/test/support/manifest/resources/user_settings.ex
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.UserSettings do
+  @moduledoc """
+  Test resource for user settings with multitenancy support.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Manifest.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    primary_read_warning?: false
+
+  ets do
+    private? true
+  end
+
+  multitenancy do
+    strategy :attribute
+    attribute :user_id
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :user_id, :uuid do
+      allow_nil? false
+      public? true
+    end
+
+    attribute :theme, :atom do
+      constraints one_of: [:light, :dark, :auto]
+      default :light
+      public? true
+    end
+
+    attribute :language, :string do
+      constraints max_length: 10
+      default "en"
+      public? true
+    end
+
+    attribute :notifications_enabled, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :email_notifications, :boolean do
+      default true
+      public? true
+    end
+
+    attribute :timezone, :string do
+      constraints max_length: 50
+      default "UTC"
+      public? true
+    end
+
+    attribute :date_format, :string do
+      constraints max_length: 20
+      default "YYYY-MM-DD"
+      public? true
+    end
+
+    attribute :preferences, :map do
+      default %{}
+      public? true
+    end
+
+    create_timestamp :created_at do
+      public? true
+    end
+
+    update_timestamp :updated_at do
+      public? true
+    end
+  end
+
+  relationships do
+    belongs_to :user, Ash.Test.Manifest.User do
+      allow_nil? false
+      public? true
+      attribute_writable? true
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+
+      accept [
+        :theme,
+        :language,
+        :notifications_enabled,
+        :email_notifications,
+        :timezone,
+        :date_format,
+        :preferences
+      ]
+
+      argument :user_id, :uuid do
+        allow_nil? false
+      end
+
+      change manage_relationship(:user_id, :user, type: :append)
+    end
+
+    update :update do
+      primary? true
+
+      accept [
+        :theme,
+        :language,
+        :notifications_enabled,
+        :email_notifications,
+        :timezone,
+        :date_format,
+        :preferences
+      ]
+    end
+
+    read :get_by_user do
+      get_by [:user_id]
+    end
+  end
+end

--- a/test/support/manifest/types/content_item.ex
+++ b/test/support/manifest/types/content_item.ex
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.ContentItem do
+  @moduledoc """
+  Union type for polymorphic content items.
+  """
+
+  use Ash.Type.NewType,
+    subtype_of: :union,
+    constraints: [
+      types: [
+        article: [
+          type: :struct,
+          constraints: [instance_of: Ash.Test.Manifest.Article]
+        ]
+      ]
+    ]
+end

--- a/test/support/manifest/types/custom_identifier.ex
+++ b/test/support/manifest/types/custom_identifier.ex
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.CustomIdentifier do
+  @moduledoc """
+  A custom Ash type with no special handling.
+
+  This simulates a type from a third-party dependency where users cannot
+  add the callback themselves. The type should be mapped via config.
+  """
+  use Ash.Type
+
+  @impl true
+  def storage_type(_constraints), do: :string
+
+  @impl true
+  def cast_input(nil, _constraints), do: {:ok, nil}
+  def cast_input(value, _constraints) when is_binary(value), do: {:ok, value}
+  def cast_input(_value, _constraints), do: :error
+
+  @impl true
+  def cast_stored(nil, _constraints), do: {:ok, nil}
+  def cast_stored(value, _constraints) when is_binary(value), do: {:ok, value}
+  def cast_stored(_value, _constraints), do: :error
+
+  @impl true
+  def dump_to_native(nil, _constraints), do: {:ok, nil}
+  def dump_to_native(value, _constraints) when is_binary(value), do: {:ok, value}
+  def dump_to_native(_value, _constraints), do: :error
+end

--- a/test/support/manifest/types/custom_metadata.ex
+++ b/test/support/manifest/types/custom_metadata.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.CustomMetadata do
+  @moduledoc """
+  A custom map type with constrained fields for testing.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        field_1: [type: :string, allow_nil?: false],
+        is_active?: [type: :boolean, allow_nil?: false],
+        line_2: [type: :string, allow_nil?: true]
+      ]
+    ]
+end


### PR DESCRIPTION
# Summary

Introduces `Ash.Info.Manifest` — a language-agnostic IR describing an Ash app's public surface (resources, types, action entrypoints). Designed to be consumed by code generators (TypeScript clients, OpenAPI docs, etc.) so they don't have to re-derive the public API shape from Ash internals.

- New struct `%Ash.Info.Manifest{resources, types, entrypoints}` + sub-structs under `Ash.Info.Manifest.*` (Resource, Action, Field, Argument, Relationship, Entrypoint, Metadata, Pagination, Type)
- Generator pipeline (`Ash.Info.Manifest.Generator`) with reachability analysis, resource/action builders, and a type resolver covering all Ash type variants
- JSON serializer (`Ash.Info.Manifest.JsonSerializer`) with a versioned `schema_version` for downstream tools
- Validators (`Ash.Info.Manifest.Validators`) enforcing public-API invariants (e.g. accept lists may only reference `public? true` attributes)
- Public entry point `Ash.Info.manifest/1` and `mix ash.manifest.dump` CLI

## Try it out

In any Ash app, add a domain + resource and run:

```elixir
{:ok, manifest} = Ash.Info.manifest(otp_app: :my_app)
```

Or from the CLI:

```bash
mix ash.manifest.dump                       # JSON to stdout
mix ash.manifest.dump -o manifest.json      # write to file
```

The result is a tree of plain Elixir structs covering every public resource, named type, and action reachable from your domains. Useful options include `:action_entrypoints` (filter to specific actions), `:overrides` (force-include resources/types), and `:include_private_*?` flags (per-category visibility).

## Test plan

- [ ] `mix test test/ash/info/manifest` — 106 tests covering generator, reachability, resource builder, action builder, type resolver, JSON serializer, validators
- [ ] `mix ash.manifest.dump` against a sample app produces valid JSON
- [ ] `Ash.Info.manifest(otp_app: :your_app)` returns a populated `%Ash.Info.Manifest{}` reflecting the app's domains


# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Features include unit/acceptance tests
