### PR TITLE
feat: Add new type callback for `to_simple_equality_comparable`

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -1661,7 +1661,9 @@ defmodule Ash.Actions.Read.Relationships do
       # holds *either* a pkey map (`%{id: ...}`) or a single attribute value,
       # depending on how the lateral join was constructed. Dispatch on shape:
       # plain map → pkey path; anything else (including structs like
-      # `%Ash.CiString{}`) → attribute path.
+      # `%Ash.CiString{}`) → attribute path. This mirrors the existing
+      # slow-path dispatch below (`is_map(...)` check around the
+      # `primary_key_matches?` vs `Ash.Type.equal?` branch).
       lateral_source_key = fn
         m when is_map(m) and not is_struct(m) -> pkey_to_key.(m)
         v -> attr_to_key.(v)
@@ -2065,10 +2067,7 @@ defmodule Ash.Actions.Read.Relationships do
         & &1
 
       Ash.Type.simple_equality_comparable?(type) ->
-        fn value ->
-          {:ok, key} = Ash.Type.to_simple_equality_comparable(type, value)
-          key
-        end
+        & Ash.Type.to_simple_equality_comparable(type, &1)
 
       true ->
         nil

--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -1122,18 +1122,19 @@ defmodule Ash.Actions.Read.Relationships do
          related_records,
          {:lazy, _related_query}
        ) do
-    if Ash.Resource.Info.primary_key_simple_equality?(relationship.source) do
-      pkey = Ash.Resource.Info.primary_key(resource)
+    pkey = Ash.Resource.Info.primary_key(resource)
+    pkey_to_key = pkey_normalizer(resource, pkey)
 
+    if pkey_to_key do
       records_by_pkey =
         Enum.reduce(related_records, %{}, fn related, acc ->
           Enum.reduce(related.__metadata__.__lazy_join_sources__, acc, fn source, acc ->
-            Map.update(acc, source, [related], &[related | &1])
+            Map.update(acc, pkey_to_key.(source), [related], &[related | &1])
           end)
         end)
 
       Enum.map(records, fn record ->
-        record_pkey = Map.take(record, pkey)
+        record_pkey = pkey_to_key.(Map.take(record, pkey))
 
         related = Enum.reverse(Map.get(records_by_pkey, record_pkey, []))
 
@@ -1379,11 +1380,11 @@ defmodule Ash.Actions.Read.Relationships do
 
   defp do_attach_related_records(records, relationship, related_records, related_query) do
     attribute = Ash.Resource.Info.attribute(relationship.source, relationship.source_attribute)
-    simple_equality? = Ash.Type.simple_equality?(attribute.type)
+    to_key = key_fn_for_type(attribute.type)
 
     related =
-      if simple_equality? do
-        Enum.group_by(related_records, &Map.get(&1, relationship.destination_attribute))
+      if to_key do
+        Enum.group_by(related_records, &to_key.(Map.get(&1, relationship.destination_attribute)))
       else
         related_records
       end
@@ -1395,9 +1396,9 @@ defmodule Ash.Actions.Read.Relationships do
         []
       end
 
-    if simple_equality? do
+    if to_key do
       Enum.map(records, fn record ->
-        value = Map.get(record, relationship.source_attribute)
+        value = to_key.(Map.get(record, relationship.source_attribute))
 
         if relationship.cardinality == :many do
           Map.put(
@@ -1648,19 +1649,35 @@ defmodule Ash.Actions.Read.Relationships do
         Ash.Resource.Info.attribute(relationship.source, relationship.source_attribute)
       end
 
-    pkey_simple_equality? = Ash.Resource.Info.primary_key_simple_equality?(relationship.source)
-
-    source_attribute_simple_equality? =
-      is_nil(source_attribute) || Ash.Type.simple_equality?(source_attribute.type)
-
     primary_key = Ash.Resource.Info.primary_key(resource)
+    pkey_to_key = pkey_normalizer(resource, primary_key)
+    attr_to_key = source_attribute && key_fn_for_type(source_attribute.type)
 
-    if pkey_simple_equality? && source_attribute_simple_equality? do
+    # Fast path requires that we can build comparable Map keys for whichever
+    # shape `__lateral_join_source__` takes. The pkey side is always needed;
+    # the attribute side only when this relationship has a `source_attribute`.
+    if pkey_to_key && (is_nil(source_attribute) || attr_to_key) do
+      # `__lateral_join_source__` is set by the data layer at query time and
+      # holds *either* a pkey map (`%{id: ...}`) or a single attribute value,
+      # depending on how the lateral join was constructed. Dispatch on shape:
+      # plain map → pkey path; anything else (including structs like
+      # `%Ash.CiString{}`) → attribute path.
+      lateral_source_key = fn
+        m when is_map(m) and not is_struct(m) -> pkey_to_key.(m)
+        v -> attr_to_key.(v)
+      end
+
       values =
         if relationship.cardinality == :many do
-          Enum.group_by(related_records, & &1.__lateral_join_source__)
+          Enum.group_by(related_records, &lateral_source_key.(&1.__lateral_join_source__))
         else
-          Map.new(Enum.reverse(related_records), &{&1.__lateral_join_source__, &1})
+          # `Enum.reverse` + `Map.new` makes the *first* related record win on
+          # key collisions (Map.new keeps the last write); reversing flips that
+          # to first-wins, matching the prior behaviour of this code.
+          Map.new(
+            Enum.reverse(related_records),
+            &{lateral_source_key.(&1.__lateral_join_source__), &1}
+          )
         end
 
       default =
@@ -1671,9 +1688,15 @@ defmodule Ash.Actions.Read.Relationships do
         end
 
       if source_attribute do
+        # Two lookups because `__lateral_join_source__` could have been
+        # populated as either shape; try pkey first, then the attribute value.
         Enum.map(records, fn record ->
-          with :error <- Map.fetch(values, Map.take(record, primary_key)),
-               :error <- Map.fetch(values, Map.get(record, relationship.source_attribute)) do
+          with :error <- Map.fetch(values, pkey_to_key.(Map.take(record, primary_key))),
+               :error <-
+                 Map.fetch(
+                   values,
+                   attr_to_key.(Map.get(record, relationship.source_attribute))
+                 ) do
             attach_fun.(record, relationship.name, default)
           else
             {:ok, value} ->
@@ -1682,7 +1705,7 @@ defmodule Ash.Actions.Read.Relationships do
         end)
       else
         Enum.map(records, fn record ->
-          case Map.fetch(values, Map.take(record, primary_key)) do
+          case Map.fetch(values, pkey_to_key.(Map.take(record, primary_key))) do
             {:ok, value} ->
               attach_fun.(record, relationship.name, value)
 
@@ -2022,4 +2045,58 @@ defmodule Ash.Actions.Read.Relationships do
   end
 
   defp is_many_to_many_not_unique_on_join?(_, _, _), do: false
+
+  # Returns a function that converts a value of `type` into a term safe for use
+  # as a Map key (i.e. comparable with `==`). Callers use this to build O(n+m)
+  # hash-based joins instead of O(n*m) `Ash.Type.equal?/3` scans.
+  #
+  # Three outcomes:
+  #
+  #   * `simple_equality?` types (string, integer, uuid, ...): returns `& &1`.
+  #     Values already work as Map keys; no transformation needed.
+  #   * Types that define `c:Ash.Type.to_simple_equality_comparable/1` (e.g.
+  #     `:ci_string` returns the downcased binary): returns a closure that
+  #     applies the callback.
+  #   * Neither: returns `nil`. The caller's contract is that `nil` means
+  #     "no safe Map key exists, fall back to the scan-based slow path."
+  defp key_fn_for_type(type) do
+    cond do
+      Ash.Type.simple_equality?(type) ->
+        & &1
+
+      Ash.Type.simple_equality_comparable?(type) ->
+        fn value ->
+          {:ok, key} = Ash.Type.to_simple_equality_comparable(type, value)
+          key
+        end
+
+      true ->
+        nil
+    end
+  end
+
+  # The pkey analogue of `key_fn_for_type/1`. Returns a function that
+  # normalizes a `%{field => value}` pkey map (the shape produced by
+  # `Map.take(record, primary_key)`) into one usable as a Map key.
+  defp pkey_normalizer(resource, primary_key) do
+    if Ash.Resource.Info.primary_key_simple_equality?(resource) do
+      & &1
+    else
+      Enum.reduce_while(primary_key, [], fn name, acc ->
+        case key_fn_for_type(Ash.Resource.Info.attribute(resource, name).type) do
+          nil -> {:halt, nil}
+          f -> {:cont, [{name, f} | acc]}
+        end
+      end)
+      |> case do
+        nil ->
+          nil
+
+        pairs ->
+          fn pkey_map ->
+            Map.new(pairs, fn {name, f} -> {name, f.(Map.get(pkey_map, name))} end)
+          end
+      end
+    end
+  end
 end

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -340,7 +340,17 @@ defmodule Ash.Resource.Info do
   @doc "Whether or not all primary key attributes can be compared with simple_equality"
   @spec primary_key_simple_equality?(Spark.Dsl.t() | Ash.Resource.t()) :: boolean()
   def primary_key_simple_equality?(resource) do
-    Spark.Dsl.Extension.get_persisted(resource, :primary_key_simple_equality?, [])
+    Spark.Dsl.Extension.get_persisted(resource, :primary_key_simple_equality?, false)
+  end
+
+  @doc """
+  Whether or not all primary key attributes can be reduced to a simple-equality
+  comparable term — either because their type is `simple_equality?/1`, or
+  because their type implements `c:Ash.Type.to_simple_equality_comparable/1`.
+  """
+  @spec primary_key_simple_equality_comparable?(Spark.Dsl.t() | Ash.Resource.t()) :: boolean()
+  def primary_key_simple_equality_comparable?(resource) do
+    Spark.Dsl.Extension.get_persisted(resource, :primary_key_simple_equality_comparable?, false)
   end
 
   @doc "Returns all relationships of a resource"

--- a/lib/ash/resource/transformers/cache_primary_key.ex
+++ b/lib/ash/resource/transformers/cache_primary_key.ex
@@ -23,6 +23,10 @@ defmodule Ash.Resource.Transformers.CachePrimaryKey do
           :primary_key_simple_equality?,
           Enum.all?(attributes, &Ash.Type.simple_equality?(&1.type))
         )
+        |> Transformer.persist(
+          :primary_key_simple_equality_comparable?,
+          Enum.all?(attributes, &Ash.Type.simple_equality_comparable?(&1.type))
+        )
 
       {:ok, dsl_state}
     end

--- a/lib/ash/type/ci_string.ex
+++ b/lib/ash/type/ci_string.ex
@@ -264,4 +264,9 @@ defmodule Ash.Type.CiString do
   def equal?(left, right) do
     Ash.CiString.compare(left, right) == :eq
   end
+
+  @impl true
+  def to_simple_equality_comparable(value) do
+    {:ok, Ash.CiString.to_comparable_string(value)}
+  end
 end

--- a/lib/ash/type/ci_string.ex
+++ b/lib/ash/type/ci_string.ex
@@ -267,6 +267,6 @@ defmodule Ash.Type.CiString do
 
   @impl true
   def to_simple_equality_comparable(value) do
-    {:ok, Ash.CiString.to_comparable_string(value)}
+    Ash.CiString.to_comparable_string(value)
   end
 end

--- a/lib/ash/type/new_type.ex
+++ b/lib/ash/type/new_type.ex
@@ -517,6 +517,16 @@ defmodule Ash.Type.NewType do
       end
 
       @impl Ash.Type
+      def simple_equality_comparable? do
+        Ash.Type.simple_equality_comparable?(unquote(subtype_of))
+      end
+
+      @impl Ash.Type
+      def to_simple_equality_comparable(value) do
+        Ash.Type.to_simple_equality_comparable(unquote(subtype_of), value)
+      end
+
+      @impl Ash.Type
       def storage_type(constraints) do
         constraints = subtype_constraints(constraints)
         unquote(subtype_of).storage_type(constraints)

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -574,8 +574,35 @@ defmodule Ash.Type do
   For example, if a resource's primary key cannot be compared with `==`, we cannot do things like key
   a list of records by their primary key. Implementing `c:equal?/2` will cause various code paths to be considerably
   slower, so only do it when necessary.
+
+  If a type can be converted to a form that *can* be used with `==` to compare instances,
+  implement `c:to_simple_equality_comparable/1`.
   """
   @callback simple_equality?() :: boolean
+
+  @doc """
+  Convert a value of this type into a term that can be compared with `==`
+  against other comparable terms produced by this type.
+
+  Types that cannot be compared using `==` incur significant runtime costs when used in certain ways.
+  For example, if a resource's primary key cannot be compared with `==`, we cannot do things like key
+  a list of records by their primary key.
+
+  Only meaningful for types where `c:simple_equality?/0` returns `false`.
+  Return `:error` if no equivalent comparable form exists.
+  """
+  @callback to_simple_equality_comparable(term) :: {:ok, term} | :error
+
+  @doc """
+  Whether or not this type defines a custom `c:to_simple_equality_comparable/1`.
+  This is defined automatically.
+
+  **Contract:** if this returns `true`, `c:to_simple_equality_comparable/1`
+  must return `{:ok, _}` for every valid instance of the type. Returning
+  `:error` while reporting `true` here will crash callers that use the
+  hash-based lookup optimisation.
+  """
+  @callback simple_equality_comparable?() :: boolean
 
   @doc "Whether or not the type is an embedded resource. This is defined by embedded resources, you should not define this."
   @callback embedded?() :: boolean
@@ -1752,6 +1779,59 @@ defmodule Ash.Type do
     type.simple_equality?()
   end
 
+  @doc """
+  Whether or not the type can be converted to a term that supports `==`
+  comparison (and Map key use) via `to_simple_equality_comparable/3`.
+
+  Returns true when `simple_equality?/1` is true, or when the type defines
+  `c:to_simple_equality_comparable/1`.
+  """
+  @spec simple_equality_comparable?(t()) :: boolean
+  def simple_equality_comparable?({:array, type}), do: simple_equality_comparable?(type)
+
+  def simple_equality_comparable?(type) do
+    type = get_type(type)
+    type.simple_equality?() || type.simple_equality_comparable?()
+  end
+
+  @doc """
+  Convert a value into a term suitable for `==` comparison and Map key use
+  against other instances of the same type.
+
+  Returns `{:ok, term}` or `:error` if the type cannot produce a comparable
+  form. For types where `simple_equality?/1` is true, returns the value
+  unchanged.
+
+  For `{:array, type}`, each element is converted; if any element fails,
+  returns `:error`.
+  """
+  @spec to_simple_equality_comparable(t(), term) :: {:ok, term} | :error
+  def to_simple_equality_comparable(_type, nil), do: {:ok, nil}
+
+  def to_simple_equality_comparable({:array, type}, values) when is_list(values) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case to_simple_equality_comparable(type, value) do
+        {:ok, v} -> {:cont, {:ok, [v | acc]}}
+        :error -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, list} -> {:ok, Enum.reverse(list)}
+      :error -> :error
+    end
+  end
+
+  def to_simple_equality_comparable(type, value) do
+    resolved = get_type(type)
+
+    if resolved.simple_equality?() do
+      {:ok, value}
+    else
+      resolved.to_simple_equality_comparable(value)
+    end
+  end
+
   defmacro __using__(opts) do
     quote location: :keep, generated: true do
       @behaviour Ash.Type
@@ -2438,6 +2518,17 @@ defmodule Ash.Type do
 
         @impl true
         def equal?(left, right), do: left == right
+      end
+
+      if Module.defines?(__MODULE__, {:to_simple_equality_comparable, 1}, :def) do
+        @impl true
+        def simple_equality_comparable?, do: true
+      else
+        @impl true
+        def simple_equality_comparable?, do: false
+
+        @impl true
+        def to_simple_equality_comparable(_value), do: :error
       end
 
       if Module.defines?(__MODULE__, {:handle_change_array, 3}, :def) do

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -589,18 +589,12 @@ defmodule Ash.Type do
   a list of records by their primary key.
 
   Only meaningful for types where `c:simple_equality?/0` returns `false`.
-  Return `:error` if no equivalent comparable form exists.
   """
-  @callback to_simple_equality_comparable(term) :: {:ok, term} | :error
+  @callback to_simple_equality_comparable(term) :: term
 
   @doc """
   Whether or not this type defines a custom `c:to_simple_equality_comparable/1`.
   This is defined automatically.
-
-  **Contract:** if this returns `true`, `c:to_simple_equality_comparable/1`
-  must return `{:ok, _}` for every valid instance of the type. Returning
-  `:error` while reporting `true` here will crash callers that use the
-  hash-based lookup optimisation.
   """
   @callback simple_equality_comparable?() :: boolean
 
@@ -702,7 +696,8 @@ defmodule Ash.Type do
     rewrite: 3,
     operator_overloads: 0,
     evaluate_operator: 1,
-    operator_expression: 1
+    operator_expression: 1,
+    to_simple_equality_comparable: 1
   ]
 
   @builtin_types Registry.builtin_types()
@@ -1798,37 +1793,33 @@ defmodule Ash.Type do
   Convert a value into a term suitable for `==` comparison and Map key use
   against other instances of the same type.
 
-  Returns `{:ok, term}` or `:error` if the type cannot produce a comparable
-  form. For types where `simple_equality?/1` is true, returns the value
-  unchanged.
+  For types where `simple_equality?/1` is true, returns the value unchanged.
+  For `{:array, type}`, each element is converted.
 
-  For `{:array, type}`, each element is converted; if any element fails,
-  returns `:error`.
+  Callers must check `simple_equality_comparable?/1` first; calling this on
+  a type that has no comparable form raises `ArgumentError`.
   """
-  @spec to_simple_equality_comparable(t(), term) :: {:ok, term} | :error
-  def to_simple_equality_comparable(_type, nil), do: {:ok, nil}
+  @spec to_simple_equality_comparable(t(), term) :: term
+  def to_simple_equality_comparable(_type, nil), do: nil
 
   def to_simple_equality_comparable({:array, type}, values) when is_list(values) do
-    values
-    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
-      case to_simple_equality_comparable(type, value) do
-        {:ok, v} -> {:cont, {:ok, [v | acc]}}
-        :error -> {:halt, :error}
-      end
-    end)
-    |> case do
-      {:ok, list} -> {:ok, Enum.reverse(list)}
-      :error -> :error
-    end
+    Enum.map(values, &to_simple_equality_comparable(type, &1))
   end
 
   def to_simple_equality_comparable(type, value) do
     resolved = get_type(type)
 
-    if resolved.simple_equality?() do
-      {:ok, value}
-    else
-      resolved.to_simple_equality_comparable(value)
+    cond do
+      resolved.simple_equality?() ->
+        value
+
+      resolved.simple_equality_comparable?() ->
+        resolved.to_simple_equality_comparable(value)
+
+      true ->
+        raise ArgumentError,
+              "#{inspect(type)} has no simple-equality-comparable form; " <>
+                "check Ash.Type.simple_equality_comparable?/1 first"
     end
   end
 
@@ -2526,9 +2517,6 @@ defmodule Ash.Type do
       else
         @impl true
         def simple_equality_comparable?, do: false
-
-        @impl true
-        def to_simple_equality_comparable(_value), do: :error
       end
 
       if Module.defines?(__MODULE__, {:handle_change_array, 3}, :def) do

--- a/test/type/simple_equality_comparable_test.exs
+++ b/test/type/simple_equality_comparable_test.exs
@@ -152,19 +152,19 @@ defmodule Ash.Test.Type.SimpleEqualityComparableTest do
 
   describe "Ash.Type.to_simple_equality_comparable/2" do
     test "returns the value unchanged for simple-equality types" do
-      assert {:ok, "foo"} = Ash.Type.to_simple_equality_comparable(:string, "foo")
-      assert {:ok, 42} = Ash.Type.to_simple_equality_comparable(:integer, 42)
+      assert "foo" == Ash.Type.to_simple_equality_comparable(:string, "foo")
+      assert 42 == Ash.Type.to_simple_equality_comparable(:integer, 42)
     end
 
     test "downcases CiString values regardless of input shape" do
-      assert {:ok, "foo"} = Ash.Type.to_simple_equality_comparable(:ci_string, "FoO")
+      assert "foo" == Ash.Type.to_simple_equality_comparable(:ci_string, "FoO")
 
-      assert {:ok, "foo"} =
+      assert "foo" ==
                Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{
                  string: "FoO"
                })
 
-      assert {:ok, "foo"} =
+      assert "foo" ==
                Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{
                  string: "foo",
                  case: :lower,
@@ -173,34 +173,37 @@ defmodule Ash.Test.Type.SimpleEqualityComparableTest do
     end
 
     test "produces equal terms for differently-cased CiStrings" do
-      {:ok, a} = Ash.Type.to_simple_equality_comparable(:ci_string, "FRED")
-      {:ok, b} = Ash.Type.to_simple_equality_comparable(:ci_string, "fReD")
-      {:ok, c} = Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{string: "fred"})
+      a = Ash.Type.to_simple_equality_comparable(:ci_string, "FRED")
+      b = Ash.Type.to_simple_equality_comparable(:ci_string, "fReD")
+      c = Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{string: "fred"})
 
       assert a == b
       assert b == c
     end
 
     test "passes nil through" do
-      assert {:ok, nil} = Ash.Type.to_simple_equality_comparable(:ci_string, nil)
+      assert nil == Ash.Type.to_simple_equality_comparable(:ci_string, nil)
     end
 
     test "normalizes each element of an array" do
-      assert {:ok, ["foo", "bar"]} =
+      assert ["foo", "bar"] ==
                Ash.Type.to_simple_equality_comparable({:array, :ci_string}, ["FoO", "BAR"])
     end
 
-    test "returns :error for types without a comparable form" do
-      assert :error = Ash.Type.to_simple_equality_comparable(:decimal, Decimal.new("1.0"))
+    test "raises for types without a comparable form" do
+      assert_raise ArgumentError, ~r/has no simple-equality-comparable form/, fn ->
+        Ash.Type.to_simple_equality_comparable(:decimal, Decimal.new("1.0"))
+      end
     end
 
     test "NewType delegates to its subtype" do
-      assert {:ok, "foo"} = Ash.Type.to_simple_equality_comparable(CiStringNewType, "FoO")
+      assert "foo" == Ash.Type.to_simple_equality_comparable(CiStringNewType, "FoO")
     end
 
-    test "NewType wrapping a non-comparable subtype returns :error" do
-      assert :error =
-               Ash.Type.to_simple_equality_comparable(DecimalNewType, Decimal.new("1.0"))
+    test "NewType wrapping a non-comparable subtype raises" do
+      assert_raise ArgumentError, ~r/has no simple-equality-comparable form/, fn ->
+        Ash.Type.to_simple_equality_comparable(DecimalNewType, Decimal.new("1.0"))
+      end
     end
   end
 

--- a/test/type/simple_equality_comparable_test.exs
+++ b/test/type/simple_equality_comparable_test.exs
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Type.SimpleEqualityComparableTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule CiStringNewType do
+    use Ash.Type.NewType, subtype_of: :ci_string
+  end
+
+  defmodule DecimalNewType do
+    use Ash.Type.NewType, subtype_of: :decimal
+  end
+
+  defmodule Parent do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    attributes do
+      attribute :id, :ci_string do
+        primary_key?(true)
+        allow_nil?(false)
+        public?(true)
+      end
+    end
+
+    relationships do
+      has_many(:children, Ash.Test.Type.SimpleEqualityComparableTest.Child,
+        destination_attribute: :parent_id,
+        public?: true
+      )
+    end
+  end
+
+  defmodule Child do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults([:read, :destroy, create: :*, update: :*])
+
+      # Paginated read used to force the lateral-join attach path.
+      read :paginated do
+        pagination do
+          offset? true
+          default_limit 100
+          countable true
+        end
+      end
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:label, :string, public?: true)
+    end
+
+    relationships do
+      belongs_to :parent, Ash.Test.Type.SimpleEqualityComparableTest.Parent do
+        attribute_type(:ci_string)
+        public?(true)
+      end
+    end
+  end
+
+  # Resource with a composite PK that mixes a ci_string and an integer.
+  # Exercises the multi-field branch of pkey_normalizer/2.
+  defmodule CompositeParent do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    attributes do
+      attribute :id, :ci_string, primary_key?: true, allow_nil?: false, public?: true
+      attribute :version, :integer, primary_key?: true, allow_nil?: false, public?: true
+    end
+  end
+
+  # Resource with a non-comparable PK (decimal). Used purely to assert
+  # primary_key_simple_equality_comparable?/1 can return false.
+  defmodule DecimalKeyResource do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults([:read, create: :*])
+    end
+
+    attributes do
+      attribute :id, :decimal, primary_key?: true, allow_nil?: false, public?: true
+    end
+  end
+
+  describe "Ash.Type.simple_equality_comparable?/1" do
+    test "is true for simple-equality types" do
+      assert Ash.Type.simple_equality_comparable?(:string)
+      assert Ash.Type.simple_equality_comparable?(:integer)
+      assert Ash.Type.simple_equality_comparable?(:uuid)
+    end
+
+    test "is true for :ci_string via the callback" do
+      assert Ash.Type.simple_equality_comparable?(:ci_string)
+    end
+
+    test "is true for array of comparable types" do
+      assert Ash.Type.simple_equality_comparable?({:array, :ci_string})
+      assert Ash.Type.simple_equality_comparable?({:array, :string})
+    end
+
+    test "is true for a NewType wrapping a comparable subtype" do
+      assert Ash.Type.simple_equality_comparable?(CiStringNewType)
+    end
+
+    test "is false for types without a comparable form" do
+      refute Ash.Type.simple_equality_comparable?(:decimal)
+    end
+
+    test "is false for a NewType wrapping a non-comparable subtype" do
+      refute Ash.Type.simple_equality_comparable?(DecimalNewType)
+    end
+  end
+
+  describe "Ash.Type.to_simple_equality_comparable/2" do
+    test "returns the value unchanged for simple-equality types" do
+      assert {:ok, "foo"} = Ash.Type.to_simple_equality_comparable(:string, "foo")
+      assert {:ok, 42} = Ash.Type.to_simple_equality_comparable(:integer, 42)
+    end
+
+    test "downcases CiString values regardless of input shape" do
+      assert {:ok, "foo"} = Ash.Type.to_simple_equality_comparable(:ci_string, "FoO")
+
+      assert {:ok, "foo"} =
+               Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{
+                 string: "FoO"
+               })
+
+      assert {:ok, "foo"} =
+               Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{
+                 string: "foo",
+                 case: :lower,
+                 casted?: true
+               })
+    end
+
+    test "produces equal terms for differently-cased CiStrings" do
+      {:ok, a} = Ash.Type.to_simple_equality_comparable(:ci_string, "FRED")
+      {:ok, b} = Ash.Type.to_simple_equality_comparable(:ci_string, "fReD")
+      {:ok, c} = Ash.Type.to_simple_equality_comparable(:ci_string, %Ash.CiString{string: "fred"})
+
+      assert a == b
+      assert b == c
+    end
+
+    test "passes nil through" do
+      assert {:ok, nil} = Ash.Type.to_simple_equality_comparable(:ci_string, nil)
+    end
+
+    test "normalizes each element of an array" do
+      assert {:ok, ["foo", "bar"]} =
+               Ash.Type.to_simple_equality_comparable({:array, :ci_string}, ["FoO", "BAR"])
+    end
+
+    test "returns :error for types without a comparable form" do
+      assert :error = Ash.Type.to_simple_equality_comparable(:decimal, Decimal.new("1.0"))
+    end
+
+    test "NewType delegates to its subtype" do
+      assert {:ok, "foo"} = Ash.Type.to_simple_equality_comparable(CiStringNewType, "FoO")
+    end
+
+    test "NewType wrapping a non-comparable subtype returns :error" do
+      assert :error =
+               Ash.Type.to_simple_equality_comparable(DecimalNewType, Decimal.new("1.0"))
+    end
+  end
+
+  describe "Ash.Resource.Info.primary_key_simple_equality_comparable?/1" do
+    test "is true when all pkey attributes are comparable" do
+      assert Ash.Resource.Info.primary_key_simple_equality_comparable?(Parent)
+    end
+
+    test "is true for a composite pkey of comparable types" do
+      assert Ash.Resource.Info.primary_key_simple_equality_comparable?(CompositeParent)
+    end
+
+    test "is false when any pkey attribute has no comparable form" do
+      refute Ash.Resource.Info.primary_key_simple_equality_comparable?(DecimalKeyResource)
+    end
+
+    test "Parent's pkey is not simple_equality? (so the integration tests below exercise the comparable path, not the identity path)" do
+      refute Ash.Resource.Info.primary_key_simple_equality?(Parent)
+    end
+  end
+
+  describe "loading has_many across a CI string PK" do
+    setup do
+      for id <- ["ALPHA", "Beta", "Gamma"] do
+        Parent
+        |> Ash.Changeset.for_create(:create, %{id: id})
+        |> Ash.create!()
+      end
+
+      # Children reference parents with various casings — should all still match.
+      for {parent_id, label} <- [
+            {"alpha", "a1"},
+            {"ALPHA", "a2"},
+            {"aLpHa", "a3"},
+            {"BETA", "b1"},
+            {"beta", "b2"}
+          ] do
+        Child
+        |> Ash.Changeset.for_create(:create, %{parent_id: parent_id, label: label})
+        |> Ash.create!()
+      end
+
+      :ok
+    end
+
+    test "main attach path: stitches children regardless of case" do
+      parents = Parent |> Ash.read!() |> Ash.load!(:children)
+      result = group_labels(parents)
+
+      assert result["ALPHA"] == ["a1", "a2", "a3"]
+      assert result["Beta"] == ["b1", "b2"]
+      assert result["Gamma"] == []
+    end
+
+    test "lazy attach path: re-load already-loaded children with lazy?: true" do
+      parents = Parent |> Ash.read!() |> Ash.load!(:children)
+      reloaded = Ash.load!(parents, [:children], lazy?: true)
+      result = group_labels(reloaded)
+
+      assert result["ALPHA"] == ["a1", "a2", "a3"]
+      assert result["Beta"] == ["b1", "b2"]
+      assert result["Gamma"] == []
+    end
+
+    test "lateral attach path: paginated children stitch back to mixed-case parents" do
+      children_query =
+        Child
+        |> Ash.Query.for_read(:paginated)
+        |> Ash.Query.page(limit: 100)
+
+      parents = Parent |> Ash.read!() |> Ash.load!(children: children_query)
+
+      # Pattern-matching Ash.Page.Offset confirms the paginated read fired —
+      # which is what triggers the lateral-join attach path under the hood.
+      result =
+        Map.new(parents, fn parent ->
+          %Ash.Page.Offset{results: results} = parent.children
+          {to_string(parent.id), results |> Enum.map(& &1.label) |> Enum.sort()}
+        end)
+
+      assert result["ALPHA"] == ["a1", "a2", "a3"]
+      assert result["Beta"] == ["b1", "b2"]
+      assert result["Gamma"] == []
+    end
+  end
+
+  defp group_labels(parents) do
+    Map.new(parents, fn parent ->
+      {to_string(parent.id), parent.children |> Enum.map(& &1.label) |> Enum.sort()}
+    end)
+  end
+end


### PR DESCRIPTION
As discussed on Discord (read discussion from [here](https://discord.com/channels/711271361523351632/711271361523351636/1507791237749411900) on). 

### The problem being solved 

The current behaviour for attaching loaded relationship records to their parent works well with a map-based lookup when the primary/foreign keys all support simple equality (with `==`). If they don't, it still works, just with a lot slower 'check every value against every other value to find which parent goes with which child' approach.

My example app uses CiStrings as IDs - so I was hitting the slow path.

In my app (which has 2000 parent `QuestVersion` records and about 12000 child `JournalEntry` records) - 

```elixir
:timer.tc fn -> Ash.read(Resdayn.Codex.Dialogue.QuestVersion, load: [:journal_entries]); :ok end
```

This would generally take 15-20 seconds, but sometimes upwards of 60 seconds (!!) Which is crazy too long. 

### The solution

The new callback, if defined for a type, defines a way of normalizing the primary/foreign keys to something that *can* be used with simple equality. I've implemented it for `Ash.Type.CiString` - it calls `Ash.CiString.to_comparable_string(value)` which returns a normalized string version, which *can* be used with `==`.

The result: The same query that took 15-20 seconds, now takes 200-300ms, most of which is in the actual database query to load the child data.

### Bits I'm not completely confident about

* The code touches three methods of loading relationships - normal, lazy, and lateral. The code for the lateral matching is a bit more complex than the rest and I'm not fully across it, but it appears to work (and has a test to cover it). The test does hit the updated code path (tested by putting a `dbg` statement in there and ensuring it printed). Please review that part well!

* The code doesn't really handle if the supplied callback definition doesn't return the right type, or if the newly-simple-equal-comparable value *isn't* actually simple equality comparable.
  eg. if I define it like this in `Ash.Type.CiString`:
```elixir
def to_simple_equality_comparable(value), do: :froo
```
  then the error is kind of obscure:
```
** (Ash.Error.Unknown)
Bread Crumbs:
  > Exception raised in: Resdayn.Codex.Dialogue.QuestVersion.read

Unknown Error

* ** (MatchError) no match of right hand side value:

    :froo

  (ash 3.26.0) lib/ash/actions/read/read.ex:472: Ash.Actions.Read.do_run/3
    (ash 3.26.0) lib/ash/actions/read/relationships.ex:2069: anonymous fn/2 in Ash.Actions.Read.Relationships.key_fn_for_type/1
    (elixir 1.20.0-rc.3) lib/enum.ex:1428: anonymous fn/4 in Enum.group_by/3
```
Defining it like this in `Ash.Type.CiString`:
```elixir
def to_simple_equality_comparable(value), do: value
```
Will compare the actual CiStrings with `==`, returning false if they don't match in case, so records will be silently dropped from the relationship. 

This might just be a case of making sure we test well for the built-in types, and documenting it clearly for users? (which I think I've done here)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
