### PR TITLE
fix: Arguments are not passed into expression template on relationship filters

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -333,7 +333,7 @@ defmodule Ash.Actions.Read.Relationships do
       |> Ash.Query.default_sort(relationship.default_sort)
       |> Ash.Query.do_filter(relationship.filter, parent_stack: parent_stack)
       |> Ash.Query.set_context(relationship.context)
-      |> hydrate_refs(query.context[:private][:actor], relationship.source)
+      |> hydrate_refs(query.context[:private][:actor], relationship.source, query.arguments)
       |> with_lateral_join_query(query, relationship, records)
 
     if !related_query.context[:data_layer][:lateral_join_source] &&
@@ -458,7 +458,11 @@ defmodule Ash.Actions.Read.Relationships do
                 relationship.source_attribute_on_join_resource,
                 relationship.destination_attribute_on_join_resource
               ])
-              |> hydrate_refs(source_query.context[:private][:actor], relationship.source)
+              |> hydrate_refs(
+                source_query.context[:private][:actor],
+                relationship.source,
+                source_query.arguments
+              )
 
             if source_query.context[:private][:authorize?] do
               case Ash.can(
@@ -531,12 +535,12 @@ defmodule Ash.Actions.Read.Relationships do
     end
   end
 
-  defp hydrate_refs(query, actor, parent) do
+  defp hydrate_refs(query, actor, parent, source_args) do
     query.filter
     |> Ash.Expr.fill_template(
       actor: actor,
       tenant: query.to_tenant,
-      args: %{},
+      args: source_args,
       context: query.context
     )
     |> Ash.Filter.hydrate_refs(%{

--- a/test/actions/has_many_test.exs
+++ b/test/actions/has_many_test.exs
@@ -131,6 +131,14 @@ defmodule Ash.Test.Actions.HasManyTest do
       default_accept :*
       defaults [:read, :destroy, create: :*, update: :*]
 
+      read :with_min_priority_comments do
+        argument :min_priority, :integer, allow_nil?: false
+
+        prepare fn query, _ ->
+          Ash.Query.load(query, :comments_with_min_priority)
+        end
+      end
+
       update :add_comment do
         require_atomic? false
         accept []
@@ -221,6 +229,13 @@ defmodule Ash.Test.Actions.HasManyTest do
            |> Ash.read!(actor: actor, authorize?: authorize?)
            |> Enum.group_by(& &1.post_id)}
         end
+      end
+
+      has_many :comments_with_min_priority, Comment do
+        destination_attribute :post_id
+        public? true
+        domain OtherDomain
+        filter expr(priority >= ^arg(:min_priority))
       end
     end
   end
@@ -532,6 +547,74 @@ defmodule Ash.Test.Actions.HasManyTest do
 
     user = Ash.get!(User, to_string(user.id), load: :unread_posts, authorize?: false)
     assert length(user.unread_posts) == 2
+  end
+
+  describe "has_many filter with ^arg template" do
+    test "^arg in relationship filter resolves the action argument" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "Test Post"})
+        |> Ash.create!()
+
+      for priority <- [10, 50, 90] do
+        Comment
+        |> Ash.Changeset.for_create(:create, %{
+          post_id: post.id,
+          content: "comment #{priority}",
+          priority: priority
+        })
+        |> Ash.create!()
+      end
+
+      # min_priority: 50 should return comments with priority >= 50
+      [result] =
+        Post
+        |> Ash.Query.for_read(:with_min_priority_comments, %{min_priority: 50})
+        |> Ash.Query.filter(id == ^post.id)
+        |> Ash.read!()
+
+      priorities =
+        result.comments_with_min_priority
+        |> Enum.map(& &1.priority)
+        |> Enum.sort()
+
+      assert priorities == [50, 90]
+    end
+
+    test "^arg in relationship filter changes results with different argument values" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "Test Post"})
+        |> Ash.create!()
+
+      for priority <- [10, 50, 90] do
+        Comment
+        |> Ash.Changeset.for_create(:create, %{
+          post_id: post.id,
+          content: "comment #{priority}",
+          priority: priority
+        })
+        |> Ash.create!()
+      end
+
+      # min_priority: 100 should return no comments
+      [result] =
+        Post
+        |> Ash.Query.for_read(:with_min_priority_comments, %{min_priority: 100})
+        |> Ash.Query.filter(id == ^post.id)
+        |> Ash.read!()
+
+      assert result.comments_with_min_priority == []
+
+      # min_priority: 1 should return all comments
+      [result] =
+        Post
+        |> Ash.Query.for_read(:with_min_priority_comments, %{min_priority: 1})
+        |> Ash.Query.filter(id == ^post.id)
+        |> Ash.read!()
+
+      assert length(result.comments_with_min_priority) == 3
+    end
   end
 
   describe "relationship offset and limit" do


### PR DESCRIPTION
The documentation for the `has_many.filter` dsl [mention](https://hexdocs.pm/ash/dsl-ash-resource.html#arguments-9) that it's possible to use `^arg()` template in filter queries. 
But the source action arguments are not added to the template so the `^arg(...)` always resovles to `nil`. 

Added a reproduction test in `test/actions/has_many_test.exs:553`.

Fixed it by passing the source_query.arguments to the `hydrate_refs` function. 
Not entirely sure if it's the best way to fix it. So let me know if another approach should be taken.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
