### PR TITLE
perf: avoid related-record read in relate_actor for belongs_to

### DIFF
--- a/lib/ash/resource/change/relate_actor.ex
+++ b/lib/ash/resource/change/relate_actor.ex
@@ -70,7 +70,7 @@ defmodule Ash.Resource.Change.RelateActor do
         )
 
       actor when relationship.type == :belongs_to ->
-        Changeset.change_attribute(
+        Changeset.force_change_attribute(
           changeset,
           relationship.source_attribute,
           Map.get(actor, relationship.destination_attribute)

--- a/lib/ash/resource/change/relate_actor.ex
+++ b/lib/ash/resource/change/relate_actor.ex
@@ -69,6 +69,16 @@ defmodule Ash.Resource.Change.RelateActor do
           )
         )
 
+      actor when relationship.type == :belongs_to ->
+        Changeset.change_attribute(
+          changeset,
+          relationship.source_attribute,
+          Map.get(actor, relationship.destination_attribute)
+        )
+        |> Changeset.after_action(fn _changeset, record ->
+          {:ok, Map.put(record, relationship.name, actor)}
+        end)
+
       actor ->
         Changeset.manage_relationship(
           changeset,


### PR DESCRIPTION
`RelateActor.change/3` calls `manage_relationship/4` on every write, which for some reason selects the actor from the data layer everytime and so we get too many (usually unnecessary) select queries on our users table. 

For `belongs_to` we can set the FK and attach the actor as the loaded relationship without the read. `atomic/3` already does this for `belongs_to`, so probably the non-atomic path can match.

**Note:** after this patch, actor relationship doesn't get into `changeset.relationships` anymore. Code that uses `changeset.relationships[name]` and expects `relate_actor` to set it won't see it anymore. 

The atomic path was already in that state, so this makes the two paths consistent, but I'm not sure .. maybe we make this opt in by a config? or add another option to relate_actor .. like maybe `relate_actor(:created_by, attribute_only?: true)`

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
