### PR TITLE
fix: propagate parent query's context.shared into aggregate authorization filters

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -3359,6 +3359,7 @@ defmodule Ash.Actions.Read do
 
         agg.query
         |> Ash.Query.set_context(%{private: %{require_actor?: false}})
+        |> Ash.Query.set_context(%{shared: opts[:source_context][:shared]})
         |> Ash.Query.for_read(read_action, %{},
           domain: domain,
           actor: actor,
@@ -3366,12 +3367,14 @@ defmodule Ash.Actions.Read do
           authorize?: agg.authorize? && authorize?
         )
       else
-        Ash.Query.set_context(agg.query, %{
+        agg.query
+        |> Ash.Query.set_context(%{
           private: %{
             authorize?: agg.authorize? && authorize?,
             actor: actor
           }
         })
+        |> Ash.Query.set_context(%{shared: opts[:source_context][:shared]})
       end
 
     authorize? =

--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -1100,14 +1100,21 @@ defmodule Ash.Filter do
          filters,
          last_relationship,
          domain,
-         _query,
+         query,
          actor,
          tenant,
          _refs,
          base_related_query \\ nil,
          _aggregate? \\ false
        ) do
-    case relationship_query(last_relationship, domain, actor, tenant, base_related_query) do
+    case relationship_query(
+           last_relationship,
+           domain,
+           actor,
+           tenant,
+           base_related_query,
+           %{shared: query.context[:shared]}
+         ) do
       %{errors: []} = related_query ->
         if filters[{last_relationship.source, last_relationship.name, related_query.action.name}] do
           {:cont, {:ok, filters}}
@@ -1176,6 +1183,8 @@ defmodule Ash.Filter do
          refs,
          authorize?
        ) do
+    shared = %{shared: query.context[:shared]}
+
     refs
     |> Enum.flat_map(fn {_path, refs} ->
       refs
@@ -1190,6 +1199,9 @@ defmodule Ash.Filter do
     |> Enum.concat(aggregates)
     |> Enum.filter(& &1.authorize?)
     |> Enum.reduce_while({:ok, path_filters}, fn aggregate, {:ok, filters} ->
+      aggregate_query = Ash.Query.set_context(aggregate.query, shared)
+      aggregate = %{aggregate | query: aggregate_query}
+
       if Map.get(aggregate, :related?, true) do
         aggregate.relationship_path
         |> :lists.droplast()
@@ -1211,13 +1223,14 @@ defmodule Ash.Filter do
               %{},
               actor: actor,
               tenant: tenant,
-              authorize?: authorize?
+              authorize?: authorize?,
+              context: shared
             ),
             true
           )
         end)
       else
-        case Ash.can(aggregate.query, actor,
+        case Ash.can(aggregate_query, actor,
                run_queries?: false,
                pre_flight?: false,
                alter_source?: true,
@@ -1490,7 +1503,7 @@ defmodule Ash.Filter do
     end
   end
 
-  defp relationship_query(relationship, domain, actor, tenant, base) do
+  defp relationship_query(relationship, domain, actor, tenant, base, source_context \\ %{}) do
     base_query = base || Ash.Query.new(relationship.destination)
     domain = relationship.domain || domain
 
@@ -1501,6 +1514,7 @@ defmodule Ash.Filter do
     query =
       relationship.destination
       |> Ash.Query.set_context(relationship.context)
+      |> Ash.Query.set_context(source_context)
       |> Ash.Query.sort(relationship.sort, prepend?: true)
 
     if query.__validated_for_action__ == action do
@@ -1510,7 +1524,8 @@ defmodule Ash.Filter do
         actor: actor,
         authorize?: true,
         tenant: tenant,
-        domain: domain
+        domain: domain,
+        context: source_context
       )
     end
   end

--- a/test/policy/context_shared_test.exs
+++ b/test/policy/context_shared_test.exs
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Policy.ContextSharedTest do
+  @moduledoc """
+  Verifies that a policy filter referencing `^context([:shared, ...])` resolves
+  against the *parent* query's shared context wherever a child resource is
+  authorized as a side effect of the parent read — direct reads, has_many
+  loads, and aggregates. Regression coverage for context.shared propagation
+  through the aggregate/relationship authorization path.
+  """
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  defmodule Child do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Ash.Test.Policy.ContextSharedTest.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:dept_id, :integer, allow_nil?: false, public?: true)
+      attribute(:amt, :integer, allow_nil?: false, public?: true)
+    end
+
+    relationships do
+      belongs_to(:parent, Ash.Test.Policy.ContextSharedTest.Parent,
+        public?: true,
+        allow_nil?: false
+      )
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    policies do
+      policy action_type(:read) do
+        authorize_if(expr(dept_id == ^context([:shared, :dept_id])))
+      end
+
+      policy action_type([:create, :update, :destroy]) do
+        authorize_if(always())
+      end
+    end
+  end
+
+  defmodule Parent do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Ash.Test.Policy.ContextSharedTest.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer]
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:dept_id, :integer, allow_nil?: false, public?: true)
+    end
+
+    relationships do
+      has_many(:children, Child)
+    end
+
+    aggregates do
+      sum(:children_total, :children, :amt) do
+        default(0)
+      end
+    end
+
+    calculations do
+      calculate(:has_any_child, :boolean, expr(exists(children, true)))
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    policies do
+      policy always() do
+        authorize_if(always())
+      end
+    end
+  end
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain
+
+    resources do
+      resource(Parent)
+      resource(Child)
+    end
+  end
+
+  describe "child policy referencing ^context([:shared, ...])" do
+    setup do
+      dept_id = 1
+      ash_opts = [context: %{shared: %{dept_id: dept_id}}, authorize?: true]
+
+      {:ok, parent} =
+        Parent
+        |> Ash.Changeset.for_create(:create, %{dept_id: dept_id})
+        |> Ash.create(authorize?: false)
+
+      {:ok, _matching_child} =
+        Child
+        |> Ash.Changeset.for_create(:create, %{
+          dept_id: dept_id,
+          amt: 11_000,
+          parent_id: parent.id
+        })
+        |> Ash.create(authorize?: false)
+
+      {:ok, _non_matching_child} =
+        Child
+        |> Ash.Changeset.for_create(:create, %{
+          dept_id: dept_id + 1,
+          amt: 999,
+          parent_id: parent.id
+        })
+        |> Ash.create(authorize?: false)
+
+      %{parent: parent, dept_id: dept_id, ash_opts: ash_opts}
+    end
+
+    test "direct read of child filters by context.shared", %{ash_opts: ash_opts} do
+      assert {:ok, [%Child{amt: 11_000}]} = Ash.read(Child, ash_opts)
+    end
+
+    test "has_many load on parent filters child by context.shared",
+         %{parent: parent, ash_opts: ash_opts} do
+      loaded = Ash.load!(parent, [:children], ash_opts)
+      assert [%Child{amt: 11_000}] = loaded.children
+    end
+
+    test "sum aggregate on parent applies context.shared to its source query",
+         %{parent: parent, ash_opts: ash_opts} do
+      loaded = Ash.load!(parent, [:children_total], ash_opts)
+      assert loaded.children_total == 11_000
+    end
+
+    test "parent filter referencing children applies context.shared to child policy",
+         %{parent: parent, ash_opts: ash_opts} do
+      [filtered] =
+        Parent
+        |> Ash.Query.filter(exists(children, amt == 11_000))
+        |> Ash.read!(ash_opts)
+
+      assert filtered.id == parent.id
+    end
+
+    # Pins the intentional aggregate-vs-calc divergence in the same setup.
+    # See "filter policies bypassed for calculations" in
+    # `test/policy/simple_test.exs` — calc paths bypass child read policies
+    # on purpose.
+    test "calculation referencing children diverges from aggregate (intentional bypass)",
+         %{parent: parent, ash_opts: ash_opts} do
+      loaded = Ash.load!(parent, [:children_total, :has_any_child], ash_opts)
+
+      assert loaded.children_total == 11_000
+      assert loaded.has_any_child == false
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

A child resource's read policy filter that references `^context([:shared, ...])` collapsed to "no rows" when evaluated inside
an aggregate's source query, even when the parent query carried a matching `context.shared`. Direct child reads and explicit `has_many` loads were unaffected — only the aggregate / `exists(...)` authorization paths dropped the parent's shared context.

```elixir
ash_opts = [context: %{shared: %{dept_id: 1}}, authorize?: true]

Ash.read!(Child, ash_opts)              # [%Child{dept_id: 1, amt: 11_000}]  ✓
Ash.load!(parent, [:children], ash_opts) # children: [%Child{dept_id: 1}]    ✓
Ash.load!(parent, [:children_total], ash_opts)
# Before: 0  | After: 11_000
```

## Root cause

When building the per-relationship path_filter map, ash constructs a fresh child query and asks the authorizer to alter it — but several call sites never forward the parent query's context:

- `Ash.Filter.relationship_query/5`
- `Ash.Filter.add_aggregate_path_authorization/9` (the fresh `Ash.Query.for_read(last_relationship.destination, …)`)
- `Ash.Actions.Read.add_calc_context/8` for `%Ash.Query.Aggregate{}`

`Ash.Policy.FilterCheck.try_strict_check/3` then calls `fill_template` against an empty `:shared`, `^context([:shared, :dept_id])` resolves to `nil`, and the policy filter degenerates to `dept_id == nil` — matching nothing.

## Fix

Forward only the `:shared` sub-map of the parent's context (not the whole `query.context`) through those three call sites. Scoping is deliberate: an earlier draft that forwarded the full context regressed nested relationship pagination in `test/actions/load_test.exs` by leaking lateral-join / parent-stack / accessing-from state into unrelated child queries.