### PR TITLE
fix: Error when passing in {:ok, []} to Ash.load

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -2490,9 +2490,7 @@ defmodule Ash do
   def load({:error, error}, _, _), do: {:error, error}
 
   def load({:ok, values}, query, opts) do
-    Ash.Helpers.expect_options!(opts)
-    resource = Ash.Helpers.resource_from_data!(values, query, opts)
-    load(values, query, Keyword.put(opts, :resource, resource))
+    load(values, query, opts)
   end
 
   def load(%Ash.Query{}, _query, _opts) do

--- a/test/actions/load_test.exs
+++ b/test/actions/load_test.exs
@@ -661,6 +661,32 @@ defmodule Ash.Test.Actions.LoadTest do
       :ok
     end
 
+    test "it handles {:ok, []} input" do
+      assert {:ok, []} = Ash.load({:ok, []}, [:author])
+    end
+
+    test "it handles {:ok, nil} input" do
+      assert {:ok, nil} = Ash.load({:ok, nil}, [:author])
+    end
+
+    test "it handles {:ok, record} input" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "post1", category: "foo"})
+        |> Ash.create!()
+
+      assert {:ok, %Post{title: "post1"}} = Ash.load({:ok, post}, [])
+    end
+
+    test "it handles {:ok, [record]} input" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "post1", category: "foo"})
+        |> Ash.create!()
+
+      assert {:ok, [%Post{title: "post1"}]} = Ash.load({:ok, [post]}, [])
+    end
+
     test "it allows loading manual relationships" do
       post1 =
         Post


### PR DESCRIPTION
Previous I would get:

```
** (ArgumentError) Could not determine a resource from the provided input:

  []
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
