### PR TITLE
fix: propagate include_source? from union to inner embedded type constraints

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,5 +60,4 @@ if config_env() == :test do
   config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
   config :ash, Ash.Type.UUIDv7, match_v4_uuids?: true
-  config :ash, :include_embedded_source_by_default?, false
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -60,4 +60,5 @@ if config_env() == :test do
   config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
   config :ash, Ash.Type.UUIDv7, match_v4_uuids?: true
+  config :ash, :include_embedded_source_by_default?, false
 end

--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -770,11 +770,21 @@ defmodule Ash.Type.Union do
             config[:constraints] || []
           end
 
+        constraints_with_include_source =
+          if Ash.Type.embedded_type?(config[:type]) and
+               function_exported?(config[:type], :include_source, 2) do
+            Keyword.put_new_lazy(config_constraints, :include_source?, fn ->
+              Keyword.get(constraints, :include_source?, @include_source_by_default)
+            end)
+          else
+            config_constraints
+          end
+
         constraints_with_source =
           Ash.Type.include_source(
             config[:type],
             constraints[:__source__],
-            config_constraints
+            constraints_with_include_source
           )
 
         case Ash.Type.cast_input(
@@ -1151,6 +1161,15 @@ defmodule Ash.Type.Union do
           type_constraints =
             if union_tag = constraints[:types][name][:tag] do
               Keyword.put(type_constraints, :__union_tag__, union_tag)
+            else
+              type_constraints
+            end
+
+          type_constraints =
+            if Ash.Type.embedded_type?(type) do
+              Keyword.put_new_lazy(type_constraints, :include_source?, fn ->
+                Keyword.get(constraints, :include_source?, @include_source_by_default)
+              end)
             else
               type_constraints
             end

--- a/test/resource/changes/relate_actor_test.exs
+++ b/test/resource/changes/relate_actor_test.exs
@@ -137,6 +137,156 @@ defmodule Ash.Test.Resource.Changes.RelateActorTest do
     end
   end
 
+  defmodule User do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+    end
+
+    actions do
+      defaults [:read, create: :*]
+    end
+  end
+
+  # --- Deepest embedded: uses relate_actor --------------------------------
+
+  defmodule UserAuthor do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: :embedded
+
+    actions do
+      defaults [:read, :destroy]
+
+      create :create do
+        primary? true
+        change relate_actor(:user)
+      end
+    end
+
+    relationships do
+      belongs_to :user, User do
+        allow_nil? false
+        attribute_type :uuid
+      end
+    end
+  end
+
+  # --- Union wrapping UserAuthor ------------------------------------------
+  # include_source?: true opts in to source propagation, but the bug
+  # prevents this from reaching the inner embedded type.
+
+  defmodule AuthorUnion do
+    use Ash.Type.NewType,
+      subtype_of: :union,
+      constraints: [
+        include_source?: true,
+        storage: :map_with_tag,
+        types: [
+          user_author: [
+            type: UserAuthor,
+            tag: :__type__,
+            tag_value: "user_author"
+          ]
+        ]
+      ]
+  end
+
+  # --- Embedded resource containing the union author ----------------------
+
+  defmodule CommentData do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: :embedded
+
+    actions do
+      defaults [:read, create: [:text, :author]]
+    end
+
+    attributes do
+      attribute :text, :string, allow_nil?: false, public?: true
+      attribute :author, AuthorUnion, allow_nil?: false, public?: true
+    end
+  end
+
+  # --- Top-level union wrapping CommentData -------------------------------
+
+  defmodule EntryData do
+    use Ash.Type.NewType,
+      subtype_of: :union,
+      constraints: [
+        include_source?: true,
+        storage: :map_with_tag,
+        types: [
+          comment: [
+            type: CommentData,
+            tag: :__type__,
+            tag_value: "comment"
+          ]
+        ]
+      ]
+  end
+
+  # --- Child resource (has the embedded data attribute) -------------------
+
+  defmodule Child do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+      attribute :data, EntryData, allow_nil?: false, public?: true
+    end
+
+    actions do
+      defaults [:read, create: [:data, :parent_id]]
+    end
+
+    relationships do
+      belongs_to :parent,
+                 Ash.Test.Resource.Changes.RelateActorEmbeddedTest.Parent do
+        allow_nil? false
+        public? true
+      end
+    end
+  end
+
+  # --- Parent resource (manages children via relationship) ----------------
+
+  defmodule Parent do
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :name, :string do
+        public? true
+      end
+    end
+
+    actions do
+      defaults [:read, create: [:name]]
+
+      update :add_child do
+        require_atomic? false
+        argument :children, {:array, :map}
+        change manage_relationship(:children, type: :create)
+      end
+    end
+
+    relationships do
+      has_many :children, Child do
+        destination_attribute :parent_id
+      end
+    end
+  end
+
   test "relate_actor change with defaults work" do
     actor =
       Author
@@ -237,5 +387,67 @@ defmodule Ash.Test.Resource.Changes.RelateActorTest do
       |> Ash.create!()
 
     assert is_nil(post_without.author_id)
+  end
+
+  test "relate_actor propagates through manage_relationship into nested embedded union" do
+    user =
+      User
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+
+    parent =
+      Parent
+      |> Ash.Changeset.for_create(:create, %{name: "parent"})
+      |> Ash.create!()
+
+    child_data = [
+      %{
+        data: %{
+          __type__: "comment",
+          text: "hello",
+          author: %{__type__: "user_author"}
+        }
+      }
+    ]
+
+    updated =
+      parent
+      |> Ash.Changeset.for_update(:add_child, %{children: child_data}, actor: user)
+      |> Ash.update!()
+
+    updated = Ash.load!(updated, :children)
+
+    assert [child] = updated.children
+    assert child.data.value.text == "hello"
+    assert child.data.value.author.type == :user_author
+    assert child.data.value.author.value.user_id == user.id
+  end
+
+  test "relate_actor propagates through direct create into nested embedded union" do
+    user =
+      User
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+
+    parent =
+      Parent
+      |> Ash.Changeset.for_create(:create, %{name: "parent"})
+      |> Ash.create!()
+
+    child =
+      Child
+      |> Ash.Changeset.for_create(
+        :create,
+        %{
+          parent_id: parent.id,
+          data: %{__type__: "comment", text: "direct", author: %{__type__: "user_author"}}
+        },
+        actor: user
+      )
+      |> Ash.create!()
+
+    assert child.data.value.text == "direct"
+    assert child.data.value.author.type == :user_author
+    assert child.data.value.author.value.user_id == user.id
   end
 end


### PR DESCRIPTION
fix: propagate include_source? from union to inner embedded type constraints
When a union type has `include_source?: true` but the global config
`include_embedded_source_by_default?` is `false`, the inner embedded
type's `include_source` callback falls back to the compile-time default
(`false`) because the variant-level constraints don't include
`include_source?`. This breaks `relate_actor` on nested embedded
resources since the source changeset (carrying the actor) is never set.

Propagate the union's `include_source?` setting to the variant's
config_constraints via `Keyword.put_new_lazy`, so the inner type
inherits the union's opt-in.

~~I don't think this should be merged as is, because it includes changing the `ash` config, but I couldn't find any other way to create a reproducing test. We should either make the test reproducible without the config change or remove the test entirely, I think. Any suggestions?~~

I've removed the config setting, so the PR should be good to go now.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
