### PR TITLE
fix(manifest): pass real resource to data_layer.functions/1

### DIFF
--- a/lib/ash/info/manifest/generator.ex
+++ b/lib/ash/info/manifest/generator.ex
@@ -111,10 +111,10 @@ defmodule Ash.Info.Manifest.Generator do
     reachable_resources = Enum.uniq(reachable_resources ++ always_resources)
     standalone_types = Enum.uniq(standalone_types ++ always_types)
 
-    data_layer_modules = collect_data_layer_modules(reachable_resources)
+    resources_by_data_layer = collect_resources_by_data_layer(reachable_resources)
 
     {filter_capabilities, sort_capabilities} =
-      CapabilitiesBuilder.build(data_layer_modules: data_layer_modules)
+      CapabilitiesBuilder.build(resources_by_data_layer: resources_by_data_layer)
 
     # Build resource specs (no actions — those live in entrypoints)
     resources =
@@ -157,14 +157,14 @@ defmodule Ash.Info.Manifest.Generator do
      }}
   end
 
-  # Distinct data-layer modules across reachable resources, in a stable order
-  # (sorted by module split). `nil` data layers are filtered out.
-  defp collect_data_layer_modules(resources) do
+  # Groups reachable resources by their data layer, dropping resources whose
+  # `Ash.DataLayer.data_layer/1` returns `nil`. The resulting map is what
+  # `CapabilitiesBuilder` needs to pass a real (non-nil) resource into each
+  # data layer's `functions/1` callback.
+  defp collect_resources_by_data_layer(resources) do
     resources
-    |> Enum.map(&Ash.DataLayer.data_layer/1)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-    |> Enum.sort_by(&Module.split/1)
+    |> Enum.group_by(&Ash.DataLayer.data_layer/1)
+    |> Map.delete(nil)
   end
 
   # Normalizes action_filter entries into {resource, action_name, config} triples.

--- a/lib/ash/info/manifest/generator/capabilities_builder.ex
+++ b/lib/ash/info/manifest/generator/capabilities_builder.ex
@@ -24,26 +24,26 @@ defmodule Ash.Info.Manifest.Generator.CapabilitiesBuilder do
 
   ## Options
 
-    * `:data_layer_modules` - List of data-layer modules whose `functions/1`
-      callback contributes additional predicate functions to the catalog. Each
-      contributed `%Function{}` is tagged with `data_layer_module` so consumers
-      can intersect against a resource's data layer.
+    * `:resources_by_data_layer` - Map of `%{data_layer_module => [resources]}`
+      whose `functions/1` callback contributes additional predicate functions
+      to the catalog. The first resource per data layer is used as the
+      representative when invoking `functions/1` — required because some
+      data-layer implementations (e.g. `AshPostgres.DataLayer`) read
+      configuration off the resource and crash with `nil`. Each contributed
+      `%Function{}` is tagged with `data_layer_module` so consumers can
+      intersect against a resource's data layer.
 
-  Without `:data_layer_modules`, the catalog is the Ash builtins plus the
-  app's registered custom expressions — identical to the previous `build/0`
-  behavior.
+  Without `:resources_by_data_layer`, the catalog is the Ash builtins plus
+  the app's registered custom expressions.
   """
   @spec build(keyword()) :: {FilterCapabilities.t(), SortCapabilities.t()}
   def build(opts \\ []) do
-    data_layer_modules =
-      opts
-      |> Keyword.get(:data_layer_modules, [])
-      |> Enum.uniq()
+    resources_by_data_layer = Keyword.get(opts, :resources_by_data_layer, %{})
 
     operators = Enum.map(Ash.Filter.builtin_operators(), &build_operator/1)
 
     builtin_functions = Enum.map(Ash.Filter.builtin_functions(), &build_function(&1, nil))
-    data_layer_functions = collect_data_layer_functions(data_layer_modules)
+    data_layer_functions = collect_data_layer_functions(resources_by_data_layer)
     functions = builtin_functions ++ data_layer_functions
 
     custom_expressions =
@@ -65,35 +65,52 @@ defmodule Ash.Info.Manifest.Generator.CapabilitiesBuilder do
   end
 
   # Each data-layer module contributes its `functions/1` modules, deduplicated
-  # by function module across data layers. Tag with the *first* data layer that
-  # claimed it. Modules that don't export `functions/1` contribute nothing.
-  defp collect_data_layer_functions(data_layer_modules) do
-    Enum.flat_map(data_layer_modules, fn dl_module ->
-      Code.ensure_loaded(dl_module)
+  # by function module across data layers. Tag each with the *first* data
+  # layer that claims it. Data layers that don't export `functions/1`, that
+  # have no representative resource, or whose `functions/1` raises contribute
+  # nothing — the rescue here protects the manifest build from a misbehaving
+  # data-layer implementation (e.g. one that assumes a non-nil resource).
+  defp collect_data_layer_functions(resources_by_data_layer) do
+    function_modules_by_data_layer =
+      Map.new(resources_by_data_layer, fn {dl_module, resources} ->
+        {dl_module, list_functions_safely(dl_module, resources)}
+      end)
 
-      if function_exported?(dl_module, :functions, 1) do
-        # The functions/1 callback is per-resource in the Ash data-layer API,
-        # but at this catalog level we just need the set of contributed
-        # modules. Passing nil works for data layers whose `functions/1` is
-        # resource-independent (Postgres ilike/trigram, the test fake).
-        apply(dl_module, :functions, [nil])
-      else
-        []
-      end
-    end)
+    function_modules_by_data_layer
+    |> Map.values()
+    |> List.flatten()
     |> Enum.uniq()
     |> Enum.map(fn module ->
-      data_layer_module = first_data_layer_owning(module, data_layer_modules)
+      data_layer_module = first_data_layer_owning(module, function_modules_by_data_layer)
       build_function(module, data_layer_module)
     end)
   end
 
-  defp first_data_layer_owning(function_module, data_layer_modules) do
-    Enum.find(data_layer_modules, fn dl ->
-      Code.ensure_loaded(dl)
+  defp list_functions_safely(dl_module, resources) do
+    Code.ensure_loaded(dl_module)
 
-      function_exported?(dl, :functions, 1) and
-        function_module in apply(dl, :functions, [nil])
+    with true <- function_exported?(dl_module, :functions, 1),
+         representative when not is_nil(representative) <- List.first(resources) do
+      apply(dl_module, :functions, [representative])
+    else
+      _ -> []
+    end
+  rescue
+    error ->
+      require Logger
+
+      Logger.warning(
+        "#{inspect(dl_module)}.functions/1 raised during manifest capability " <>
+          "building (#{Exception.message(error)}); its predicate functions will " <>
+          "not be included in the manifest catalog."
+      )
+
+      []
+  end
+
+  defp first_data_layer_owning(function_module, function_modules_by_data_layer) do
+    Enum.find_value(function_modules_by_data_layer, fn {dl, modules} ->
+      if function_module in modules, do: dl
     end)
   end
 

--- a/test/ash/info/manifest/capabilities_builder_test.exs
+++ b/test/ash/info/manifest/capabilities_builder_test.exs
@@ -184,9 +184,14 @@ defmodule Ash.Test.Info.Manifest.Generator.CapabilitiesBuilderTest do
   end
 
   describe "build/1 with data layer functions" do
+    # FakeDataLayer ignores its resource arg, so any module works as the
+    # representative — but the API still requires a real resource because
+    # other data layers (e.g. AshPostgres) crash on nil.
+    @fake_dl_resources %{Ash.Test.Manifest.FakeDataLayer => [Ash.Test.Manifest.Todo]}
+
     test "collects functions from each data layer and tags them with data_layer_module" do
       {filter_caps, _} =
-        CapabilitiesBuilder.build(data_layer_modules: [Ash.Test.Manifest.FakeDataLayer])
+        CapabilitiesBuilder.build(resources_by_data_layer: @fake_dl_resources)
 
       fake =
         Enum.find(
@@ -202,7 +207,7 @@ defmodule Ash.Test.Info.Manifest.Generator.CapabilitiesBuilderTest do
 
     test "predicate_functions includes data-layer-sourced predicates" do
       {filter_caps, _} =
-        CapabilitiesBuilder.build(data_layer_modules: [Ash.Test.Manifest.FakeDataLayer])
+        CapabilitiesBuilder.build(resources_by_data_layer: @fake_dl_resources)
 
       assert :fake_ilike in filter_caps.predicate_functions
     end
@@ -216,19 +221,37 @@ defmodule Ash.Test.Info.Manifest.Generator.CapabilitiesBuilderTest do
       assert contains.data_layer_module == nil
     end
 
-    test "deduplicates a function module if multiple data layers list it" do
+    test "deduplicates a function module across resources of the same data layer" do
       {filter_caps, _} =
         CapabilitiesBuilder.build(
-          data_layer_modules: [
-            Ash.Test.Manifest.FakeDataLayer,
-            Ash.Test.Manifest.FakeDataLayer
-          ]
+          resources_by_data_layer: %{
+            Ash.Test.Manifest.FakeDataLayer => [
+              Ash.Test.Manifest.Todo,
+              Ash.Test.Manifest.User
+            ]
+          }
         )
 
       hits =
         Enum.count(filter_caps.functions, &(&1.module == Ash.Test.Manifest.FakeDataLayerFunction))
 
       assert hits == 1
+    end
+
+    test "data layers whose functions/1 raises are skipped (manifest build survives)" do
+      defmodule CrashingDataLayer do
+        def functions(_resource), do: raise("boom")
+      end
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {%Ash.Info.Manifest.FilterCapabilities{}, _} =
+                   CapabilitiesBuilder.build(
+                     resources_by_data_layer: %{CrashingDataLayer => [Ash.Test.Manifest.Todo]}
+                   )
+        end)
+
+      assert log =~ "CrashingDataLayer.functions/1 raised"
     end
   end
 end

--- a/test/ash/info/manifest/operator_resolver_test.exs
+++ b/test/ash/info/manifest/operator_resolver_test.exs
@@ -247,7 +247,11 @@ defmodule Ash.Test.Info.Manifest.Generator.OperatorResolverTest do
   describe "resolve/3 with data layer scoping" do
     setup do
       {filter_caps, _sort_caps} =
-        CapabilitiesBuilder.build(data_layer_modules: [Ash.Test.Manifest.FakeDataLayer])
+        CapabilitiesBuilder.build(
+          resources_by_data_layer: %{
+            Ash.Test.Manifest.FakeDataLayer => [Ash.Test.Manifest.Todo]
+          }
+        )
 
       {:ok, caps: filter_caps}
     end


### PR DESCRIPTION
Previously called functions(nil), which crashed for data layers like AshPostgres that read repo config off the resource. Now passes a representative resource per data layer; misbehavior is rescued + logged.
