### PR TITLE
fix: auto-detect argument vs attribute in validation 

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -7791,19 +7791,24 @@ defmodule Ash.Changeset do
   defp keyword_to_validation_change_error(changeset, keyword) do
     error =
       if keyword[:field] do
-        exception =
-          if has_argument?(changeset.action, keyword[:field]) do
-            InvalidArgument
-          else
-            InvalidAttribute
-          end
+        field = keyword[:field]
 
-        exception.exception(
-          field: keyword[:field],
+        opts = [
           message: keyword[:message],
           value: keyword[:value],
           vars: keyword
-        )
+        ]
+
+        cond do
+          has_argument?(changeset.action, field) ->
+            InvalidArgument.exception(Keyword.put(opts, :field, field))
+
+          Ash.Resource.Info.attribute(changeset.resource, field) ->
+            InvalidAttribute.exception(Keyword.put(opts, :field, field))
+
+          true ->
+            InvalidChanges.exception(Keyword.put(opts, :fields, [field]))
+        end
       else
         InvalidChanges.exception(
           fields: keyword[:fields] || [],

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -4368,15 +4368,20 @@ defmodule Ash.Changeset do
                   end
 
                 {:error, errors} when is_list(errors) ->
-                  if validation.message do
-                    errors =
-                      Enum.map(errors, fn error ->
-                        Ash.Error.override_validation_message(error, validation.message)
-                      end)
+                  cond do
+                    validation.message ->
+                      errors =
+                        Enum.map(errors, fn error ->
+                          Ash.Error.override_validation_message(error, validation.message)
+                        end)
 
-                    add_error(changeset, errors)
-                  else
-                    add_error(changeset, errors)
+                      add_error(changeset, errors)
+
+                    Keyword.keyword?(errors) ->
+                      add_error(changeset, keyword_to_validation_change_error(changeset, errors))
+
+                    true ->
+                      add_error(changeset, errors)
                   end
 
                 {:error, error} ->
@@ -7762,6 +7767,38 @@ defmodule Ash.Changeset do
     error =
       if keyword[:field] do
         InvalidAttribute.exception(
+          field: keyword[:field],
+          message: keyword[:message],
+          value: keyword[:value],
+          vars: keyword
+        )
+      else
+        InvalidChanges.exception(
+          fields: keyword[:fields] || [],
+          message: keyword[:message],
+          value: keyword[:value],
+          vars: keyword
+        )
+      end
+
+    if keyword[:path] do
+      Ash.Error.set_path(error, keyword[:path])
+    else
+      error
+    end
+  end
+
+  defp keyword_to_validation_change_error(changeset, keyword) do
+    error =
+      if keyword[:field] do
+        exception =
+          if has_argument?(changeset.action, keyword[:field]) do
+            InvalidArgument
+          else
+            InvalidAttribute
+          end
+
+        exception.exception(
           field: keyword[:field],
           message: keyword[:message],
           value: keyword[:value],

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -10,6 +10,19 @@ defmodule Ash.Test.Changeset.ChangesetTest do
 
   require Ash.Query
 
+  defmodule KeywordErrorValidation do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+
+    @impl true
+    def validate(_changeset, opts, _context) do
+      {:error, field: opts[:field], message: opts[:message]}
+    end
+  end
+
   defmodule Slugify do
     use Ash.Resource.Change
 
@@ -79,6 +92,16 @@ defmodule Ash.Test.Changeset.ChangesetTest do
 
       create :create_with_private_argument do
         argument :ip_address_public, :string, allow_nil?: false, public?: true
+      end
+
+      create :create_with_keyword_argument_validation do
+        argument :token, :string, allow_nil?: false
+
+        validate {KeywordErrorValidation, field: :token, message: "invalid token"}
+      end
+
+      create :create_with_keyword_attribute_validation do
+        validate {KeywordErrorValidation, field: :name, message: "invalid name"}
       end
     end
 
@@ -1337,6 +1360,36 @@ defmodule Ash.Test.Changeset.ChangesetTest do
 
       assert Ash.Changeset.get_argument(changeset, :true_optional_argument) == true
       assert Ash.Changeset.get_argument(changeset, :false_optional_argument) == false
+    end
+  end
+
+  describe "validation keyword errors" do
+    test "keyword list errors on action arguments use InvalidArgument" do
+      assert [
+               %Ash.Error.Changes.InvalidArgument{
+                 class: :invalid,
+                 field: :token,
+                 message: "invalid token",
+                 path: []
+               }
+             ] =
+               Ash.Changeset.for_create(Category, :create_with_keyword_argument_validation, %{
+                 token: "bad"
+               }).errors
+    end
+
+    test "keyword list errors on attributes use InvalidAttribute" do
+      assert [
+               %Ash.Error.Changes.InvalidAttribute{
+                 class: :invalid,
+                 field: :name,
+                 message: "invalid name",
+                 path: []
+               }
+             ] =
+               Ash.Changeset.for_create(Category, :create_with_keyword_attribute_validation, %{
+                 name: "bad"
+               }).errors
     end
   end
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Resolves issue #2360 

## Summary
When custom validations return `{:error, field: name, message: msg}`, Ash always built `Ash.Error.Changes.InvalidAttribute` using `add_error` → `to_change_error/1`, even if the value of name was an argument.
In `do_validation/5`, single keyword-list errors now use `changeset.action` to choose `InvalidArgument` vs `InvalidAttribute` before calling `add_error`.
## Tests
- I created two tests to ensure this change worked well: 
1. Argument `:token` → expects `%InvalidArgument{}`
2. Attribute `:name` → expects `%InvalidAttribute{}`
Both use a tiny validation that returns `{:error, field:, message:}`.