### PR TITLE
Improvement: Include all constraints in `Ash.Type.Decimal.generator/1`

### DIFF
--- a/lib/ash/type/decimal.ex
+++ b/lib/ash/type/decimal.ex
@@ -49,26 +49,34 @@ defmodule Ash.Type.Decimal do
 
   @impl true
   def generator(constraints) do
-    params =
-      constraints
-      |> Keyword.take([:min, :max])
-      |> Enum.map(fn {key, value} ->
-        if Decimal.is_decimal(value) do
-          {key, Decimal.to_float(value)}
-        else
-          {key, value}
-        end
-      end)
+    # Use the more restrictive constraint
+    float_options = [
+      max: minimum(constraints[:less_than], constraints[:max]),
+      min: maximum(constraints[:greater_than], constraints[:min])
+    ]
 
-    params
+    float_options
     |> StreamData.float()
-    |> StreamData.map(&Decimal.from_float/1)
-    #  A second pass filter to account for inaccuracies in the above float -> decimal
+    |> StreamData.map(fn float ->
+      float
+      |> Decimal.from_float()
+      |> Map.update!(:coef, &trunc_coef(&1, constraints[:precision]))
+      |> Map.update!(:exp, &trunc_exp(&1, constraints[:scale]))
+      |> Decimal.normalize()
+    end)
+    #  A second pass filter to account for:
+    # - inaccuracies in the above float -> decimal
+    # - truncated coefficients and/or exponents that result in a number that violates other constraints
     |> StreamData.filter(fn value ->
-      !(constraints[:max] && Decimal.gt?(value, constraints[:max])) &&
-        (!constraints[:less_than] || Decimal.lt?(value, constraints[:less_than])) &&
-        !(constraints[:min] && Decimal.lt?(value, constraints[:min])) &&
-        (!constraints[:greater_than] || Decimal.gt?(value, constraints[:greater_than]))
+      Enum.all?([
+        !constraints[:max] || Decimal.lte?(value, constraints[:max]),
+        !constraints[:less_than] || Decimal.lt?(value, constraints[:less_than]),
+        !constraints[:min] || Decimal.gte?(value, constraints[:min]),
+        !constraints[:greater_than] || Decimal.gt?(value, constraints[:greater_than]),
+        constraints[:scale] == :arbitrary || Decimal.scale(value) <= constraints[:scale],
+        constraints[:precision] == :arbitrary ||
+          count_significant_digits(value) <= constraints[:precision]
+      ])
     end)
   end
 
@@ -346,6 +354,30 @@ defmodule Ash.Type.Decimal do
       String.length(coef_str)
     end
   end
+
+  # Generator helpers
+
+  defp maximum(nil, nil), do: nil
+  defp maximum(v1, nil), do: Decimal.to_float(v1)
+  defp maximum(nil, v2), do: Decimal.to_float(v2)
+  defp maximum(v1, v2), do: max(Decimal.to_float(v1), Decimal.to_float(v2))
+
+  defp minimum(nil, nil), do: nil
+  defp minimum(v1, nil), do: Decimal.to_float(v1)
+  defp minimum(nil, v2), do: Decimal.to_float(v2)
+  defp minimum(v1, v2), do: min(Decimal.to_float(v1), Decimal.to_float(v2))
+
+  defp trunc_coef(coef, :arbitrary), do: coef
+
+  defp trunc_coef(coef, precision) do
+    coef
+    |> Integer.to_string()
+    |> String.slice(0..(precision - 1))
+    |> String.to_integer()
+  end
+
+  defp trunc_exp(exp, :arbitrary), do: exp
+  defp trunc_exp(exp, scale), do: max(exp, -1 * scale)
 end
 
 import Ash.Type.Comparable

--- a/lib/ash/type/decimal.ex
+++ b/lib/ash/type/decimal.ex
@@ -49,34 +49,22 @@ defmodule Ash.Type.Decimal do
 
   @impl true
   def generator(constraints) do
-    # Use the more restrictive constraint
-    float_options = [
-      max: minimum(constraints[:less_than], constraints[:max]),
-      min: maximum(constraints[:greater_than], constraints[:min])
-    ]
+    max =
+      constraints[:less_than]
+      |> perturb(:down)
+      |> minimum(constraints[:max])
 
-    float_options
-    |> StreamData.float()
+    min =
+      constraints[:greater_than]
+      |> perturb(:up)
+      |> maximum(constraints[:min])
+
+    StreamData.float(max: max, min: min)
     |> StreamData.map(fn float ->
       float
       |> Decimal.from_float()
-      |> Map.update!(:coef, &trunc_coef(&1, constraints[:precision]))
-      |> Map.update!(:exp, &trunc_exp(&1, constraints[:scale]))
-      |> Decimal.normalize()
-    end)
-    #  A second pass filter to account for:
-    # - inaccuracies in the above float -> decimal
-    # - truncated coefficients and/or exponents that result in a number that violates other constraints
-    |> StreamData.filter(fn value ->
-      Enum.all?([
-        !constraints[:max] || Decimal.lte?(value, constraints[:max]),
-        !constraints[:less_than] || Decimal.lt?(value, constraints[:less_than]),
-        !constraints[:min] || Decimal.gte?(value, constraints[:min]),
-        !constraints[:greater_than] || Decimal.gt?(value, constraints[:greater_than]),
-        constraints[:scale] == :arbitrary || Decimal.scale(value) <= constraints[:scale],
-        constraints[:precision] == :arbitrary ||
-          count_significant_digits(value) <= constraints[:precision]
-      ])
+      |> trunc_scale(constraints[:scale])
+      |> trunc_precision(constraints[:precision])
     end)
   end
 
@@ -356,28 +344,65 @@ defmodule Ash.Type.Decimal do
   end
 
   # Generator helpers
+  defp perturb(nil, _), do: nil
 
-  defp maximum(nil, nil), do: nil
-  defp maximum(v1, nil), do: Decimal.to_float(v1)
-  defp maximum(nil, v2), do: Decimal.to_float(v2)
-  defp maximum(v1, v2), do: max(Decimal.to_float(v1), Decimal.to_float(v2))
-
-  defp minimum(nil, nil), do: nil
-  defp minimum(v1, nil), do: Decimal.to_float(v1)
-  defp minimum(nil, v2), do: Decimal.to_float(v2)
-  defp minimum(v1, v2), do: min(Decimal.to_float(v1), Decimal.to_float(v2))
-
-  defp trunc_coef(coef, :arbitrary), do: coef
-
-  defp trunc_coef(coef, precision) do
-    coef
-    |> Integer.to_string()
-    |> String.slice(0..(precision - 1))
-    |> String.to_integer()
+  defp perturb(%Decimal{} = decimal, :down) do
+    %Decimal{exp: exp} = Decimal.normalize(decimal)
+    Decimal.sub(decimal, Decimal.new(1, 10, exp - 1))
   end
 
-  defp trunc_exp(exp, :arbitrary), do: exp
-  defp trunc_exp(exp, scale), do: max(exp, -1 * scale)
+  defp perturb(%Decimal{} = decimal, :up) do
+    %Decimal{exp: exp} = Decimal.normalize(decimal)
+    Decimal.add(decimal, Decimal.new(1, 10, exp - 1))
+  end
+
+  defp trunc_precision(decimal, :arbitrary), do: decimal
+
+  defp trunc_precision(%Decimal{sign: sign, coef: coef, exp: exp} = decimal, precision) do
+    diff = count_significant_digits(decimal) - precision
+
+    if diff > 0 do
+      Decimal.new(sign, trunc_coef(coef, diff), exp + diff)
+      |> Decimal.normalize()
+    else
+      decimal
+    end
+  end
+
+  defp trunc_scale(decimal, :arbitrary), do: decimal
+
+  defp trunc_scale(%Decimal{sign: sign, coef: coef, exp: exp} = decimal, scale) do
+    max_exp = max(exp, -1 * scale)
+    diff = max_exp - exp
+
+    if diff > 0 do
+      Decimal.new(sign, trunc_coef(coef, diff), max_exp)
+      |> Decimal.normalize()
+    else
+      decimal
+    end
+  end
+
+  defp trunc_coef(coef, num_digits) do
+    coef
+    |> Integer.digits()
+    |> Enum.slice(0..-(num_digits + 1)//1)
+    |> Integer.undigits()
+  end
+
+  defp maximum(nil, nil), do: nil
+  defp maximum(v1, nil), do: to_number(v1)
+  defp maximum(nil, v2), do: to_number(v2)
+  defp maximum(v1, v2), do: max(to_number(v1), to_number(v2))
+
+  defp minimum(nil, nil), do: nil
+  defp minimum(v1, nil), do: to_number(v1)
+  defp minimum(nil, v2), do: to_number(v2)
+  defp minimum(v1, v2), do: min(to_number(v1), to_number(v2))
+
+  defp to_number(nil), do: nil
+  defp to_number(%Decimal{} = decimal), do: Decimal.to_float(decimal)
+  defp to_number(number), do: number
 end
 
 import Ash.Type.Comparable

--- a/lib/ash/type/decimal.ex
+++ b/lib/ash/type/decimal.ex
@@ -51,12 +51,12 @@ defmodule Ash.Type.Decimal do
   def generator(constraints) do
     max =
       constraints[:less_than]
-      |> perturb(:down)
+      |> nudge(:down)
       |> minimum(constraints[:max])
 
     min =
       constraints[:greater_than]
-      |> perturb(:up)
+      |> nudge(:up)
       |> maximum(constraints[:min])
 
     StreamData.float(max: max, min: min)
@@ -344,16 +344,17 @@ defmodule Ash.Type.Decimal do
   end
 
   # Generator helpers
-  defp perturb(nil, _), do: nil
+  def nudge(nil, _), do: nil
+  def nudge(%Decimal{} = decimal, :down), do: Decimal.sub(decimal, nudge_amount(decimal))
+  def nudge(%Decimal{} = decimal, :up), do: Decimal.add(decimal, nudge_amount(decimal))
 
-  defp perturb(%Decimal{} = decimal, :down) do
-    %Decimal{exp: exp} = Decimal.normalize(decimal)
-    Decimal.sub(decimal, Decimal.new(1, 10, exp - 1))
-  end
-
-  defp perturb(%Decimal{} = decimal, :up) do
-    %Decimal{exp: exp} = Decimal.normalize(decimal)
-    Decimal.add(decimal, Decimal.new(1, 10, exp - 1))
+  defp nudge_amount(%Decimal{} = decimal) do
+    decimal
+    |> Decimal.normalize()
+    |> Decimal.scale()
+    |> min(0)
+    |> Kernel.-(1)
+    |> then(&Decimal.new(1, 10, &1))
   end
 
   defp trunc_precision(decimal, :arbitrary), do: decimal

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -5,8 +5,10 @@
 defmodule Ash.Test.Type.DecimalTest do
   @moduledoc false
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   require Ash.Expr
+  require Decimal
 
   defmodule Balance do
     @moduledoc false
@@ -310,5 +312,103 @@ defmodule Ash.Test.Type.DecimalTest do
     with {:ok, value} <- Ash.Type.Decimal.cast_input(value, constraints) do
       Ash.Type.Decimal.apply_constraints(value, constraints)
     end
+  end
+
+  describe "generator/1" do
+    property "with a :min option" do
+      check all(decimal <- generator(min: 1.23)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.gte?(decimal, Decimal.from_float(1.23))
+      end
+
+      check all(decimal <- generator(min: -10.0)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.gte?(decimal, Decimal.from_float(-10.0))
+      end
+    end
+
+    property "with a :max option" do
+      check all(decimal <- generator(max: 1.23)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.lte?(decimal, Decimal.from_float(1.23))
+      end
+
+      check all(decimal <- generator(max: -10.0)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.lte?(decimal, Decimal.from_float(-10.0))
+      end
+    end
+
+    property "with a :greater_than option" do
+      check all(decimal <- generator(greater_than: 1.23)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.gt?(decimal, Decimal.from_float(1.23))
+      end
+
+      check all(decimal <- generator(greater_than: -10.0)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.gt?(decimal, Decimal.from_float(-10.0))
+      end
+    end
+
+    property "with a :less_than option" do
+      check all(decimal <- generator(less_than: 1.23)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.lt?(decimal, Decimal.from_float(1.23))
+      end
+
+      check all(decimal <- generator(less_than: -10.0)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.lt?(decimal, Decimal.from_float(-10.0))
+      end
+    end
+
+    property "with a :scale option" do
+      check all(decimal <- generator(scale: 3)) do
+        assert Decimal.is_decimal(decimal)
+        assert Decimal.scale(decimal) <= 3
+      end
+    end
+
+    property "with a :precision option" do
+      check all(decimal <- generator(precision: 7)) do
+        assert Decimal.is_decimal(decimal)
+        assert String.length(Integer.to_string(decimal.coef)) <= 7
+      end
+    end
+
+    property "with all options" do
+      options = [
+        scale: 3,
+        precision: 7,
+        min: -1000.49,
+        greater_than: -1100.23,
+        max: 5000.23,
+        less_than: 4000.234
+      ]
+
+      check all(decimal <- generator(options)) do
+        assert Decimal.is_decimal(decimal)
+
+        assert Decimal.gt?(decimal, Decimal.from_float(options[:greater_than]))
+        assert Decimal.lt?(decimal, Decimal.from_float(options[:less_than]))
+        assert Decimal.scale(decimal) <= options[:scale]
+        assert String.length(Integer.to_string(decimal.coef)) <= options[:precision]
+      end
+    end
+  end
+
+  defp generator(constraints) do
+    {:ok, constraints} = Ash.Type.Decimal.init(constraints)
+
+    constraints
+    |> Enum.map(fn {key, value} ->
+      if key in ~w(greater_than less_than max min)a do
+        {key, Decimal.from_float(value)}
+      else
+        {key, value}
+      end
+    end)
+    |> Ash.Type.Decimal.generator()
   end
 end

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -314,101 +314,99 @@ defmodule Ash.Test.Type.DecimalTest do
     end
   end
 
+  @default_constraints [
+    precision: :arbitrary,
+    scale: :arbitrary
+  ]
+
   describe "generator/1" do
     property "with a :min option" do
-      check all(decimal <- generator(min: 1.23)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.gte?(decimal, Decimal.from_float(1.23))
-      end
+      Enum.each([1.23, -10.0], fn min ->
+        constraints = [min: Decimal.from_float(min)]
 
-      check all(decimal <- generator(min: -10.0)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.gte?(decimal, Decimal.from_float(-10.0))
-      end
+        check all(decimal <- generator(constraints)) do
+          assert Decimal.is_decimal(decimal)
+          assert Decimal.gte?(decimal, constraints[:min])
+        end
+      end)
     end
 
     property "with a :max option" do
-      check all(decimal <- generator(max: 1.23)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.lte?(decimal, Decimal.from_float(1.23))
-      end
+      Enum.each([1.23, -10.0], fn max ->
+        constraints = [max: Decimal.from_float(max)]
 
-      check all(decimal <- generator(max: -10.0)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.lte?(decimal, Decimal.from_float(-10.0))
-      end
+        check all(decimal <- generator(constraints)) do
+          assert Decimal.is_decimal(decimal)
+          assert Decimal.lte?(decimal, constraints[:max])
+        end
+      end)
     end
 
     property "with a :greater_than option" do
-      check all(decimal <- generator(greater_than: 1.23)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.gt?(decimal, Decimal.from_float(1.23))
-      end
+      Enum.each([1.23, -10.0], fn greater_than ->
+        constraints = [greater_than: Decimal.from_float(greater_than)]
 
-      check all(decimal <- generator(greater_than: -10.0)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.gt?(decimal, Decimal.from_float(-10.0))
-      end
+        check all(decimal <- generator(constraints)) do
+          assert Decimal.is_decimal(decimal)
+          assert Decimal.gt?(decimal, constraints[:greater_than])
+        end
+      end)
     end
 
     property "with a :less_than option" do
-      check all(decimal <- generator(less_than: 1.23)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.lt?(decimal, Decimal.from_float(1.23))
-      end
+      Enum.each([1.23, -10.0], fn less_than ->
+        constraints = [less_than: Decimal.from_float(less_than)]
 
-      check all(decimal <- generator(less_than: -10.0)) do
-        assert Decimal.is_decimal(decimal)
-        assert Decimal.lt?(decimal, Decimal.from_float(-10.0))
-      end
+        check all(decimal <- generator(constraints)) do
+          assert Decimal.is_decimal(decimal)
+          assert Decimal.lt?(decimal, constraints[:less_than])
+        end
+      end)
     end
 
     property "with a :scale option" do
-      check all(decimal <- generator(scale: 3)) do
+      constraints = [scale: 3]
+
+      check all(decimal <- generator(constraints)) do
         assert Decimal.is_decimal(decimal)
-        assert Decimal.scale(decimal) <= 3
+        assert Decimal.scale(decimal) <= constraints[:scale]
       end
     end
 
     property "with a :precision option" do
-      check all(decimal <- generator(precision: 7)) do
+      constraints = [precision: 7]
+
+      check all(decimal <- generator(constraints)) do
         assert Decimal.is_decimal(decimal)
-        assert String.length(Integer.to_string(decimal.coef)) <= 7
+        assert String.length(Integer.to_string(decimal.coef)) <= constraints[:precision]
       end
     end
 
     property "with all options" do
-      options = [
+      constraints = [
         scale: 3,
-        precision: 7,
-        min: -1000.49,
-        greater_than: -1100.23,
-        max: 5000.23,
-        less_than: 4000.234
+        precision: 5,
+        min: Decimal.from_float(-1000.49),
+        greater_than: Decimal.from_float(-1100.23),
+        max: Decimal.from_float(5000.23),
+        less_than: Decimal.from_float(4000.234)
       ]
 
-      check all(decimal <- generator(options)) do
+      check all(decimal <- generator(constraints)) do
         assert Decimal.is_decimal(decimal)
 
-        assert Decimal.gt?(decimal, Decimal.from_float(options[:greater_than]))
-        assert Decimal.lt?(decimal, Decimal.from_float(options[:less_than]))
-        assert Decimal.scale(decimal) <= options[:scale]
-        assert String.length(Integer.to_string(decimal.coef)) <= options[:precision]
+        assert Decimal.gt?(decimal, constraints[:greater_than])
+        assert Decimal.lt?(decimal, constraints[:less_than])
+        assert Decimal.gte?(decimal, constraints[:min])
+        assert Decimal.lte?(decimal, constraints[:max])
+        assert Decimal.scale(decimal) <= constraints[:scale]
+        assert String.length(Integer.to_string(decimal.coef)) <= constraints[:precision]
       end
     end
   end
 
   defp generator(constraints) do
-    {:ok, constraints} = Ash.Type.Decimal.init(constraints)
-
-    constraints
-    |> Enum.map(fn {key, value} ->
-      if key in ~w(greater_than less_than max min)a do
-        {key, Decimal.from_float(value)}
-      else
-        {key, value}
-      end
-    end)
+    Keyword.merge(@default_constraints, constraints)
     |> Ash.Type.Decimal.generator()
   end
 end

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -314,11 +314,6 @@ defmodule Ash.Test.Type.DecimalTest do
     end
   end
 
-  @default_constraints [
-    precision: :arbitrary,
-    scale: :arbitrary
-  ]
-
   describe "generator/1" do
     property "with a :min option" do
       Enum.each([1.23, -10.0], fn min ->
@@ -406,7 +401,12 @@ defmodule Ash.Test.Type.DecimalTest do
   end
 
   defp generator(constraints) do
-    Keyword.merge(@default_constraints, constraints)
+    default_constraints = [
+      precision: :arbitrary,
+      scale: :arbitrary
+    ]
+
+    Keyword.merge(default_constraints, constraints)
     |> Ash.Type.Decimal.generator()
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

## Summary
Currently, `Ash.Type.Decimal` values generated via `Ash.Generator`:
1. do not respect the `:scale` and `:precision` constraints and
2. may result in StreamData errors when the `:greater_than` and `:less_than` constraints are used

This PR refactors `Ash.Type.Decimal.generator/1` to respect all constraints and resolve StreamData errors.

## Details
- Updates `Ash.Type.Decimal.generator/1` to take `:scale` and `:precision` options into account
- Resolves StreamData errors when using `:greater_than` and `:less_than` constraints
- Adds tests for `Ash.Type.Decimal.generator/1`

## Notes
Repeated runs of the test suite demonstrate that the implementation appears stable.

First time contributor, please let me know if you have any questions or suggestions for improvement.