### PR TITLE
Allow can to not log policy breakdown

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -979,6 +979,11 @@ defmodule Ash do
       type: :boolean,
       default: false,
       doc: "Whether or not to log the authorization result."
+    ],
+    log_policy_breakdown?: [
+      type: :boolean,
+      doc:
+        "If set to `false`, suppresses policy breakdown logs, overriding the global `show_policy_breakdowns?` configuration."
     ]
   ]
 

--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -226,7 +226,10 @@ defmodule Ash.Can do
             subject
         end
         |> Ash.Subject.set_context(%{
-          private: %{authorizer_log?: opts[:log?] || false}
+          private: %{
+            authorizer_log?: opts[:log?] || false,
+            log_policy_breakdown?: opts[:log_policy_breakdown?]
+          }
         })
 
       case Ash.Domain.Info.resource(domain, resource) do

--- a/lib/ash/error/forbidden/policy.ex
+++ b/lib/ash/error/forbidden/policy.ex
@@ -35,15 +35,25 @@ defmodule Ash.Error.Forbidden.Policy do
     exception =
       super(Keyword.put(opts, :policy_breakdown?, Ash.Policy.Info.show_policy_breakdowns?()))
 
-    log_level =
-      if exception.for_fields do
-        Ash.Policy.Info.log_successful_policy_breakdowns()
-      else
-        Ash.Policy.Info.log_policy_breakdowns()
-      end
+    private_context = get_in(opts, [:subject, Access.key(:context), :private])
+
+    log_policy_breakdown? = private_context[:log_policy_breakdown?]
 
     log_level =
-      log_level || (opts[:subject] && opts[:subject].context[:private][:authorizer_log?] && :info)
+      if log_policy_breakdown? == false do
+        nil
+      else
+        log_level =
+          if exception.for_fields do
+            Ash.Policy.Info.log_successful_policy_breakdowns()
+          else
+            Ash.Policy.Info.log_policy_breakdowns()
+          end
+
+        log_level
+        |> Kernel.||(log_policy_breakdown? == true && :info)
+        |> Kernel.||(private_context[:authorizer_log?] && :info)
+      end
 
     if log_level do
       Logger.log(log_level, report(exception, help_text?: false))

--- a/test/policy/simple_test.exs
+++ b/test/policy/simple_test.exs
@@ -1171,6 +1171,42 @@ defmodule Ash.Test.Policy.SimpleTest do
     end
   end
 
+  describe "Ash.can? log_policy_breakdown? option" do
+    setup do
+      old_policies = Application.get_env(:ash, :policies, [])
+
+      policies = Keyword.put(old_policies, :log_policy_breakdowns, :error)
+      Application.put_env(:ash, :policies, policies)
+
+      on_exit(fn -> Application.put_env(:ash, :policies, old_policies) end)
+
+      actor = %{role: :viewer, has_read_permission: true}
+
+      actor
+    end
+
+    test "Ash.can? logs policy breakdown at global config level by default", actor do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          refute Ash.can?({ResourceWithForbidUnlessAndAuthorizeIf, :read}, actor)
+        end)
+
+      assert log =~ "Policy Breakdown"
+    end
+
+    test "Ash.can? suppresses policy breakdown log when set to false, overriding global config",
+         actor do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          refute Ash.can?({ResourceWithForbidUnlessAndAuthorizeIf, :read}, actor,
+                   log_policy_breakdown?: false
+                 )
+        end)
+
+      assert log == ""
+    end
+  end
+
   describe "check init/1 callback" do
     test "init/1 is called and normalizes opts during compilation" do
       # CheckWithInit sets :initialized to true when :required_option is provided.


### PR DESCRIPTION
This PR basically add a `log_policy_breakdown?` option to `Ash.can?` so users can call it as authorization barriers (I use in LV to enable/disable parts of the UI based on what the user can/cannot do) without flooding the terminal with policies breakdowns

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
