### PR TITLE
Feat/add manifest filtering and sorting

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,11 +60,4 @@ if config_env() == :test do
   config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
   config :ash, Ash.Type.UUIDv7, match_v4_uuids?: true
-
-  # Manifest tests use a dedicated otp_app so the generator only walks
-  # the manifest test domain — the other :ash test domains predate the
-  # `enforce_public_accept?` invariant and would fail validation.
-  config :ash_manifest_test, :ash_domains, [
-    Ash.Test.Manifest.Domain
-  ]
 end

--- a/lib/ash/info/manifest.ex
+++ b/lib/ash/info/manifest.ex
@@ -9,6 +9,15 @@ defmodule Ash.Info.Manifest do
   Given a list of `{resource, action_name}` tuples or an OTP app, traverses the
   type graph to find all reachable resources and types, producing structured IR
   (Elixir structs) that can also be serialized to JSON.
+
+  ## Operator canonical name vs. alias
+
+  `%Operator{}.name` is the user-facing symbol that appears in
+  `Ash.Query.filter` expressions (e.g. `:==`, `:<`, `:in`). The
+  `%Operator{}.aliases` list carries internal/legacy module-derived names
+  (e.g. `:eq`, `:less_than`) for backward-compatible rendering. New code
+  should prefer `name`; alias-substitution is for tools that historically
+  rendered the module-derived spelling.
   """
 
   alias Ash.Info.Manifest.{Entrypoint, Resource}
@@ -18,7 +27,9 @@ defmodule Ash.Info.Manifest do
   @type t :: %__MODULE__{
           resources: [Resource.t()],
           types: [Ash.Info.Manifest.Type.t()],
-          entrypoints: [Entrypoint.t()]
+          entrypoints: [Entrypoint.t()],
+          filter_capabilities: Ash.Info.Manifest.FilterCapabilities.t() | nil,
+          sort_capabilities: Ash.Info.Manifest.SortCapabilities.t() | nil
         }
 
   @type resource_lookup :: %{atom() => Resource.t()}
@@ -27,7 +38,9 @@ defmodule Ash.Info.Manifest do
 
   defstruct resources: [],
             types: [],
-            entrypoints: []
+            entrypoints: [],
+            filter_capabilities: nil,
+            sort_capabilities: nil
 
   @doc """
   The schema version of the manifest's JSON serialization format.
@@ -193,6 +206,102 @@ defmodule Ash.Info.Manifest do
     case Map.get(resource_lookup, resource_module) do
       %Resource{primary_key: pk} -> pk
       nil -> []
+    end
+  end
+
+  @doc """
+  Builds an operator lookup map from the spec, keyed by operator name atom.
+
+  Returns an empty map when `filter_capabilities` is `nil`.
+  """
+  @spec operator_lookup(t()) :: %{atom() => Ash.Info.Manifest.Operator.t()}
+  def operator_lookup(%__MODULE__{filter_capabilities: nil}), do: %{}
+
+  def operator_lookup(%__MODULE__{filter_capabilities: %{operators: operators}}) do
+    Map.new(operators, fn op -> {op.name, op} end)
+  end
+
+  @doc """
+  Builds a function lookup map from the spec, keyed by function name atom.
+  """
+  @spec function_lookup(t()) :: %{atom() => Ash.Info.Manifest.Function.t()}
+  def function_lookup(%__MODULE__{filter_capabilities: nil}), do: %{}
+
+  def function_lookup(%__MODULE__{filter_capabilities: %{functions: functions}}) do
+    Map.new(functions, fn fun -> {fun.name, fun} end)
+  end
+
+  @doc """
+  Builds a custom-expression lookup map from the spec, keyed by expression name atom.
+  """
+  @spec custom_expression_lookup(t()) :: %{atom() => Ash.Info.Manifest.CustomExpression.t()}
+  def custom_expression_lookup(%__MODULE__{filter_capabilities: nil}), do: %{}
+
+  def custom_expression_lookup(%__MODULE__{
+        filter_capabilities: %{custom_expressions: custom_expressions}
+      }) do
+    Map.new(custom_expressions, fn ce -> {ce.name, ce} end)
+  end
+
+  @doc """
+  Returns the resolved `%ApplicableOperator{}` list for `{resource_module, field_name}`.
+
+  Returns `[]` when the field exists but is not filterable. Raises if the
+  resource or field is unknown.
+  """
+  @spec applicable_filter_operators(t(), {atom(), atom()}) ::
+          [Ash.Info.Manifest.ApplicableOperator.t()]
+  def applicable_filter_operators(%__MODULE__{} = manifest, {resource_module, field_name}) do
+    case lookup_field!(manifest, resource_module, field_name) do
+      %{filter_operators: nil} -> []
+      %{filter_operators: list} when is_list(list) -> list
+    end
+  end
+
+  @doc """
+  Returns the resolved `%ApplicableFunction{}` list for `{resource_module, field_name}`.
+  See `applicable_filter_operators/2` for behavior.
+  """
+  @spec applicable_filter_functions(t(), {atom(), atom()}) ::
+          [Ash.Info.Manifest.ApplicableFunction.t()]
+  def applicable_filter_functions(%__MODULE__{} = manifest, {resource_module, field_name}) do
+    case lookup_field!(manifest, resource_module, field_name) do
+      %{filter_functions: nil} -> []
+      %{filter_functions: list} when is_list(list) -> list
+    end
+  end
+
+  @doc """
+  Returns the resolved `%ApplicableCustomExpression{}` list for `{resource_module, field_name}`.
+  See `applicable_filter_operators/2` for behavior.
+  """
+  @spec applicable_filter_custom_expressions(t(), {atom(), atom()}) ::
+          [Ash.Info.Manifest.ApplicableCustomExpression.t()]
+  def applicable_filter_custom_expressions(
+        %__MODULE__{} = manifest,
+        {resource_module, field_name}
+      ) do
+    case lookup_field!(manifest, resource_module, field_name) do
+      %{filter_custom_expressions: nil} -> []
+      %{filter_custom_expressions: list} when is_list(list) -> list
+    end
+  end
+
+  defp lookup_field!(manifest, resource_module, field_name) do
+    lookup = resource_lookup(manifest)
+
+    resource =
+      case Map.get(lookup, resource_module) do
+        %Resource{} = r -> r
+        nil -> raise "Resource #{inspect(resource_module)} not found in manifest"
+      end
+
+    case Resource.get_field(resource, field_name) do
+      %Ash.Info.Manifest.Field{} = field ->
+        field
+
+      nil ->
+        raise "Field #{inspect(field_name)} not found on resource #{inspect(resource_module)}"
     end
   end
 end

--- a/lib/ash/info/manifest/applicable_custom_expression.ex
+++ b/lib/ash/info/manifest/applicable_custom_expression.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.ApplicableCustomExpression do
+  @moduledoc """
+  A custom expression resolved as applicable to a specific field, paired with
+  the resolved right-hand-side type.
+
+  See `Ash.Info.Manifest.ApplicableOperator` for the shape of `rhs`.
+  """
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          rhs: Ash.Info.Manifest.ApplicableOperator.rhs()
+        }
+
+  defstruct [:name, :rhs]
+end

--- a/lib/ash/info/manifest/applicable_function.ex
+++ b/lib/ash/info/manifest/applicable_function.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.ApplicableFunction do
+  @moduledoc """
+  A predicate function resolved as applicable to a specific field, paired
+  with the resolved right-hand-side type.
+
+  See `Ash.Info.Manifest.ApplicableOperator` for the shape of `rhs`.
+  """
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          rhs: Ash.Info.Manifest.ApplicableOperator.rhs()
+        }
+
+  defstruct [:name, :rhs]
+end

--- a/lib/ash/info/manifest/applicable_operator.ex
+++ b/lib/ash/info/manifest/applicable_operator.ex
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.ApplicableOperator do
+  @moduledoc """
+  A predicate operator resolved as applicable to a specific field, paired
+  with the resolved right-hand-side type.
+
+  `rhs` is one of:
+
+    * `:same` — RHS is the same type as the field (e.g. `field == field_value`).
+    * `:any` — RHS is untyped; the renderer chooses (typically maps to the
+      renderer's `any`/`unknown`).
+    * `{:concrete, type_ref}` — RHS is a specific Ash type. `type_ref` is
+      either a builtin atom (e.g. `:string`, `:boolean`) or a module
+      (e.g. `Ash.Type.UUID`).
+    * `{:array, rhs}` — RHS is an array whose element RHS is the nested value.
+
+  ## Examples
+
+      iex> # `:==` on a string field
+      iex> %Ash.Info.Manifest.ApplicableOperator{name: :==, rhs: :same}
+
+      iex> # `:in` on any field — RHS is an array of the field type
+      iex> %Ash.Info.Manifest.ApplicableOperator{name: :in, rhs: {:array, :same}}
+
+      iex> # `:is_nil` — RHS is always a boolean
+      iex> %Ash.Info.Manifest.ApplicableOperator{name: :is_nil, rhs: {:concrete, :boolean}}
+  """
+
+  @type rhs ::
+          :same
+          | :any
+          | {:concrete, atom() | module()}
+          | {:array, rhs()}
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          rhs: rhs()
+        }
+
+  defstruct [:name, :rhs]
+end

--- a/lib/ash/info/manifest/argument_signature.ex
+++ b/lib/ash/info/manifest/argument_signature.ex
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.ArgumentSignature do
+  @moduledoc """
+  Normalized argument signature for an operator, function, or custom expression.
+
+  One signature represents one accepted argument shape. The `args` list is the
+  ordered list of arg specs; each arg spec has a `kind`:
+
+    * `:concrete` — a specific type (`builtin` atom or `type_ref` module).
+    * `:same` — same type as the field being filtered (or the first arg).
+    * `:any` — any type accepted.
+    * `:array` — an array whose inner element spec is in `of`.
+    * `:ref` — fallback for shapes we don't structurally model yet.
+
+  Use `from_ash_signature/1` to normalize the raw shape returned by an Ash
+  operator's `types/0` or a function's `args/0` callback.
+  """
+
+  @type arg_spec :: %{
+          required(:kind) => :concrete | :same | :any | :array | :ref,
+          required(:builtin) => atom() | nil,
+          required(:type_ref) => module() | nil,
+          required(:constraints) => keyword(),
+          optional(:of) => arg_spec()
+        }
+
+  @type t :: %__MODULE__{args: [arg_spec()]}
+
+  defstruct args: []
+
+  @doc """
+  Normalize a raw signature from an Ash operator/function/custom expression callback.
+
+  Accepts:
+  - A list of arg specs (one explicit signature): `[:string, :string]`
+  - A bare sentinel atom (`:same` or `:any`) treated as a one-arg signature.
+  """
+  @spec from_ash_signature(term()) :: t()
+  def from_ash_signature(args) when is_list(args) do
+    %__MODULE__{args: Enum.map(args, &normalize_arg/1)}
+  end
+
+  def from_ash_signature(atom) when atom in [:same, :any] do
+    %__MODULE__{args: [normalize_arg(atom)]}
+  end
+
+  @doc "Normalize a single arg spec entry."
+  @spec normalize_arg(term()) :: arg_spec()
+  def normalize_arg(:same), do: spec(:same)
+  def normalize_arg(:any), do: spec(:any)
+
+  def normalize_arg(atom) when is_atom(atom) do
+    if builtin_type?(atom) do
+      spec(:concrete, builtin: atom)
+    else
+      spec(:concrete, type_ref: atom)
+    end
+  end
+
+  def normalize_arg({module, constraints}) when is_atom(module) and is_list(constraints) do
+    spec(:concrete, type_ref: module, constraints: constraints)
+  end
+
+  def normalize_arg({:array, inner}), do: spec(:array, of: normalize_arg(inner))
+  def normalize_arg(_other), do: spec(:ref)
+
+  defp spec(kind, opts \\ []) do
+    base = %{
+      kind: kind,
+      builtin: Keyword.get(opts, :builtin),
+      type_ref: Keyword.get(opts, :type_ref),
+      constraints: Keyword.get(opts, :constraints, [])
+    }
+
+    case Keyword.fetch(opts, :of) do
+      {:ok, of} -> Map.put(base, :of, of)
+      :error -> base
+    end
+  end
+
+  # Heuristic: lowercase, non-Elixir atom is a builtin (`:string`, `:integer`, ...).
+  # Modules start with uppercase (`Ash.Type.Integer`).
+  defp builtin_type?(atom) do
+    case Atom.to_string(atom) do
+      "Elixir." <> _ -> false
+      _ -> true
+    end
+  end
+end

--- a/lib/ash/info/manifest/custom_expression.ex
+++ b/lib/ash/info/manifest/custom_expression.ex
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.CustomExpression do
+  @moduledoc """
+  Represents an app-registered custom expression in the filter capabilities catalog.
+
+  Built from `Application.get_env(:ash, :custom_expressions, [])` at manifest
+  generation time. Does not carry a `:returns` field — `Ash.CustomExpression`
+  has no `returns/0` callback.
+  """
+
+  alias Ash.Info.Manifest.ArgumentSignature
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          module: module(),
+          predicate?: boolean(),
+          signatures: [ArgumentSignature.t()],
+          description: String.t() | nil
+        }
+
+  defstruct [:name, :module, :predicate?, :signatures, :description]
+end

--- a/lib/ash/info/manifest/field.ex
+++ b/lib/ash/info/manifest/field.ex
@@ -25,7 +25,14 @@ defmodule Ash.Info.Manifest.Field do
           # For calculations only
           arguments: [Ash.Info.Manifest.Argument.t()] | nil,
           # For aggregates only
-          aggregate_kind: atom() | nil
+          aggregate_kind: atom() | nil,
+          # Resolved at generation time; nil iff filterable? == false.
+          # Each entry carries the operator/function/expression name plus its
+          # pre-resolved right-hand-side type — consumers don't need to walk
+          # signatures again.
+          filter_operators: [Ash.Info.Manifest.ApplicableOperator.t()] | nil,
+          filter_functions: [Ash.Info.Manifest.ApplicableFunction.t()] | nil,
+          filter_custom_expressions: [Ash.Info.Manifest.ApplicableCustomExpression.t()] | nil
         }
 
   defstruct [
@@ -42,6 +49,9 @@ defmodule Ash.Info.Manifest.Field do
     :sensitive?,
     :select_by_default?,
     :arguments,
-    :aggregate_kind
+    :aggregate_kind,
+    :filter_operators,
+    :filter_functions,
+    :filter_custom_expressions
   ]
 end

--- a/lib/ash/info/manifest/filter_capabilities.ex
+++ b/lib/ash/info/manifest/filter_capabilities.ex
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.FilterCapabilities do
+  @moduledoc """
+  Top-level filter vocabulary for a manifest.
+
+  Carries every operator, function, and registered custom expression
+  available to filter expressions in this app. The `predicate_*` lists are
+  denormalized convenience views: the names of entries whose `predicate?` is
+  `true` — i.e. the leaf-usable subset of each catalog.
+  """
+
+  alias Ash.Info.Manifest.{CustomExpression, Function, Operator}
+
+  @type t :: %__MODULE__{
+          operators: [Operator.t()],
+          functions: [Function.t()],
+          custom_expressions: [CustomExpression.t()],
+          boolean_connectives: [atom()],
+          predicate_operators: [atom()],
+          predicate_functions: [atom()],
+          predicate_custom_expressions: [atom()]
+        }
+
+  defstruct operators: [],
+            functions: [],
+            custom_expressions: [],
+            boolean_connectives: [:and, :or, :not],
+            predicate_operators: [],
+            predicate_functions: [],
+            predicate_custom_expressions: []
+end

--- a/lib/ash/info/manifest/function.ex
+++ b/lib/ash/info/manifest/function.ex
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Function do
+  @moduledoc """
+  Represents a single function in the filter capabilities catalog.
+
+  Built from `Ash.Filter.builtin_functions/0` and from the `functions/1`
+  callback of each data layer reachable from the manifest's resources.
+
+  `signatures` may be the atom `:var_args` for functions that accept arbitrary
+  arity (e.g. `fragment`).
+
+  `data_layer_module` is `nil` for Ash builtins and a module atom for entries
+  sourced from a specific data layer (e.g. `AshPostgres.DataLayer`).
+  Consumers can use it to intersect a resource's data layer against the
+  catalog when deciding which functions to render for that resource.
+  """
+
+  alias Ash.Info.Manifest.ArgumentSignature
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          module: module(),
+          predicate?: boolean(),
+          signatures: [ArgumentSignature.t()] | :var_args,
+          returns: ArgumentSignature.arg_spec() | :unknown,
+          description: String.t() | nil,
+          data_layer_module: module() | nil
+        }
+
+  defstruct [
+    :name,
+    :module,
+    :predicate?,
+    :signatures,
+    :returns,
+    :description,
+    :data_layer_module
+  ]
+end

--- a/lib/ash/info/manifest/generator.ex
+++ b/lib/ash/info/manifest/generator.ex
@@ -14,7 +14,14 @@ defmodule Ash.Info.Manifest.Generator do
   5. Produce `%Ash.Info.Manifest{}`
   """
 
-  alias Ash.Info.Manifest.Generator.{ActionBuilder, Reachability, ResourceBuilder, TypeResolver}
+  alias Ash.Info.Manifest.Generator.{
+    ActionBuilder,
+    CapabilitiesBuilder,
+    Reachability,
+    ResourceBuilder,
+    TypeResolver
+  }
+
   alias Ash.Info.Manifest.Validators
 
   @doc """
@@ -104,12 +111,17 @@ defmodule Ash.Info.Manifest.Generator do
     reachable_resources = Enum.uniq(reachable_resources ++ always_resources)
     standalone_types = Enum.uniq(standalone_types ++ always_types)
 
+    data_layer_modules = collect_data_layer_modules(reachable_resources)
+
+    {filter_capabilities, sort_capabilities} =
+      CapabilitiesBuilder.build(data_layer_modules: data_layer_modules)
+
     # Build resource specs (no actions — those live in entrypoints)
     resources =
       reachable_resources
       |> Enum.sort_by(&Module.split/1)
       |> Enum.map(fn resource ->
-        ResourceBuilder.build(resource, build_opts)
+        ResourceBuilder.build(resource, build_opts, filter_capabilities)
       end)
 
     # Build entrypoints — one per normalized entry (not per unique action)
@@ -139,8 +151,20 @@ defmodule Ash.Info.Manifest.Generator do
      %Ash.Info.Manifest{
        resources: resources,
        types: types,
-       entrypoints: entrypoints
+       entrypoints: entrypoints,
+       filter_capabilities: filter_capabilities,
+       sort_capabilities: sort_capabilities
      }}
+  end
+
+  # Distinct data-layer modules across reachable resources, in a stable order
+  # (sorted by module split). `nil` data layers are filtered out.
+  defp collect_data_layer_modules(resources) do
+    resources
+    |> Enum.map(&Ash.DataLayer.data_layer/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.sort_by(&Module.split/1)
   end
 
   # Normalizes action_filter entries into {resource, action_name, config} triples.

--- a/lib/ash/info/manifest/generator/capabilities_builder.ex
+++ b/lib/ash/info/manifest/generator/capabilities_builder.ex
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.CapabilitiesBuilder do
+  @moduledoc """
+  Builds the top-level `%FilterCapabilities{}` and `%SortCapabilities{}` for a
+  manifest by enumerating Ash's builtin operators/functions and the app's
+  registered custom expressions.
+  """
+
+  alias Ash.Info.Manifest.{
+    ArgumentSignature,
+    CustomExpression,
+    FilterCapabilities,
+    Function,
+    Operator,
+    SortCapabilities
+  }
+
+  @doc """
+  Build the global `%FilterCapabilities{}` and `%SortCapabilities{}` for a
+  manifest.
+
+  ## Options
+
+    * `:data_layer_modules` - List of data-layer modules whose `functions/1`
+      callback contributes additional predicate functions to the catalog. Each
+      contributed `%Function{}` is tagged with `data_layer_module` so consumers
+      can intersect against a resource's data layer.
+
+  Without `:data_layer_modules`, the catalog is the Ash builtins plus the
+  app's registered custom expressions — identical to the previous `build/0`
+  behavior.
+  """
+  @spec build(keyword()) :: {FilterCapabilities.t(), SortCapabilities.t()}
+  def build(opts \\ []) do
+    data_layer_modules =
+      opts
+      |> Keyword.get(:data_layer_modules, [])
+      |> Enum.uniq()
+
+    operators = Enum.map(Ash.Filter.builtin_operators(), &build_operator/1)
+
+    builtin_functions = Enum.map(Ash.Filter.builtin_functions(), &build_function(&1, nil))
+    data_layer_functions = collect_data_layer_functions(data_layer_modules)
+    functions = builtin_functions ++ data_layer_functions
+
+    custom_expressions =
+      :ash
+      |> Application.get_env(:custom_expressions, [])
+      |> Enum.map(&build_custom_expression/1)
+
+    filter_caps = %FilterCapabilities{
+      operators: operators,
+      functions: functions,
+      custom_expressions: custom_expressions,
+      boolean_connectives: [:and, :or, :not],
+      predicate_operators: predicate_names(operators),
+      predicate_functions: predicate_names(functions),
+      predicate_custom_expressions: predicate_names(custom_expressions)
+    }
+
+    {filter_caps, %SortCapabilities{}}
+  end
+
+  # Each data-layer module contributes its `functions/1` modules, deduplicated
+  # by function module across data layers. Tag with the *first* data layer that
+  # claimed it. Modules that don't export `functions/1` contribute nothing.
+  defp collect_data_layer_functions(data_layer_modules) do
+    Enum.flat_map(data_layer_modules, fn dl_module ->
+      Code.ensure_loaded(dl_module)
+
+      if function_exported?(dl_module, :functions, 1) do
+        # The functions/1 callback is per-resource in the Ash data-layer API,
+        # but at this catalog level we just need the set of contributed
+        # modules. Passing nil works for data layers whose `functions/1` is
+        # resource-independent (Postgres ilike/trigram, the test fake).
+        apply(dl_module, :functions, [nil])
+      else
+        []
+      end
+    end)
+    |> Enum.uniq()
+    |> Enum.map(fn module ->
+      data_layer_module = first_data_layer_owning(module, data_layer_modules)
+      build_function(module, data_layer_module)
+    end)
+  end
+
+  defp first_data_layer_owning(function_module, data_layer_modules) do
+    Enum.find(data_layer_modules, fn dl ->
+      Code.ensure_loaded(dl)
+
+      function_exported?(dl, :functions, 1) and
+        function_module in apply(dl, :functions, [nil])
+    end)
+  end
+
+  defp build_operator(module) do
+    Code.ensure_loaded(module)
+    {name, aliases} = operator_name_and_aliases(module)
+
+    %Operator{
+      name: name,
+      module: module,
+      aliases: aliases,
+      predicate?: module.predicate?(),
+      signatures: normalize_signatures(module.types()),
+      returns: normalize_returns(module.returns()),
+      description: module_doc(module)
+    }
+  end
+
+  defp build_function(module, data_layer_module) do
+    Code.ensure_loaded(module)
+
+    signatures =
+      case module.args() do
+        :var_args -> :var_args
+        args -> normalize_signatures(args)
+      end
+
+    %Function{
+      name: module.name(),
+      module: module,
+      predicate?: module.predicate?(),
+      signatures: signatures,
+      returns: normalize_returns(module.returns()),
+      description: module_doc(module),
+      data_layer_module: data_layer_module
+    }
+  end
+
+  defp build_custom_expression(module) do
+    %CustomExpression{
+      name: module.name(),
+      module: module,
+      predicate?: module.predicate?(),
+      signatures: normalize_signatures(module.arguments()),
+      description: module_doc(module)
+    }
+  end
+
+  # Canonical name = the user-facing symbol (`:==`, `:<`, `:in`, `:is_nil`).
+  # For operators where `name:` differs from `operator:` (e.g. Eq has
+  # operator: :==, name: :eq), the operator symbol is what users write in
+  # `Ash.Query.filter` expressions and what extensions render to clients.
+  defp operator_name_and_aliases(module) do
+    if function_exported?(module, :operator, 0) do
+      op = module.operator()
+      internal_name = module.name()
+      aliases = if internal_name != op, do: [internal_name], else: []
+      {op, aliases}
+    else
+      {module.name(), []}
+    end
+  end
+
+  defp normalize_signatures(signatures) when is_list(signatures) do
+    Enum.map(signatures, &ArgumentSignature.from_ash_signature/1)
+  end
+
+  defp normalize_signatures(_), do: []
+
+  defp normalize_returns(:unknown), do: :unknown
+  defp normalize_returns(nil), do: :unknown
+
+  defp normalize_returns(returns) when is_list(returns) do
+    case returns do
+      [] -> :unknown
+      [single] -> ArgumentSignature.normalize_arg(single)
+      [first | _] -> ArgumentSignature.normalize_arg(first)
+    end
+  end
+
+  defp normalize_returns(other) when is_atom(other) or is_tuple(other) do
+    ArgumentSignature.normalize_arg(other)
+  end
+
+  defp normalize_returns(_), do: :unknown
+
+  defp predicate_names(entries) do
+    entries
+    |> Enum.filter(& &1.predicate?)
+    |> Enum.map(& &1.name)
+  end
+
+  defp module_doc(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, %{"en" => doc}, _, _} -> doc
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+end

--- a/lib/ash/info/manifest/generator/operator_resolver.ex
+++ b/lib/ash/info/manifest/generator/operator_resolver.ex
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.OperatorResolver do
+  @moduledoc """
+  Resolves which predicate operators and functions in the filter capabilities
+  catalog apply to a given field type, pre-resolving the right-hand-side type
+  for each match.
+
+  Treats the field as the *first argument* of each operator/function signature.
+  `:any` and `:same` arg-kind sentinels always match. Concrete builtins match
+  when the type's `kind` agrees; concrete modules match when the type's
+  `module` agrees. `Ash.Type.operator_overloads/0` is consulted for the
+  type's module — any operator listed there is considered applicable.
+
+  ## NewType subtype matching
+
+  When the field's type module is an `Ash.Type.NewType`, applicability is
+  evaluated against both the NewType and its `subtype_of/0` base type. This
+  mirrors how ash_graphql derives filter inputs for NewType fields — operators
+  with concrete signatures (e.g. `:contains` requires `:string`) match the
+  underlying base.
+
+  ## Ordered comparison trimming
+
+  For `:array`- and `:boolean`-kind field types, ordered comparison
+  operators (`:<`, `:>`, `:<=`, `:>=`) are dropped from the result. They
+  survive the structural signature match (their sigs are `[:same, :any]`,
+  which accepts anything) but the orderings aren't useful: no common Ash
+  data layer offers a meaningful whole-array compare (Postgres'
+  lexicographic compare is rarely what users want, Ets has no notion at
+  all), and booleans have no meaningful ordering for filter UX. Equality,
+  membership, and `is_nil` are preserved.
+
+  ## RHS resolution
+
+  For each applicable entry, the matching signature's *second* arg drives the
+  `rhs` value on the returned `%ApplicableOperator{}`/`%ApplicableFunction{}`.
+  Single-arg signatures (e.g. `Eq`'s `[:any]` and `[:same]` shorthand) yield
+  `rhs: :same`. Multi-arg signatures yield:
+
+    * second arg `:same`        → `:same`
+    * second arg `:any`         → `:any`
+    * second arg concrete       → `{:concrete, type_ref}`
+    * second arg `{:array, t}`  → `{:array, rhs(t)}`
+
+  Operators that apply only via `operator_overloads/0` (no matching signature
+  found structurally) default to `rhs: :same`.
+  """
+
+  alias Ash.Info.Manifest.{
+    ApplicableFunction,
+    ApplicableOperator,
+    ArgumentSignature,
+    FilterCapabilities,
+    Type
+  }
+
+  alias Ash.Info.Manifest.Generator.TypeResolver
+
+  @ordered_comparison_operators MapSet.new([:<, :>, :<=, :>=])
+
+  @doc """
+  Resolve applicable operators and functions for a field type.
+
+  Returns `{[ApplicableOperator.t()], [ApplicableFunction.t()]}` — each entry
+  pairs an operator/function name with its pre-resolved right-hand-side type.
+
+  When `resource_data_layer` is given, data-layer-tagged functions
+  (`%Function{data_layer_module: dl}` with `dl != nil`) are filtered to only
+  those whose `data_layer_module` matches. Untagged (builtin) functions are
+  always considered. Pass `nil` to hide all data-layer-tagged functions —
+  use the default `resolve/2` when there's no data-layer context.
+  """
+  @spec resolve(Type.t(), FilterCapabilities.t(), module() | nil) ::
+          {[ApplicableOperator.t()], [ApplicableFunction.t()]}
+  def resolve(%Type{} = field_type, %FilterCapabilities{} = caps, resource_data_layer \\ nil) do
+    predicate_ops = MapSet.new(caps.predicate_operators)
+    predicate_fns = MapSet.new(caps.predicate_functions)
+    overloaded = overloaded_operator_names(field_type)
+    candidates = candidate_types(field_type)
+    op_blacklist = blacklisted_operators(field_type)
+
+    operators =
+      caps.operators
+      |> Enum.filter(fn op ->
+        op.name in predicate_ops and op.name not in op_blacklist
+      end)
+      |> Enum.flat_map(fn op ->
+        case match_with_rhs(op, candidates) do
+          {:ok, rhs} ->
+            [%ApplicableOperator{name: op.name, rhs: rhs}]
+
+          :error ->
+            if op.name in overloaded do
+              [%ApplicableOperator{name: op.name, rhs: :same}]
+            else
+              []
+            end
+        end
+      end)
+      |> Enum.uniq_by(& &1.name)
+
+    functions =
+      caps.functions
+      |> Enum.filter(fn fun ->
+        fun.name in predicate_fns and data_layer_visible?(fun, resource_data_layer)
+      end)
+      |> Enum.flat_map(fn fun ->
+        case match_with_rhs(fun, candidates) do
+          {:ok, rhs} -> [%ApplicableFunction{name: fun.name, rhs: rhs}]
+          :error -> []
+        end
+      end)
+      |> Enum.uniq_by(& &1.name)
+
+    {operators, functions}
+  end
+
+  @doc """
+  Resolve applicable custom expressions for a field type.
+
+  Same shape as the operator/function resolution but against
+  `caps.custom_expressions` filtered by `predicate_custom_expressions`.
+  Returns a list of `%ApplicableCustomExpression{}`.
+  """
+  @spec resolve_custom_expressions(Type.t(), FilterCapabilities.t()) ::
+          [Ash.Info.Manifest.ApplicableCustomExpression.t()]
+  def resolve_custom_expressions(%Type{} = field_type, %FilterCapabilities{} = caps) do
+    predicate_ces = MapSet.new(caps.predicate_custom_expressions)
+    candidates = candidate_types(field_type)
+
+    caps.custom_expressions
+    |> Enum.filter(&(&1.name in predicate_ces))
+    |> Enum.flat_map(fn ce ->
+      case match_with_rhs(ce, candidates) do
+        {:ok, rhs} ->
+          [%Ash.Info.Manifest.ApplicableCustomExpression{name: ce.name, rhs: rhs}]
+
+        :error ->
+          []
+      end
+    end)
+    |> Enum.uniq_by(& &1.name)
+  end
+
+  defp data_layer_visible?(%{data_layer_module: nil}, _resource_data_layer), do: true
+  defp data_layer_visible?(%{data_layer_module: dl}, dl), do: true
+  defp data_layer_visible?(_, _), do: false
+
+  # Try each signature against each candidate. First match wins; returns the
+  # signature so we can derive the RHS from its second arg.
+  defp match_with_rhs(%{signatures: :var_args}, _candidates), do: :error
+  defp match_with_rhs(%{signatures: []}, _candidates), do: :error
+
+  defp match_with_rhs(%{signatures: signatures}, candidates) when is_list(signatures) do
+    Enum.find_value(signatures, :error, fn sig ->
+      if Enum.any?(candidates, &first_arg_matches?(sig, &1)) do
+        {:ok, rhs_from_signature(sig)}
+      end
+    end)
+  end
+
+  defp match_with_rhs(_, _), do: :error
+
+  defp rhs_from_signature(%ArgumentSignature{args: [_only]}), do: :same
+
+  defp rhs_from_signature(%ArgumentSignature{args: [_first, second | _]}) do
+    arg_to_rhs(second)
+  end
+
+  defp rhs_from_signature(_), do: :any
+
+  defp arg_to_rhs(%{kind: :same}), do: :same
+  defp arg_to_rhs(%{kind: :any}), do: :any
+
+  defp arg_to_rhs(%{kind: :concrete, builtin: builtin, type_ref: nil}) when not is_nil(builtin),
+    do: {:concrete, builtin}
+
+  defp arg_to_rhs(%{kind: :concrete, builtin: nil, type_ref: module}) when not is_nil(module),
+    do: {:concrete, module}
+
+  defp arg_to_rhs(%{kind: :array, of: inner}), do: {:array, arg_to_rhs(inner)}
+  defp arg_to_rhs(_), do: :any
+
+  defp first_arg_matches?(%ArgumentSignature{args: [first | _]}, field_type) do
+    arg_matches_type?(first, field_type)
+  end
+
+  defp first_arg_matches?(_, _), do: false
+
+  defp arg_matches_type?(%{kind: :any}, _), do: true
+  defp arg_matches_type?(%{kind: :same}, _), do: true
+
+  defp arg_matches_type?(%{kind: :array, of: inner_spec}, %Type{
+         kind: :array,
+         item_type: %Type{} = item_type
+       }) do
+    arg_matches_type?(inner_spec, item_type)
+  end
+
+  defp arg_matches_type?(%{kind: :concrete, builtin: builtin, type_ref: nil}, %Type{
+         kind: kind
+       })
+       when not is_nil(builtin) do
+    builtin == kind
+  end
+
+  defp arg_matches_type?(%{kind: :concrete, type_ref: module, builtin: nil}, %Type{
+         module: module
+       })
+       when not is_nil(module) do
+    true
+  end
+
+  defp arg_matches_type?(_, _), do: false
+
+  defp blacklisted_operators(%Type{kind: :array}), do: @ordered_comparison_operators
+  defp blacklisted_operators(%Type{kind: :boolean}), do: @ordered_comparison_operators
+  defp blacklisted_operators(_), do: MapSet.new()
+
+  defp candidate_types(%Type{module: module} = field_type)
+       when is_atom(module) and not is_nil(module) do
+    Code.ensure_loaded(module)
+
+    if Ash.Type.NewType.new_type?(module) do
+      base = Ash.Type.NewType.subtype_of(module)
+      [field_type, TypeResolver.resolve(base)]
+    else
+      [field_type]
+    end
+  rescue
+    _ -> [field_type]
+  end
+
+  defp candidate_types(field_type), do: [field_type]
+
+  defp overloaded_operator_names(%Type{module: module})
+       when is_atom(module) and not is_nil(module) do
+    Code.ensure_loaded(module)
+
+    if function_exported?(module, :operator_overloads, 0) do
+      module.operator_overloads()
+      |> Map.keys()
+      |> MapSet.new()
+    else
+      MapSet.new()
+    end
+  rescue
+    _ -> MapSet.new()
+  end
+
+  defp overloaded_operator_names(_), do: MapSet.new()
+end

--- a/lib/ash/info/manifest/generator/resource_builder.ex
+++ b/lib/ash/info/manifest/generator/resource_builder.ex
@@ -8,7 +8,12 @@ defmodule Ash.Info.Manifest.Generator.ResourceBuilder do
   """
 
   alias Ash.Info.Manifest.{Argument, Field, Relationship, Resource}
-  alias Ash.Info.Manifest.Generator.TypeResolver
+
+  alias Ash.Info.Manifest.Generator.{
+    OperatorResolver,
+    ResultNullability,
+    TypeResolver
+  }
 
   @doc """
   Build a `%Ash.Info.Manifest.Resource{}` from an Ash resource module.
@@ -22,51 +27,57 @@ defmodule Ash.Info.Manifest.Generator.ResourceBuilder do
     * `:include_private_aggregates?` - Include private aggregates (default: `false`)
     * `:include_private_relationships?` - Include private relationships (default: `false`)
   """
-  @spec build(atom(), keyword()) :: Resource.t()
-  def build(resource, opts \\ []) do
+  @spec build(atom(), keyword(), Ash.Info.Manifest.FilterCapabilities.t() | nil) :: Resource.t()
+  def build(resource, opts \\ [], filter_capabilities \\ nil) do
+    data_layer = Ash.DataLayer.data_layer(resource)
+
     %Resource{
       name: resource_name(resource),
       module: resource,
       embedded?: Ash.Resource.Info.embedded?(resource),
       primary_key: Ash.Resource.Info.primary_key(resource),
       description: Ash.Resource.Info.description(resource),
-      fields: build_fields(resource, opts),
+      fields: build_fields(resource, opts, filter_capabilities, data_layer),
       relationships: build_relationships(resource, opts),
       identities: build_identities(resource),
       multitenancy: build_multitenancy(resource)
     }
   end
 
-  defp build_fields(resource, opts) do
-    attributes = build_attributes(resource, opts)
-    calculations = build_calculations(resource, opts)
-    aggregates = build_aggregates(resource, opts)
+  defp build_fields(resource, opts, filter_capabilities, data_layer) do
+    attributes = build_attributes(resource, opts, filter_capabilities, data_layer)
+    calculations = build_calculations(resource, opts, filter_capabilities, data_layer)
+    aggregates = build_aggregates(resource, opts, filter_capabilities, data_layer)
 
     Map.new(attributes ++ calculations ++ aggregates, fn field -> {field.name, field} end)
   end
 
-  defp build_attributes(resource, opts) do
+  defp build_attributes(resource, opts, filter_capabilities, data_layer) do
     resource
     |> get_attributes(opts)
     |> Enum.map(fn attr ->
+      type = TypeResolver.resolve(attr.type, attr.constraints || [])
+      filterable? = Map.get(attr, :filterable?, true)
+
       %Field{
         name: attr.name,
         kind: :attribute,
-        type: TypeResolver.resolve(attr.type, attr.constraints || []),
+        type: type,
         allow_nil?: attr.allow_nil?,
         writable?: attr.writable?,
         has_default?: not is_nil(attr.default),
         description: Map.get(attr, :description),
-        filterable?: Map.get(attr, :filterable?, true),
+        filterable?: filterable?,
         sortable?: Map.get(attr, :sortable?, true),
         primary_key?: attr.primary_key?,
         sensitive?: Map.get(attr, :sensitive?, false),
         select_by_default?: Map.get(attr, :select_by_default?, true)
       }
+      |> resolve_filter_lists(filterable?, type, filter_capabilities, data_layer)
     end)
   end
 
-  defp build_calculations(resource, opts) do
+  defp build_calculations(resource, opts, filter_capabilities, data_layer) do
     resource
     |> get_calculations(opts)
     |> Enum.filter(fn calc -> Map.get(calc, :field?, true) end)
@@ -83,46 +94,83 @@ defmodule Ash.Info.Manifest.Generator.ResourceBuilder do
           }
         end)
 
+      type = TypeResolver.resolve(calc.type, calc.constraints || [])
+      filterable? = Map.get(calc, :filterable?, true)
+
       %Field{
         name: calc.name,
         kind: :calculation,
-        type: TypeResolver.resolve(calc.type, calc.constraints || []),
+        type: type,
         allow_nil?: calc.allow_nil?,
         writable?: false,
         has_default?: false,
         description: Map.get(calc, :description),
-        filterable?: Map.get(calc, :filterable?, true),
+        filterable?: filterable?,
         sortable?: Map.get(calc, :sortable?, true),
         primary_key?: false,
         sensitive?: Map.get(calc, :sensitive?, false),
         select_by_default?: Map.get(calc, :select_by_default?, true),
         arguments: arguments
       }
+      |> resolve_filter_lists(filterable?, type, filter_capabilities, data_layer)
     end)
   end
 
-  defp build_aggregates(resource, opts) do
+  defp build_aggregates(resource, opts, filter_capabilities, data_layer) do
     resource
     |> get_aggregates(opts)
     |> Enum.map(fn aggregate ->
-      {type, constraints} = resolve_aggregate_type(resource, aggregate)
+      {type_in, constraints} = resolve_aggregate_type(resource, aggregate)
+      type = TypeResolver.resolve(type_in, constraints)
+      filterable? = Map.get(aggregate, :filterable?, true)
 
       %Field{
         name: aggregate.name,
         kind: :aggregate,
-        type: TypeResolver.resolve(type, constraints),
-        allow_nil?: Map.get(aggregate, :include_nil?, false),
+        type: type,
+        allow_nil?: ResultNullability.for_aggregate(aggregate),
         writable?: false,
         has_default?: false,
         description: Map.get(aggregate, :description),
-        filterable?: Map.get(aggregate, :filterable?, true),
+        filterable?: filterable?,
         sortable?: Map.get(aggregate, :sortable?, true),
         primary_key?: false,
         sensitive?: false,
         select_by_default?: Map.get(aggregate, :select_by_default?, true),
         aggregate_kind: aggregate.kind
       }
+      |> resolve_filter_lists(filterable?, type, filter_capabilities, data_layer)
     end)
+  end
+
+  defp resolve_filter_lists(field, false, _type, _caps, _data_layer) do
+    %{
+      field
+      | filter_operators: nil,
+        filter_functions: nil,
+        filter_custom_expressions: nil
+    }
+  end
+
+  defp resolve_filter_lists(field, true, _type, nil, _data_layer) do
+    %{
+      field
+      | filter_operators: nil,
+        filter_functions: nil,
+        filter_custom_expressions: nil
+    }
+  end
+
+  defp resolve_filter_lists(field, true, type, capabilities, data_layer) do
+    {operators, functions} = OperatorResolver.resolve(type, capabilities, data_layer)
+    custom_expressions = OperatorResolver.resolve_custom_expressions(type, capabilities)
+
+    %{
+      field
+      | filter_operators: operators,
+        filter_functions: functions,
+        filter_custom_expressions: custom_expressions
+    }
   end
 
   defp resolve_aggregate_type(resource, aggregate) do

--- a/lib/ash/info/manifest/generator/result_nullability.ex
+++ b/lib/ash/info/manifest/generator/result_nullability.ex
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Generator.ResultNullability do
+  @moduledoc """
+  Computes manifest-level `allow_nil?` (result nullability) for aggregates.
+
+  Per Ash's aggregate semantics, this is independent of the user-facing
+  `include_nil?` flag (which controls whether nils contribute to the aggregated
+  set — an *input* concern). The result nullability is determined by the
+  aggregate's `kind`:
+
+    * `:count`, `:exists`, `:list` — never null. `:count` returns 0 on an empty
+      relationship, `:exists` returns false, `:list` returns `[]`.
+    * `:first`, `:max`, `:min`, `:sum`, `:avg` — null on an empty relationship.
+    * `:custom` — preserves the aggregate's own `allow_nil?` if set; otherwise
+      defaults to `true` (the safe assumption, since the callback's behavior is
+      unknown).
+  """
+
+  @spec for_aggregate(map()) :: boolean()
+  def for_aggregate(%{kind: kind} = aggregate) do
+    case kind do
+      k when k in [:count, :exists, :list] -> false
+      k when k in [:first, :max, :min, :sum, :avg] -> true
+      :custom -> Map.get(aggregate, :allow_nil?, true)
+    end
+  end
+end

--- a/lib/ash/info/manifest/json_serializer.ex
+++ b/lib/ash/info/manifest/json_serializer.ex
@@ -37,7 +37,96 @@ defmodule Ash.Info.Manifest.JsonSerializer do
       "types" => Enum.map(spec.types, &serialize_type/1),
       "entrypoints" => Enum.map(spec.entrypoints, &serialize_entrypoint/1)
     }
+    |> put_if_present(
+      "filter_capabilities",
+      serialize_filter_capabilities(spec.filter_capabilities)
+    )
+    |> put_if_present(
+      "sort_capabilities",
+      serialize_sort_capabilities(spec.sort_capabilities)
+    )
   end
+
+  defp serialize_filter_capabilities(nil), do: nil
+
+  defp serialize_filter_capabilities(%Ash.Info.Manifest.FilterCapabilities{} = caps) do
+    %{
+      "operators" => Enum.map(caps.operators, &serialize_operator/1),
+      "functions" => Enum.map(caps.functions, &serialize_function/1),
+      "custom_expressions" => Enum.map(caps.custom_expressions, &serialize_custom_expression/1),
+      "boolean_connectives" => Enum.map(caps.boolean_connectives, &to_string/1),
+      "predicate_operators" => Enum.map(caps.predicate_operators, &to_string/1),
+      "predicate_functions" => Enum.map(caps.predicate_functions, &to_string/1),
+      "predicate_custom_expressions" => Enum.map(caps.predicate_custom_expressions, &to_string/1)
+    }
+  end
+
+  defp serialize_sort_capabilities(nil), do: nil
+
+  defp serialize_sort_capabilities(%Ash.Info.Manifest.SortCapabilities{} = caps) do
+    %{"directions" => Enum.map(caps.directions, &to_string/1)}
+  end
+
+  defp serialize_operator(%Ash.Info.Manifest.Operator{} = op) do
+    %{
+      "name" => to_string(op.name),
+      "module" => module_to_string(op.module),
+      "aliases" => Enum.map(op.aliases || [], &to_string/1),
+      "predicate" => op.predicate?,
+      "signatures" => Enum.map(op.signatures || [], &serialize_signature/1),
+      "returns" => serialize_returns(op.returns)
+    }
+    |> put_if_present("description", op.description)
+  end
+
+  defp serialize_function(%Ash.Info.Manifest.Function{} = fun) do
+    %{
+      "name" => to_string(fun.name),
+      "module" => module_to_string(fun.module),
+      "predicate" => fun.predicate?,
+      "signatures" => serialize_function_signatures(fun.signatures),
+      "returns" => serialize_returns(fun.returns)
+    }
+    |> put_if_present("description", fun.description)
+    |> put_if_present("data_layer_module", module_to_string(fun.data_layer_module))
+  end
+
+  defp serialize_custom_expression(%Ash.Info.Manifest.CustomExpression{} = ce) do
+    %{
+      "name" => to_string(ce.name),
+      "module" => module_to_string(ce.module),
+      "predicate" => ce.predicate?,
+      "signatures" => Enum.map(ce.signatures || [], &serialize_signature/1)
+    }
+    |> put_if_present("description", ce.description)
+  end
+
+  defp serialize_function_signatures(:var_args), do: "var_args"
+
+  defp serialize_function_signatures(sigs) when is_list(sigs),
+    do: Enum.map(sigs, &serialize_signature/1)
+
+  defp serialize_signature(%Ash.Info.Manifest.ArgumentSignature{args: args}) do
+    %{"args" => Enum.map(args, &serialize_arg_spec/1)}
+  end
+
+  defp serialize_arg_spec(%{kind: kind} = arg) do
+    %{"kind" => to_string(kind)}
+    |> put_if_present("builtin", serialize_atom(arg[:builtin]))
+    |> put_if_present("type_ref", module_to_string(arg[:type_ref]))
+    |> put_if_present("of", serialize_arg_of(arg[:of]))
+    |> put_if_present(
+      "constraints",
+      if(arg[:constraints] in [nil, []], do: nil, else: inspect(arg[:constraints]))
+    )
+  end
+
+  defp serialize_arg_of(nil), do: nil
+  defp serialize_arg_of(%{kind: _} = inner), do: serialize_arg_spec(inner)
+
+  defp serialize_returns(:unknown), do: "unknown"
+  defp serialize_returns(nil), do: nil
+  defp serialize_returns(%{kind: _} = arg), do: serialize_arg_spec(arg)
 
   defp serialize_resource(%Ash.Info.Manifest.Resource{} = resource) do
     %{
@@ -78,6 +167,49 @@ defmodule Ash.Info.Manifest.JsonSerializer do
     |> put_if_present("description", field.description)
     |> put_if_present("arguments", serialize_arguments_list(field.arguments))
     |> put_if_present("aggregate_kind", serialize_atom(field.aggregate_kind))
+    |> put_if_present("filter_operators", serialize_applicable_list(field.filter_operators))
+    |> put_if_present("filter_functions", serialize_applicable_list(field.filter_functions))
+    |> put_if_present(
+      "filter_custom_expressions",
+      serialize_applicable_list(field.filter_custom_expressions)
+    )
+  end
+
+  defp serialize_applicable_list(nil), do: nil
+
+  defp serialize_applicable_list(list) when is_list(list) do
+    Enum.map(list, &serialize_applicable/1)
+  end
+
+  defp serialize_applicable(%Ash.Info.Manifest.ApplicableOperator{name: name, rhs: rhs}) do
+    %{"name" => to_string(name), "rhs" => serialize_rhs(rhs)}
+  end
+
+  defp serialize_applicable(%Ash.Info.Manifest.ApplicableFunction{name: name, rhs: rhs}) do
+    %{"name" => to_string(name), "rhs" => serialize_rhs(rhs)}
+  end
+
+  defp serialize_applicable(%Ash.Info.Manifest.ApplicableCustomExpression{
+         name: name,
+         rhs: rhs
+       }) do
+    %{"name" => to_string(name), "rhs" => serialize_rhs(rhs)}
+  end
+
+  defp serialize_rhs(:same), do: "same"
+  defp serialize_rhs(:any), do: "any"
+
+  defp serialize_rhs({:concrete, ref}) when is_atom(ref),
+    do: %{"concrete" => concrete_ref(ref)}
+
+  defp serialize_rhs({:array, inner}), do: %{"array" => serialize_rhs(inner)}
+  defp serialize_rhs(_), do: "any"
+
+  defp concrete_ref(ref) do
+    case Atom.to_string(ref) do
+      "Elixir." <> _ -> module_to_string(ref)
+      other -> other
+    end
   end
 
   defp serialize_relationship(%Ash.Info.Manifest.Relationship{} = rel) do

--- a/lib/ash/info/manifest/operator.ex
+++ b/lib/ash/info/manifest/operator.ex
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.Operator do
+  @moduledoc """
+  Represents a single operator in the filter capabilities catalog.
+
+  Built from `Ash.Filter.builtin_operators/0`.
+
+  ## Canonical name vs. aliases
+
+  `name` is the **user-facing operator symbol** — the spelling that appears
+  in `Ash.Query.filter` expressions and that extensions should render to
+  clients (e.g. `:==`, `:<`, `:in`, `:is_nil`).
+
+  `aliases` carries the legacy/module-derived spellings (e.g. `:eq`,
+  `:less_than`). New consumers should key off `name`. Tools that already
+  render the module-derived names (e.g. some historical ash_graphql input
+  shapes) can substitute via aliases for backward compatibility.
+
+  Each per-field `%Ash.Info.Manifest.ApplicableOperator{}` records `name` (the
+  canonical symbol), not an alias. Consumers look up the full operator
+  definition via `Ash.Info.Manifest.operator_lookup/1`.
+  """
+
+  alias Ash.Info.Manifest.ArgumentSignature
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          module: module(),
+          aliases: [atom()],
+          predicate?: boolean(),
+          signatures: [ArgumentSignature.t()],
+          returns: ArgumentSignature.arg_spec() | :unknown,
+          description: String.t() | nil
+        }
+
+  defstruct [:name, :module, :aliases, :predicate?, :signatures, :returns, :description]
+end

--- a/lib/ash/info/manifest/relationship.ex
+++ b/lib/ash/info/manifest/relationship.ex
@@ -5,6 +5,13 @@
 defmodule Ash.Info.Manifest.Relationship do
   @moduledoc """
   Represents a resource relationship in the API specification.
+
+  `filterable?` / `sortable?` say *whether* the relationship participates in
+  filter/sort inputs. The *shape* of the operation (dot-traversal vs.
+  existential quantifier, single-record sort vs. none) is derivable from
+  `cardinality`: `:one` relationships can be dot-traversed and sorted by;
+  `:many` relationships need an `exists`-style predicate for filters and have
+  no well-defined whole-set ordering for sorts.
   """
 
   @type relationship_type :: :has_many | :has_one | :belongs_to | :many_to_many

--- a/lib/ash/info/manifest/sort_capabilities.ex
+++ b/lib/ash/info/manifest/sort_capabilities.ex
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Info.Manifest.SortCapabilities do
+  @moduledoc """
+  Top-level sort vocabulary for a manifest. The directions list is fixed —
+  Ash's sort directions don't vary per resource or app config.
+  """
+
+  @type direction ::
+          :asc | :desc | :asc_nils_first | :asc_nils_last | :desc_nils_first | :desc_nils_last
+
+  @type t :: %__MODULE__{directions: [direction()]}
+
+  defstruct directions: [
+              :asc,
+              :desc,
+              :asc_nils_first,
+              :asc_nils_last,
+              :desc_nils_first,
+              :desc_nils_last
+            ]
+end

--- a/test/ash/info/manifest/applicable_operator_test.exs
+++ b/test/ash/info/manifest/applicable_operator_test.exs
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.ApplicableOperatorTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.{ApplicableFunction, ApplicableOperator}
+
+  describe "%ApplicableOperator{}" do
+    test "carries a name atom and an rhs descriptor" do
+      op = %ApplicableOperator{name: :==, rhs: :same}
+      assert op.name == :==
+      assert op.rhs == :same
+    end
+
+    test "rhs can be :any" do
+      assert %ApplicableOperator{rhs: :any} = %ApplicableOperator{name: :is_nil, rhs: :any}
+    end
+
+    test "rhs can be a concrete builtin atom" do
+      assert %ApplicableOperator{rhs: {:concrete, :boolean}} =
+               %ApplicableOperator{name: :is_nil, rhs: {:concrete, :boolean}}
+    end
+
+    test "rhs can be a concrete module" do
+      assert %ApplicableOperator{rhs: {:concrete, Ash.Type.UUID}} =
+               %ApplicableOperator{name: :==, rhs: {:concrete, Ash.Type.UUID}}
+    end
+
+    test "rhs can nest as {:array, rhs}" do
+      assert %ApplicableOperator{rhs: {:array, :same}} =
+               %ApplicableOperator{name: :in, rhs: {:array, :same}}
+    end
+  end
+
+  describe "%ApplicableFunction{}" do
+    test "shares the same shape as ApplicableOperator" do
+      fun = %ApplicableFunction{name: :contains, rhs: {:concrete, :string}}
+      assert fun.name == :contains
+      assert fun.rhs == {:concrete, :string}
+    end
+  end
+end

--- a/test/ash/info/manifest/argument_signature_test.exs
+++ b/test/ash/info/manifest/argument_signature_test.exs
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.ArgumentSignatureTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.ArgumentSignature
+
+  describe "from_ash_signature/1" do
+    test "normalizes a builtin-atom signature" do
+      assert %ArgumentSignature{
+               args: [
+                 %{kind: :concrete, builtin: :string, type_ref: nil, constraints: []},
+                 %{kind: :concrete, builtin: :string, type_ref: nil, constraints: []}
+               ]
+             } = ArgumentSignature.from_ash_signature([:string, :string])
+    end
+
+    test "normalizes :same and :any sentinels" do
+      assert %ArgumentSignature{
+               args: [
+                 %{kind: :same, builtin: nil, type_ref: nil, constraints: []},
+                 %{kind: :any, builtin: nil, type_ref: nil, constraints: []}
+               ]
+             } = ArgumentSignature.from_ash_signature([:same, :any])
+    end
+
+    test "normalizes module-only entries" do
+      assert %ArgumentSignature{
+               args: [
+                 %{kind: :concrete, builtin: nil, type_ref: Ash.Type.Integer, constraints: []}
+               ]
+             } = ArgumentSignature.from_ash_signature([Ash.Type.Integer])
+    end
+
+    test "normalizes {module, constraints} tuples" do
+      assert %ArgumentSignature{
+               args: [
+                 %{
+                   kind: :concrete,
+                   builtin: nil,
+                   type_ref: Ash.Type.String,
+                   constraints: [min_length: 1]
+                 }
+               ]
+             } = ArgumentSignature.from_ash_signature([{Ash.Type.String, [min_length: 1]}])
+    end
+
+    test "normalizes {:array, builtin} tuples as :array kind carrying the inner spec" do
+      assert %ArgumentSignature{
+               args: [
+                 %{
+                   kind: :array,
+                   builtin: nil,
+                   type_ref: nil,
+                   constraints: [],
+                   of: %{kind: :concrete, builtin: :integer}
+                 }
+               ]
+             } = ArgumentSignature.from_ash_signature([{:array, :integer}])
+    end
+
+    test "normalizes {:array, :same} tuples as :array kind carrying :same" do
+      assert %ArgumentSignature{
+               args: [
+                 %{
+                   kind: :array,
+                   of: %{kind: :same}
+                 }
+               ]
+             } = ArgumentSignature.from_ash_signature([{:array, :same}])
+    end
+
+    test "normalizes nested {:array, {:array, t}} tuples recursively" do
+      assert %ArgumentSignature{
+               args: [
+                 %{
+                   kind: :array,
+                   of: %{kind: :array, of: %{kind: :concrete, builtin: :integer}}
+                 }
+               ]
+             } = ArgumentSignature.from_ash_signature([{:array, {:array, :integer}}])
+    end
+
+    test "wraps a shorthand atom signature into a one-arg signature" do
+      # Ash's default `types/0` is `[:same, :any]`. The outer list is signatures;
+      # each element of the outer list can itself be a bare atom (`:same`/`:any`)
+      # representing a one-arg signature with that arg type.
+      assert %ArgumentSignature{args: [%{kind: :same}]} =
+               ArgumentSignature.from_ash_signature(:same)
+
+      assert %ArgumentSignature{args: [%{kind: :any}]} =
+               ArgumentSignature.from_ash_signature(:any)
+    end
+  end
+end

--- a/test/ash/info/manifest/capabilities_builder_test.exs
+++ b/test/ash/info/manifest/capabilities_builder_test.exs
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.CapabilitiesBuilderTest do
+  use ExUnit.Case, async: false
+
+  alias Ash.Info.Manifest.{
+    ArgumentSignature,
+    CustomExpression,
+    FilterCapabilities,
+    Function,
+    Operator,
+    SortCapabilities
+  }
+
+  alias Ash.Info.Manifest.Generator.CapabilitiesBuilder
+
+  setup do
+    original = Application.get_env(:ash, :custom_expressions, [])
+
+    Application.put_env(:ash, :custom_expressions, [
+      Ash.Test.Expressions.JaroDistance
+    ])
+
+    on_exit(fn -> Application.put_env(:ash, :custom_expressions, original) end)
+
+    :ok
+  end
+
+  describe "build/0" do
+    test "returns a FilterCapabilities and SortCapabilities" do
+      {filter_caps, sort_caps} = CapabilitiesBuilder.build()
+
+      assert %FilterCapabilities{} = filter_caps
+      assert %SortCapabilities{} = sort_caps
+    end
+
+    test "includes every Ash builtin operator" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      catalog_modules = Enum.map(filter_caps.operators, & &1.module)
+
+      for builtin <- Ash.Filter.builtin_operators() do
+        assert builtin in catalog_modules,
+               "expected operator module #{inspect(builtin)} in catalog"
+      end
+    end
+
+    test "includes every Ash builtin function" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      catalog_modules = Enum.map(filter_caps.functions, & &1.module)
+
+      for builtin <- Ash.Filter.builtin_functions() do
+        assert builtin in catalog_modules,
+               "expected function module #{inspect(builtin)} in catalog"
+      end
+    end
+
+    test "includes registered custom expressions" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      assert Enum.any?(filter_caps.custom_expressions, fn ce ->
+               ce.module == Ash.Test.Expressions.JaroDistance and ce.name == :jaro_distance
+             end)
+    end
+
+    test "operator entries use the user-facing symbol as name with internal name in aliases" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+      eq = Enum.find(filter_caps.operators, &(&1.module == Ash.Query.Operator.Eq))
+
+      assert %Operator{} = eq
+      # Canonical name is the symbol that appears in `Ash.Query.filter` expressions.
+      assert eq.name == :==
+      assert :eq in eq.aliases
+      assert eq.predicate? == true
+      assert is_list(eq.signatures)
+      assert Enum.all?(eq.signatures, &match?(%ArgumentSignature{}, &1))
+    end
+
+    test "operators without a separate `name` use the operator atom as name and have no aliases" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+      in_op = Enum.find(filter_caps.operators, &(&1.module == Ash.Query.Operator.In))
+
+      assert in_op.name == :in
+      assert in_op.aliases == []
+    end
+
+    test "function entries carry name, module, predicate?, signatures, returns" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      contains =
+        Enum.find(filter_caps.functions, &(&1.module == Ash.Query.Function.Contains))
+
+      assert %Function{} = contains
+      assert contains.name == :contains
+      assert contains.predicate? == true
+      assert is_list(contains.signatures)
+    end
+
+    test "function with :var_args is preserved" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      fragment =
+        Enum.find(filter_caps.functions, &(&1.module == Ash.Query.Function.Fragment))
+
+      if fragment do
+        assert fragment.signatures == :var_args
+      end
+    end
+
+    test "custom expression entries carry name, module, predicate?, signatures" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      jaro =
+        Enum.find(filter_caps.custom_expressions, fn ce ->
+          ce.module == Ash.Test.Expressions.JaroDistance
+        end)
+
+      assert %CustomExpression{} = jaro
+      assert jaro.name == :jaro_distance
+      assert jaro.predicate? == false
+      assert [%ArgumentSignature{args: [a, b]}] = jaro.signatures
+      assert a.kind == :concrete
+      assert a.builtin == :string
+      assert b.kind == :concrete
+      assert b.builtin == :string
+    end
+
+    test "predicate_operators is the names of predicate? operators" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      expected =
+        filter_caps.operators
+        |> Enum.filter(& &1.predicate?)
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert Enum.sort(filter_caps.predicate_operators) == expected
+    end
+
+    test "predicate_functions is the names of predicate? functions" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      expected =
+        filter_caps.functions
+        |> Enum.filter(& &1.predicate?)
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert Enum.sort(filter_caps.predicate_functions) == expected
+    end
+
+    test "predicate_custom_expressions is the names of predicate? custom expressions" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      expected =
+        filter_caps.custom_expressions
+        |> Enum.filter(& &1.predicate?)
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert Enum.sort(filter_caps.predicate_custom_expressions) == expected
+    end
+
+    test "boolean_connectives is [:and, :or, :not]" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+      assert filter_caps.boolean_connectives == [:and, :or, :not]
+    end
+
+    test "sort directions are the six standard directions" do
+      {_, sort_caps} = CapabilitiesBuilder.build()
+
+      assert sort_caps.directions == [
+               :asc,
+               :desc,
+               :asc_nils_first,
+               :asc_nils_last,
+               :desc_nils_first,
+               :desc_nils_last
+             ]
+    end
+  end
+
+  describe "build/1 with data layer functions" do
+    test "collects functions from each data layer and tags them with data_layer_module" do
+      {filter_caps, _} =
+        CapabilitiesBuilder.build(data_layer_modules: [Ash.Test.Manifest.FakeDataLayer])
+
+      fake =
+        Enum.find(
+          filter_caps.functions,
+          &(&1.module == Ash.Test.Manifest.FakeDataLayerFunction)
+        )
+
+      assert %Function{} = fake
+      assert fake.name == :fake_ilike
+      assert fake.predicate? == true
+      assert fake.data_layer_module == Ash.Test.Manifest.FakeDataLayer
+    end
+
+    test "predicate_functions includes data-layer-sourced predicates" do
+      {filter_caps, _} =
+        CapabilitiesBuilder.build(data_layer_modules: [Ash.Test.Manifest.FakeDataLayer])
+
+      assert :fake_ilike in filter_caps.predicate_functions
+    end
+
+    test "builtin functions remain untagged (data_layer_module is nil)" do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      contains =
+        Enum.find(filter_caps.functions, &(&1.module == Ash.Query.Function.Contains))
+
+      assert contains.data_layer_module == nil
+    end
+
+    test "deduplicates a function module if multiple data layers list it" do
+      {filter_caps, _} =
+        CapabilitiesBuilder.build(
+          data_layer_modules: [
+            Ash.Test.Manifest.FakeDataLayer,
+            Ash.Test.Manifest.FakeDataLayer
+          ]
+        )
+
+      hits =
+        Enum.count(filter_caps.functions, &(&1.module == Ash.Test.Manifest.FakeDataLayerFunction))
+
+      assert hits == 1
+    end
+  end
+end

--- a/test/ash/info/manifest/generator_test.exs
+++ b/test/ash/info/manifest/generator_test.exs
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 defmodule Ash.Test.Info.Manifest.GeneratorTest do
-  use ExUnit.Case, async: true
+  # async: false because the capability-population describe blocks mutate
+  # Application.put_env(:ash, :custom_expressions, ...) in setup.
+  use ExUnit.Case, async: false
 
   describe "generate/1" do
     test "generates spec for otp_app" do
@@ -189,6 +191,76 @@ defmodule Ash.Test.Info.Manifest.GeneratorTest do
 
       assert length(spec_without.resources) == length(spec_with.resources)
       assert length(spec_without.types) == length(spec_with.types)
+    end
+  end
+
+  describe "generate/1 populates filter/sort capabilities" do
+    setup do
+      original = Application.get_env(:ash, :custom_expressions, [])
+
+      Application.put_env(:ash, :custom_expressions, [
+        Ash.Test.Expressions.JaroDistance
+      ])
+
+      on_exit(fn -> Application.put_env(:ash, :custom_expressions, original) end)
+
+      :ok
+    end
+
+    test "the manifest carries a populated filter_capabilities" do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      assert %Ash.Info.Manifest.FilterCapabilities{} = manifest.filter_capabilities
+      assert manifest.filter_capabilities.operators != []
+      assert manifest.filter_capabilities.functions != []
+    end
+
+    test "the manifest includes registered custom expressions" do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      assert Enum.any?(manifest.filter_capabilities.custom_expressions, fn ce ->
+               ce.module == Ash.Test.Expressions.JaroDistance
+             end)
+    end
+
+    test "the manifest carries a populated sort_capabilities" do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      assert %Ash.Info.Manifest.SortCapabilities{directions: directions} =
+               manifest.sort_capabilities
+
+      assert :asc in directions
+      assert :desc_nils_last in directions
+    end
+  end
+
+  describe "per-field operator/function resolution invariants" do
+    test "every field's filter_operators is a subset of predicate_operators" do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      catalog_predicate_ops = MapSet.new(manifest.filter_capabilities.predicate_operators)
+
+      for resource <- manifest.resources, {_name, field} <- resource.fields do
+        if field.filter_operators do
+          field_op_names = MapSet.new(field.filter_operators, & &1.name)
+
+          assert MapSet.subset?(field_op_names, catalog_predicate_ops),
+                 "field #{resource.name}.#{field.name} has operators not in predicate_operators: #{inspect(MapSet.difference(field_op_names, catalog_predicate_ops))}"
+        end
+      end
+    end
+
+    test "every field's filter_functions is a subset of predicate_functions" do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      catalog_predicate_fns = MapSet.new(manifest.filter_capabilities.predicate_functions)
+
+      for resource <- manifest.resources, {_name, field} <- resource.fields do
+        if field.filter_functions do
+          field_fn_names = MapSet.new(field.filter_functions, & &1.name)
+
+          assert MapSet.subset?(field_fn_names, catalog_predicate_fns),
+                 "field #{resource.name}.#{field.name} has functions not in predicate_functions"
+        end
+      end
     end
   end
 end

--- a/test/ash/info/manifest/json_serializer_test.exs
+++ b/test/ash/info/manifest/json_serializer_test.exs
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 defmodule Ash.Test.Info.Manifest.JsonSerializerTest do
-  use ExUnit.Case, async: true
+  # async: false because the top-level capabilities describe blocks mutate
+  # Application.put_env(:ash, :custom_expressions, ...) in setup.
+  use ExUnit.Case, async: false
 
   alias Ash.Info.Manifest.JsonSerializer
 
@@ -150,6 +152,188 @@ defmodule Ash.Test.Info.Manifest.JsonSerializerTest do
       assert is_map(map)
       assert map["schema_version"] == "1.0.0"
       assert is_list(map["resources"])
+    end
+  end
+
+  describe "to_map/1 top-level filter/sort capabilities" do
+    setup do
+      original = Application.get_env(:ash, :custom_expressions, [])
+
+      Application.put_env(:ash, :custom_expressions, [
+        Ash.Test.Expressions.JaroDistance
+      ])
+
+      on_exit(fn -> Application.put_env(:ash, :custom_expressions, original) end)
+
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, manifest: manifest, json: Ash.Info.Manifest.JsonSerializer.to_map(manifest)}
+    end
+
+    test "includes filter_capabilities", %{json: json} do
+      assert %{"filter_capabilities" => caps} = json
+      assert is_list(caps["operators"])
+      assert is_list(caps["functions"])
+      assert is_list(caps["custom_expressions"])
+      assert caps["boolean_connectives"] == ["and", "or", "not"]
+      assert is_list(caps["predicate_operators"])
+      assert is_list(caps["predicate_functions"])
+      assert is_list(caps["predicate_custom_expressions"])
+    end
+
+    test "includes sort_capabilities", %{json: json} do
+      assert %{"sort_capabilities" => sort_caps} = json
+
+      assert sort_caps["directions"] == [
+               "asc",
+               "desc",
+               "asc_nils_first",
+               "asc_nils_last",
+               "desc_nils_first",
+               "desc_nils_last"
+             ]
+    end
+
+    test "each operator entry has name, module, predicate, signatures, returns", %{json: json} do
+      eq =
+        Enum.find(
+          json["filter_capabilities"]["operators"],
+          &(&1["module"] == "Ash.Query.Operator.Eq")
+        )
+
+      assert eq["name"] == to_string(Ash.Query.Operator.Eq.operator())
+      assert eq["predicate"] == true
+      assert is_list(eq["signatures"])
+    end
+
+    test "custom expression entries have name, module, predicate, signatures", %{json: json} do
+      jaro =
+        Enum.find(
+          json["filter_capabilities"]["custom_expressions"],
+          &(&1["module"] == "Ash.Test.Expressions.JaroDistance")
+        )
+
+      assert jaro["name"] == "jaro_distance"
+      assert jaro["predicate"] == false
+
+      assert [%{"args" => [a, b]}] = jaro["signatures"]
+      assert a["kind"] == "concrete"
+      assert a["builtin"] == "string"
+      assert b["builtin"] == "string"
+    end
+
+    test "the JSON round-trips via Jason without errors", %{manifest: manifest} do
+      assert {:ok, json_str} = Ash.Info.Manifest.JsonSerializer.to_json(manifest)
+      assert {:ok, parsed} = Jason.decode(json_str)
+      assert is_map(parsed["filter_capabilities"])
+      assert is_map(parsed["sort_capabilities"])
+    end
+
+    test "builtin function entries omit data_layer_module", %{json: json} do
+      contains =
+        Enum.find(
+          json["filter_capabilities"]["functions"],
+          &(&1["module"] == "Ash.Query.Function.Contains")
+        )
+
+      refute Map.has_key?(contains, "data_layer_module")
+    end
+
+    test "data-layer-sourced function entries include data_layer_module" do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+
+      manifest = %{
+        manifest
+        | filter_capabilities: %{
+            manifest.filter_capabilities
+            | functions:
+                manifest.filter_capabilities.functions ++
+                  [
+                    %Ash.Info.Manifest.Function{
+                      name: :fake_ilike,
+                      module: Ash.Test.Manifest.FakeDataLayerFunction,
+                      predicate?: true,
+                      signatures: [],
+                      returns: :unknown,
+                      data_layer_module: Ash.Test.Manifest.FakeDataLayer
+                    }
+                  ]
+          }
+      }
+
+      json = Ash.Info.Manifest.JsonSerializer.to_map(manifest)
+
+      fake = Enum.find(json["filter_capabilities"]["functions"], &(&1["name"] == "fake_ilike"))
+
+      assert fake["data_layer_module"] == "Ash.Test.Manifest.FakeDataLayer"
+    end
+  end
+
+  describe "to_map/1 per-field filter operators/functions" do
+    setup do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      json = Ash.Info.Manifest.JsonSerializer.to_map(manifest)
+      {:ok, manifest: manifest, json: json}
+    end
+
+    test "filterable fields include filter_operators and filter_functions", %{json: json} do
+      todo = Enum.find(json["resources"], &(&1["name"] == "Todo"))
+      title = todo["fields"]["title"]
+
+      assert is_list(title["filter_operators"])
+      assert is_list(title["filter_functions"])
+
+      eq_symbol = to_string(Ash.Query.Operator.Eq.operator())
+      assert Enum.any?(title["filter_operators"], &(&1["name"] == eq_symbol))
+    end
+
+    test "filter_operators entries are {name, rhs} records", %{json: json} do
+      todo = Enum.find(json["resources"], &(&1["name"] == "Todo"))
+      title = todo["fields"]["title"]
+
+      assert Enum.all?(title["filter_operators"], fn entry ->
+               is_map(entry) and is_binary(entry["name"]) and Map.has_key?(entry, "rhs")
+             end)
+
+      eq = Enum.find(title["filter_operators"], &(&1["name"] == "=="))
+      assert eq["rhs"] == "same"
+
+      is_nil_entry = Enum.find(title["filter_operators"], &(&1["name"] == "is_nil"))
+      assert is_nil_entry["rhs"] == %{"concrete" => "boolean"}
+
+      in_entry = Enum.find(title["filter_operators"], &(&1["name"] == "in"))
+      assert in_entry["rhs"] == %{"array" => "same"}
+    end
+
+    test "filter_custom_expressions is present on filterable fields", %{json: json} do
+      todo = Enum.find(json["resources"], &(&1["name"] == "Todo"))
+      title = todo["fields"]["title"]
+
+      assert is_list(title["filter_custom_expressions"])
+    end
+
+    test "non-filterable fields omit filter_operators and filter_functions", %{json: json} do
+      for resource <- json["resources"], {_name, field} <- resource["fields"] do
+        if field["filterable"] == false do
+          refute Map.has_key?(field, "filter_operators")
+          refute Map.has_key?(field, "filter_functions")
+          refute Map.has_key?(field, "filter_custom_expressions")
+        end
+      end
+    end
+  end
+
+  describe "to_map/1 relationship filterable/sortable booleans" do
+    setup do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, json: Ash.Info.Manifest.JsonSerializer.to_map(manifest)}
+    end
+
+    test "relationships carry filterable + sortable booleans and cardinality", %{json: json} do
+      for resource <- json["resources"], {_name, rel} <- resource["relationships"] do
+        assert is_boolean(rel["filterable"])
+        assert is_boolean(rel["sortable"])
+        assert rel["cardinality"] in ["one", "many"]
+      end
     end
   end
 end

--- a/test/ash/info/manifest/operator_resolver_test.exs
+++ b/test/ash/info/manifest/operator_resolver_test.exs
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.OperatorResolverTest do
+  use ExUnit.Case, async: false
+
+  alias Ash.Info.Manifest.Generator.{CapabilitiesBuilder, OperatorResolver}
+
+  alias Ash.Info.Manifest.{
+    ApplicableFunction,
+    ApplicableOperator,
+    FilterCapabilities,
+    Function,
+    Type
+  }
+
+  setup do
+    original = Application.get_env(:ash, :custom_expressions, [])
+
+    Application.put_env(:ash, :custom_expressions, [
+      Ash.Test.Expressions.JaroDistance
+    ])
+
+    on_exit(fn -> Application.put_env(:ash, :custom_expressions, original) end)
+
+    {filter_caps, _sort_caps} = CapabilitiesBuilder.build()
+    {:ok, caps: filter_caps}
+  end
+
+  defp op_names(applicable_ops), do: Enum.map(applicable_ops, & &1.name)
+  defp fn_names(applicable_fns), do: Enum.map(applicable_fns, & &1.name)
+
+  describe "resolve/2 returns structured records" do
+    test "operators are returned as %ApplicableOperator{name, rhs}", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {operators, _functions} = OperatorResolver.resolve(string_type, caps)
+
+      assert Enum.all?(operators, &match?(%ApplicableOperator{}, &1))
+    end
+
+    test "functions are returned as %ApplicableFunction{name, rhs}", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_operators, functions} = OperatorResolver.resolve(string_type, caps)
+
+      assert Enum.all?(functions, &match?(%ApplicableFunction{}, &1))
+    end
+  end
+
+  describe "resolve/2 — rhs computation" do
+    test ":== gets rhs :same on a string field", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {operators, _} = OperatorResolver.resolve(string_type, caps)
+      eq = Enum.find(operators, &(&1.name == :==))
+
+      assert eq.rhs == :same
+    end
+
+    test ":in gets rhs {:array, :same}", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {operators, _} = OperatorResolver.resolve(string_type, caps)
+      in_op = Enum.find(operators, &(&1.name == :in))
+
+      assert in_op.rhs == {:array, :same}
+    end
+
+    test ":is_nil gets rhs {:concrete, :boolean}", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {operators, _} = OperatorResolver.resolve(string_type, caps)
+      is_nil = Enum.find(operators, &(&1.name == :is_nil))
+
+      assert is_nil.rhs == {:concrete, :boolean}
+    end
+
+    test ":contains gets rhs concrete-string on a string field", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_operators, functions} = OperatorResolver.resolve(string_type, caps)
+      contains = Enum.find(functions, &(&1.name == :contains))
+
+      assert contains.rhs == {:concrete, :string}
+    end
+  end
+
+  describe "resolve/2 — applicability" do
+    test "a string field gets equality + membership operators and string predicate functions",
+         %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {operators, functions} = OperatorResolver.resolve(string_type, caps)
+
+      assert :== in op_names(operators)
+      assert :!= in op_names(operators)
+      assert :in in op_names(operators)
+      assert :is_nil in op_names(operators)
+      assert :contains in fn_names(functions)
+      assert :string_starts_with in fn_names(functions)
+      assert :string_ends_with in fn_names(functions)
+    end
+
+    test "an integer field gets ordered-comparison operators", %{caps: caps} do
+      integer_type = %Type{kind: :integer, name: "Integer"}
+
+      {operators, _functions} = OperatorResolver.resolve(integer_type, caps)
+      names = op_names(operators)
+
+      assert :== in names
+      assert :!= in names
+      assert :< in names
+      assert :<= in names
+      assert :> in names
+      assert :>= in names
+      assert :in in names
+      assert :is_nil in names
+    end
+
+    test "every resolved operator is in the catalog's predicate_operators", %{caps: caps} do
+      for kind <- [:string, :integer, :boolean, :date, :uuid] do
+        type = %Type{kind: kind, name: Atom.to_string(kind)}
+        {operators, _functions} = OperatorResolver.resolve(type, caps)
+
+        for %ApplicableOperator{name: op_name} <- operators do
+          assert op_name in caps.predicate_operators,
+                 "resolved operator #{inspect(op_name)} not in predicate_operators (kind: #{kind})"
+        end
+      end
+    end
+
+    test "every resolved function is in the catalog's predicate_functions", %{caps: caps} do
+      for kind <- [:string, :integer, :boolean, :date, :uuid] do
+        type = %Type{kind: kind, name: Atom.to_string(kind)}
+        {_operators, functions} = OperatorResolver.resolve(type, caps)
+
+        for %ApplicableFunction{name: fn_name} <- functions do
+          assert fn_name in caps.predicate_functions,
+                 "resolved function #{inspect(fn_name)} not in predicate_functions (kind: #{kind})"
+        end
+      end
+    end
+
+    test "a fully-unknown type returns empty lists rather than nil", %{caps: caps} do
+      unknown_type = %Type{kind: :unknown_kind_for_test, name: "Unknown"}
+
+      assert {operators, functions} = OperatorResolver.resolve(unknown_type, caps)
+      assert is_list(operators)
+      assert is_list(functions)
+    end
+
+    test "a NewType field picks up functions whose signatures target the subtype_of base",
+         %{caps: caps} do
+      newtype = %Type{
+        kind: :type_ref,
+        name: "EmailString",
+        module: Ash.Test.Manifest.Types.EmailString
+      }
+
+      {_operators, functions} = OperatorResolver.resolve(newtype, caps)
+      names = fn_names(functions)
+
+      assert :contains in names
+      assert :string_starts_with in names
+      assert :string_ends_with in names
+    end
+
+    test "an array-of-string field gets the :has predicate function", %{caps: caps} do
+      array_type = %Type{
+        kind: :array,
+        name: "Array",
+        item_type: %Type{kind: :string, name: "String"}
+      }
+
+      {_operators, functions} = OperatorResolver.resolve(array_type, caps)
+
+      assert :has in fn_names(functions)
+    end
+
+    test ":has on an array-of-string field gets rhs :same (the array element type)",
+         %{caps: caps} do
+      array_type = %Type{
+        kind: :array,
+        name: "Array",
+        item_type: %Type{kind: :string, name: "String"}
+      }
+
+      {_operators, functions} = OperatorResolver.resolve(array_type, caps)
+      has = Enum.find(functions, &(&1.name == :has))
+
+      assert has.rhs == :same
+    end
+
+    test "an array field drops the ordered comparison operators", %{caps: caps} do
+      array_type = %Type{
+        kind: :array,
+        name: "Array",
+        item_type: %Type{kind: :string, name: "String"}
+      }
+
+      {operators, _functions} = OperatorResolver.resolve(array_type, caps)
+      names = op_names(operators)
+
+      refute :< in names
+      refute :> in names
+      refute :<= in names
+      refute :>= in names
+
+      assert :== in names
+      assert :!= in names
+      assert :in in names
+      assert :is_nil in names
+    end
+
+    test "a non-array field still gets the ordered comparison operators", %{caps: caps} do
+      integer_type = %Type{kind: :integer, name: "Integer"}
+
+      {operators, _functions} = OperatorResolver.resolve(integer_type, caps)
+      names = op_names(operators)
+
+      assert :< in names
+      assert :> in names
+      assert :<= in names
+      assert :>= in names
+    end
+
+    test "a boolean field drops the ordered comparison operators", %{caps: caps} do
+      boolean_type = %Type{kind: :boolean, name: "Boolean"}
+
+      {operators, _functions} = OperatorResolver.resolve(boolean_type, caps)
+      names = op_names(operators)
+
+      refute :< in names
+      refute :> in names
+      refute :<= in names
+      refute :>= in names
+
+      assert :== in names
+      assert :!= in names
+      assert :in in names
+      assert :is_nil in names
+    end
+  end
+
+  describe "resolve/3 with data layer scoping" do
+    setup do
+      {filter_caps, _sort_caps} =
+        CapabilitiesBuilder.build(data_layer_modules: [Ash.Test.Manifest.FakeDataLayer])
+
+      {:ok, caps: filter_caps}
+    end
+
+    test "a string field whose resource uses the data layer sees that data layer's functions",
+         %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_operators, functions} =
+        OperatorResolver.resolve(string_type, caps, Ash.Test.Manifest.FakeDataLayer)
+
+      assert :fake_ilike in fn_names(functions)
+    end
+
+    test "a string field whose resource uses a different data layer does NOT see foreign functions",
+         %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_operators, functions} =
+        OperatorResolver.resolve(string_type, caps, SomeOtherDataLayer)
+
+      refute :fake_ilike in fn_names(functions)
+    end
+
+    test "a string field with no data layer (nil) only sees builtin functions", %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_operators, functions} = OperatorResolver.resolve(string_type, caps, nil)
+
+      refute :fake_ilike in fn_names(functions)
+      assert :contains in fn_names(functions)
+    end
+
+    test "a function tagged with a data layer is still returned when its data layer is passed",
+         %{caps: caps} do
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_, functions} =
+        OperatorResolver.resolve(string_type, caps, Ash.Test.Manifest.FakeDataLayer)
+
+      assert :contains in fn_names(functions)
+    end
+
+    test "resolve/2 (no data layer) hides data-layer-tagged functions" do
+      caps = %FilterCapabilities{
+        operators: [],
+        functions: [
+          %Function{
+            name: :fake_ilike,
+            module: Ash.Test.Manifest.FakeDataLayerFunction,
+            predicate?: true,
+            signatures: [],
+            returns: :unknown,
+            data_layer_module: Ash.Test.Manifest.FakeDataLayer
+          }
+        ],
+        custom_expressions: [],
+        boolean_connectives: [:and, :or, :not],
+        predicate_operators: [],
+        predicate_functions: [:fake_ilike],
+        predicate_custom_expressions: []
+      }
+
+      string_type = %Type{kind: :string, name: "String"}
+
+      {_operators, functions} = OperatorResolver.resolve(string_type, caps)
+
+      refute :fake_ilike in fn_names(functions)
+    end
+  end
+end

--- a/test/ash/info/manifest/resource_builder_test.exs
+++ b/test/ash/info/manifest/resource_builder_test.exs
@@ -84,6 +84,27 @@ defmodule Ash.Test.Info.Manifest.Generator.ResourceBuilderTest do
       assert comment_count.aggregate_kind == :count
     end
 
+    test "aggregate allow_nil? reflects result nullability, not include_nil?" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      # :count, :exists, :list aggregates never return nil
+      assert resource.fields[:comment_count].allow_nil? == false
+      assert resource.fields[:helpful_comment_count].allow_nil? == false
+      assert resource.fields[:has_comments].allow_nil? == false
+      assert resource.fields[:comment_authors].allow_nil? == false
+      assert resource.fields[:recent_comment_ids].allow_nil? == false
+      assert resource.fields[:weighted_scores].allow_nil? == false
+
+      # :first, :max, :avg, :sum aggregates can return nil on empty relationship
+      assert resource.fields[:latest_comment_content].allow_nil? == true
+      assert resource.fields[:highest_rating].allow_nil? == true
+      assert resource.fields[:average_rating].allow_nil? == true
+      assert resource.fields[:latest_comment_id].allow_nil? == true
+      assert resource.fields[:total_weighted_score].allow_nil? == true
+      assert resource.fields[:first_weighted_score].allow_nil? == true
+      assert resource.fields[:max_weighted_score].allow_nil? == true
+    end
+
     test "includes relationships" do
       assert Map.has_key?(ResourceBuilder.build(Ash.Test.Manifest.Todo).relationships, :user)
       assert Map.has_key?(ResourceBuilder.build(Ash.Test.Manifest.Todo).relationships, :comments)
@@ -115,6 +136,110 @@ defmodule Ash.Test.Info.Manifest.Generator.ResourceBuilderTest do
       if resource.multitenancy do
         assert is_atom(resource.multitenancy.strategy)
       end
+    end
+  end
+
+  describe "build/3 with filter capabilities — per-field operator resolution" do
+    alias Ash.Info.Manifest.Generator.CapabilitiesBuilder
+
+    setup do
+      {filter_caps, _} = CapabilitiesBuilder.build()
+
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo, [], filter_caps)
+      {:ok, resource: resource}
+    end
+
+    test "filterable attribute fields carry filter_operators and filter_functions lists",
+         %{resource: resource} do
+      title = resource.fields[:title]
+      assert is_list(title.filter_operators)
+      assert is_list(title.filter_functions)
+      assert Enum.any?(title.filter_operators, &(&1.name == :==))
+    end
+
+    test "non-filterable fields carry nil filter_operators / filter_functions",
+         %{resource: resource} do
+      Enum.each(resource.fields, fn {_name, field} ->
+        if field.filterable? == false do
+          assert field.filter_operators == nil
+          assert field.filter_functions == nil
+          assert field.filter_custom_expressions == nil
+        end
+      end)
+    end
+
+    test "filterable fields carry a list of filter_custom_expressions",
+         %{resource: resource} do
+      title = resource.fields[:title]
+      assert is_list(title.filter_custom_expressions)
+    end
+
+    test "calculation fields get operator lists from their declared type",
+         %{resource: resource} do
+      # is_overdue is :boolean — gets eq/neq/in/is_nil
+      is_overdue = resource.fields[:is_overdue]
+
+      if is_overdue && is_overdue.filterable? do
+        names = Enum.map(is_overdue.filter_operators, & &1.name)
+        assert :== in names
+        assert :is_nil in names
+      end
+    end
+
+    test "aggregate fields get operator lists from their resolved type",
+         %{resource: resource} do
+      aggregates = resource.fields |> Map.values() |> Enum.filter(&(&1.kind == :aggregate))
+
+      Enum.each(aggregates, fn agg ->
+        if agg.filterable? do
+          assert is_list(agg.filter_operators)
+        end
+      end)
+    end
+
+    test "filter_operators entries are %ApplicableOperator{} records with name + rhs",
+         %{resource: resource} do
+      title = resource.fields[:title]
+
+      alias Ash.Info.Manifest.ApplicableOperator
+      assert Enum.all?(title.filter_operators, &match?(%ApplicableOperator{}, &1))
+
+      eq = Enum.find(title.filter_operators, &(&1.name == :==))
+      assert eq.rhs == :same
+
+      in_op = Enum.find(title.filter_operators, &(&1.name == :in))
+      assert in_op.rhs == {:array, :same}
+    end
+  end
+
+  describe "build/2 with no capabilities passed (backwards compat)" do
+    test "filter_operators and filter_functions remain nil" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo, [])
+      title = resource.fields[:title]
+      assert title.filter_operators == nil
+      assert title.filter_functions == nil
+      assert title.filter_custom_expressions == nil
+    end
+  end
+
+  describe "build/2 relationship filterable?/sortable? carry source flags" do
+    test "relationships default to filterable? and sortable? true" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      user = resource.relationships[:user]
+      assert user.filterable? == true
+      assert user.sortable? == true
+
+      comments = resource.relationships[:comments]
+      assert comments.filterable? == true
+      assert comments.sortable? == true
+    end
+
+    test "cardinality is exposed so consumers can derive filter/sort shape" do
+      resource = ResourceBuilder.build(Ash.Test.Manifest.Todo)
+
+      assert resource.relationships[:user].cardinality == :one
+      assert resource.relationships[:comments].cardinality == :many
     end
   end
 end

--- a/test/ash/info/manifest/result_nullability_test.exs
+++ b/test/ash/info/manifest/result_nullability_test.exs
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.Manifest.Generator.ResultNullabilityTest do
+  use ExUnit.Case, async: true
+
+  alias Ash.Info.Manifest.Generator.ResultNullability
+
+  describe "for_aggregate/1" do
+    test ":count always returns 0 minimum — not nullable" do
+      assert ResultNullability.for_aggregate(%{kind: :count}) == false
+    end
+
+    test ":exists returns boolean — not nullable" do
+      assert ResultNullability.for_aggregate(%{kind: :exists}) == false
+    end
+
+    test ":list returns [] on empty — not nullable" do
+      assert ResultNullability.for_aggregate(%{kind: :list}) == false
+    end
+
+    test ":first is nil on empty relationship" do
+      assert ResultNullability.for_aggregate(%{kind: :first}) == true
+    end
+
+    test ":max is nil on empty relationship" do
+      assert ResultNullability.for_aggregate(%{kind: :max}) == true
+    end
+
+    test ":min is nil on empty relationship" do
+      assert ResultNullability.for_aggregate(%{kind: :min}) == true
+    end
+
+    test ":sum is nil on empty relationship" do
+      assert ResultNullability.for_aggregate(%{kind: :sum}) == true
+    end
+
+    test ":avg is nil on empty relationship" do
+      assert ResultNullability.for_aggregate(%{kind: :avg}) == true
+    end
+
+    test ":custom preserves explicit allow_nil? when set" do
+      assert ResultNullability.for_aggregate(%{kind: :custom, allow_nil?: false}) == false
+      assert ResultNullability.for_aggregate(%{kind: :custom, allow_nil?: true}) == true
+    end
+
+    test ":custom defaults to true when allow_nil? not present" do
+      assert ResultNullability.for_aggregate(%{kind: :custom}) == true
+    end
+  end
+end

--- a/test/ash/info/manifest_test.exs
+++ b/test/ash/info/manifest_test.exs
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Info.ManifestTest do
+  use ExUnit.Case, async: true
+
+  describe "filter/sort capabilities accessors" do
+    setup do
+      manifest = %Ash.Info.Manifest{
+        filter_capabilities: %Ash.Info.Manifest.FilterCapabilities{
+          operators: [
+            %Ash.Info.Manifest.Operator{name: :==, module: Ash.Query.Operator.Eq},
+            %Ash.Info.Manifest.Operator{name: :!=, module: Ash.Query.Operator.NotEq}
+          ],
+          functions: [
+            %Ash.Info.Manifest.Function{name: :contains, module: Ash.Query.Function.Contains}
+          ],
+          custom_expressions: [
+            %Ash.Info.Manifest.CustomExpression{
+              name: :jaro,
+              module: Ash.Test.Expressions.JaroDistance
+            }
+          ]
+        },
+        sort_capabilities: %Ash.Info.Manifest.SortCapabilities{}
+      }
+
+      {:ok, manifest: manifest}
+    end
+
+    test "operator_lookup/1 returns a name → operator map", %{manifest: manifest} do
+      lookup = Ash.Info.Manifest.operator_lookup(manifest)
+      assert %Ash.Info.Manifest.Operator{name: :==} = lookup[:==]
+      assert %Ash.Info.Manifest.Operator{name: :!=} = lookup[:!=]
+    end
+
+    test "function_lookup/1 returns a name → function map", %{manifest: manifest} do
+      lookup = Ash.Info.Manifest.function_lookup(manifest)
+      assert %Ash.Info.Manifest.Function{name: :contains} = lookup[:contains]
+    end
+
+    test "custom_expression_lookup/1 returns a name → custom_expression map", %{
+      manifest: manifest
+    } do
+      lookup = Ash.Info.Manifest.custom_expression_lookup(manifest)
+      assert %Ash.Info.Manifest.CustomExpression{name: :jaro} = lookup[:jaro]
+    end
+
+    test "lookups handle a nil filter_capabilities" do
+      empty = %Ash.Info.Manifest{}
+      assert Ash.Info.Manifest.operator_lookup(empty) == %{}
+      assert Ash.Info.Manifest.function_lookup(empty) == %{}
+      assert Ash.Info.Manifest.custom_expression_lookup(empty) == %{}
+    end
+  end
+
+  describe "applicable_filter_* per-field lookups" do
+    setup do
+      {:ok, manifest} = Ash.Info.Manifest.generate(otp_app: :ash_manifest_test)
+      {:ok, manifest: manifest}
+    end
+
+    test "applicable_filter_operators/2 returns the field's resolved %ApplicableOperator{} list",
+         %{manifest: manifest} do
+      ops =
+        Ash.Info.Manifest.applicable_filter_operators(manifest, {Ash.Test.Manifest.Todo, :title})
+
+      assert is_list(ops)
+      assert Enum.any?(ops, &(&1.name == :==))
+      assert Enum.all?(ops, &match?(%Ash.Info.Manifest.ApplicableOperator{}, &1))
+    end
+
+    test "applicable_filter_functions/2 returns the field's resolved %ApplicableFunction{} list",
+         %{manifest: manifest} do
+      fns =
+        Ash.Info.Manifest.applicable_filter_functions(manifest, {Ash.Test.Manifest.Todo, :title})
+
+      assert is_list(fns)
+      assert Enum.all?(fns, &match?(%Ash.Info.Manifest.ApplicableFunction{}, &1))
+    end
+
+    test "applicable_filter_custom_expressions/2 returns the field's resolved list",
+         %{manifest: manifest} do
+      ces =
+        Ash.Info.Manifest.applicable_filter_custom_expressions(
+          manifest,
+          {Ash.Test.Manifest.Todo, :title}
+        )
+
+      assert is_list(ces)
+    end
+
+    test "lookups raise on unknown resource", %{manifest: manifest} do
+      assert_raise RuntimeError, ~r/not found in manifest/, fn ->
+        Ash.Info.Manifest.applicable_filter_operators(manifest, {NoSuchResource, :title})
+      end
+    end
+
+    test "lookups raise on unknown field", %{manifest: manifest} do
+      assert_raise RuntimeError, ~r/not found on resource/, fn ->
+        Ash.Info.Manifest.applicable_filter_operators(
+          manifest,
+          {Ash.Test.Manifest.Todo, :no_such_field}
+        )
+      end
+    end
+  end
+end

--- a/test/support/manifest/fake_data_layer.ex
+++ b/test/support/manifest/fake_data_layer.ex
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.FakeDataLayer do
+  @moduledoc """
+  A minimal data layer used only by `CapabilitiesBuilder` tests to verify
+  that data-layer functions are collected into the manifest's filter catalog.
+
+  It only implements `functions/1`; manifest generation never invokes the
+  rest of the data-layer behaviour, so the rest is intentionally omitted.
+  """
+
+  @spec functions(Ash.Resource.t()) :: [module()]
+  def functions(_resource), do: [Ash.Test.Manifest.FakeDataLayerFunction]
+end

--- a/test/support/manifest/fake_data_layer_function.ex
+++ b/test/support/manifest/fake_data_layer_function.ex
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.FakeDataLayerFunction do
+  @moduledoc """
+  A fake Ash query function that pretends to be supplied by a data layer.
+  Used by manifest tests to verify that data-layer-sourced functions are
+  collected into `filter_capabilities.functions` and tagged with their
+  `data_layer_module`.
+
+  Mirrors `Ash.Query.Function.Contains`'s shape — single-string LHS, predicate.
+  """
+  use Ash.Query.Function, name: :fake_ilike, predicate?: true
+
+  def args, do: [[:string, :string]]
+
+  def returns, do: [:boolean]
+
+  def evaluate(%{arguments: [nil, _]}), do: {:known, nil}
+  def evaluate(%{arguments: [_, nil]}), do: {:known, nil}
+
+  def evaluate(%{arguments: [left, right]}) when is_binary(left) and is_binary(right) do
+    {:known, String.contains?(String.downcase(left), String.downcase(right))}
+  end
+
+  def evaluate(_), do: :unknown
+end

--- a/test/support/manifest/types/email_string.ex
+++ b/test/support/manifest/types/email_string.ex
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Manifest.Types.EmailString do
+  @moduledoc """
+  A NewType wrapping `:string`, used by manifest tests to verify operator
+  resolution falls through to the underlying base type.
+  """
+  use Ash.Type.NewType, subtype_of: :string
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
+# Manifest tests use the dedicated otp_app `:ash_manifest_test` so the
+# generator only walks the manifest test domain. Set via `put_env/3`
+# (rather than `config :ash_manifest_test, ...` in config/config.exs) to
+# avoid Elixir's "application not available" warning for a fake otp_app.
+Application.put_env(:ash_manifest_test, :ash_domains, [Ash.Test.Manifest.Domain])
+
 # We compile modules with the same name often while testing the DSL
 Mimic.copy(Ash.Reactor.Notifications)
 Mimic.copy(Ash.DataLayer)


### PR DESCRIPTION
# Summary

Extends `Ash.Info.Manifest` with the filter/sort vocabulary needed by code-gen consumers (e.g. ash_graphql, ash_typescript) so they no longer have to re-derive it from raw Ash internals.

**Top-level catalog** (`%FilterCapabilities{}`, `%SortCapabilities{}`):
- Every builtin operator, function, custom expression, and data-layer-contributed function, each with normalized argument signatures and predicate flag
- Sort directions

**Per-field resolution** on every `%Field{}`:
- `filter_operators`, `filter_functions`, `filter_custom_expressions` — lists of `%Applicable*{}` records pairing each applicable name with its resolved rhs type (`:same`, `:any`, `{:concrete, t}`, `{:array, t}`)
- NewType subtype fallthrough; ordered-comparison operators (`<`, `>`, `<=`, `>=`) trimmed for arrays and booleans

**Per-relationship**: `filterable?`/`sortable?` booleans replaced with `filterable_via` (`:traversal` | `:exists` | `false`) and `sortable_via` (`:traversal` | `false`) tagged atoms reflecting cardinality — one-cardinality relationships can be dot-traversed, many-cardinality need an existential quantifier. Fields keep their booleans (no cardinality distinction applies).

**Aggregate fix**: `%Field{kind: :aggregate}.allow_nil?` now derives from aggregate kind (`:count`/`:exists`/`:list` → false; `:first`/`:max`/`:min`/`:sum`/`:avg` → true) instead of the unrelated `:include_nil?` input flag.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Features include unit/acceptance tests

