### PR TITLE
improvement: expose required? on manifest Argument inputs

### DIFF
--- a/lib/ash/info/manifest/argument.ex
+++ b/lib/ash/info/manifest/argument.ex
@@ -5,6 +5,13 @@
 defmodule Ash.Info.Manifest.Argument do
   @moduledoc """
   Represents an action argument or calculation argument in the API specification.
+
+  `allow_nil?` and `has_default?` describe the shape of the value once supplied
+  (whether `nil` is a permitted value, and whether a default exists). `required?`
+  is orthogonal and describes input presence: whether a caller must supply this
+  argument at all. A field can be required-to-provide but nullable, or optional-
+  to-provide but non-null when provided — so consumers generating input types
+  should look at `required?` to decide optionality.
   """
 
   @type t :: %__MODULE__{
@@ -12,6 +19,7 @@ defmodule Ash.Info.Manifest.Argument do
           type: Ash.Info.Manifest.Type.t(),
           allow_nil?: boolean(),
           has_default?: boolean(),
+          required?: boolean(),
           description: String.t() | nil,
           sensitive?: boolean(),
           custom: map()
@@ -22,6 +30,7 @@ defmodule Ash.Info.Manifest.Argument do
     :type,
     :allow_nil?,
     :has_default?,
+    :required?,
     :description,
     :sensitive?,
     custom: %{}

--- a/lib/ash/info/manifest/generator/action_builder.ex
+++ b/lib/ash/info/manifest/generator/action_builder.ex
@@ -74,11 +74,20 @@ defmodule Ash.Info.Manifest.Generator.ActionBuilder do
             true -> attribute.allow_nil?
           end
 
+        required? =
+          cond do
+            name in allow_nil_input -> false
+            name in require_attributes -> true
+            action.type == :create -> not attribute.allow_nil? and is_nil(attribute.default)
+            true -> false
+          end
+
         %Argument{
           name: attribute.name,
           type: TypeResolver.resolve(attribute.type, attribute.constraints || []),
           allow_nil?: allow_nil?,
           has_default?: not is_nil(attribute.default),
+          required?: required?,
           description: Map.get(attribute, :description),
           sensitive?: Map.get(attribute, :sensitive?, false)
         }
@@ -91,6 +100,7 @@ defmodule Ash.Info.Manifest.Generator.ActionBuilder do
       type: TypeResolver.resolve(arg.type, arg.constraints || []),
       allow_nil?: arg.allow_nil?,
       has_default?: not is_nil(arg.default),
+      required?: not arg.allow_nil? and is_nil(arg.default),
       description: Map.get(arg, :description),
       sensitive?: Map.get(arg, :sensitive?, false)
     }

--- a/lib/ash/info/manifest/json_serializer.ex
+++ b/lib/ash/info/manifest/json_serializer.ex
@@ -261,6 +261,7 @@ defmodule Ash.Info.Manifest.JsonSerializer do
       "type" => serialize_type(arg.type),
       "allow_nil" => arg.allow_nil?,
       "has_default" => arg.has_default?,
+      "required" => arg.required?,
       "sensitive" => arg.sensitive?
     }
     |> put_if_present("description", arg.description)

--- a/test/ash/info/manifest/action_builder_test.exs
+++ b/test/ash/info/manifest/action_builder_test.exs
@@ -126,4 +126,78 @@ defmodule Ash.Test.Info.Manifest.Generator.ActionBuilderTest do
       assert result.get? == true
     end
   end
+
+  describe "input required? semantics" do
+    test "create action: non-null attribute without default is required" do
+      action = get_action(Ash.Test.Manifest.Article, :create)
+      result = ActionBuilder.build(Ash.Test.Manifest.Article, action)
+
+      hero_image_url = Enum.find(result.inputs, &(&1.name == :hero_image_url))
+      assert hero_image_url.required? == true
+      assert hero_image_url.allow_nil? == false
+    end
+
+    test "create action: allow_nil_input makes attribute optional and nullable" do
+      action = get_action(Ash.Test.Manifest.Article, :create_with_optional_hero_image)
+      result = ActionBuilder.build(Ash.Test.Manifest.Article, action)
+
+      hero_image_url = Enum.find(result.inputs, &(&1.name == :hero_image_url))
+      assert hero_image_url.required? == false
+      assert hero_image_url.allow_nil? == true
+
+      hero_image_alt = Enum.find(result.inputs, &(&1.name == :hero_image_alt))
+      assert hero_image_alt.required? == true
+      assert hero_image_alt.allow_nil? == false
+    end
+
+    test "update action: accepted attribute not in require_attributes is optional" do
+      action = get_action(Ash.Test.Manifest.Article, :update)
+      result = ActionBuilder.build(Ash.Test.Manifest.Article, action)
+
+      for name <- [:hero_image_url, :hero_image_alt, :summary, :body] do
+        input = Enum.find(result.inputs, &(&1.name == name))
+        assert input.required? == false, "expected #{name} to be optional on update"
+        assert input.allow_nil? == false, "expected #{name} to keep allow_nil?: false"
+      end
+    end
+
+    test "update action: require_attributes marks attribute as required" do
+      action = get_action(Ash.Test.Manifest.Article, :update_with_required_hero_image_alt)
+      result = ActionBuilder.build(Ash.Test.Manifest.Article, action)
+
+      hero_image_alt = Enum.find(result.inputs, &(&1.name == :hero_image_alt))
+      assert hero_image_alt.required? == true
+      assert hero_image_alt.allow_nil? == false
+
+      # Other accepted attributes remain optional even though their value, if
+      # supplied, must be non-null.
+      for name <- [:hero_image_url, :summary, :body] do
+        input = Enum.find(result.inputs, &(&1.name == name))
+        assert input.required? == false, "expected #{name} to be optional on update"
+        assert input.allow_nil? == false, "expected #{name} to keep allow_nil?: false"
+      end
+    end
+
+    test "action argument: allow_nil? false with no default is required" do
+      action = get_action(Ash.Test.Manifest.Todo, :create)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      user_id_arg = Enum.find(result.inputs, &(&1.name == :user_id))
+
+      if user_id_arg do
+        assert user_id_arg.required? == true
+      end
+    end
+
+    test "action argument: with default is optional" do
+      action = get_action(Ash.Test.Manifest.Todo, :create)
+      result = ActionBuilder.build(Ash.Test.Manifest.Todo, action)
+
+      auto_complete = Enum.find(result.inputs, &(&1.name == :auto_complete))
+
+      if auto_complete && auto_complete.has_default? do
+        assert auto_complete.required? == false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a `required?` field on Argument in addition to `allow_nil?`, which was conflating the required presence of the input and if nil values were accepted.