### PR TITLE
fix: match `ci_string` join keys case-insensitively when loading `many_to_many` relationships

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -812,6 +812,17 @@ defmodule Ash.Actions.Read.Relationships do
       fn ->
         case Ash.Actions.Read.unpaginated_read(join_query, nil) do
           {:ok, join_records} ->
+            # Stitch the join map onto destination records by a comparable key,
+            # so types like ci_string match case-insensitively (as the non-join
+            # attach path does). `destination_ids` stays raw for the `in` filter.
+            to_key =
+              key_fn_for_type(
+                Ash.Resource.Info.attribute(
+                  relationship.destination,
+                  relationship.destination_attribute
+                ).type
+              ) || (& &1)
+
             {join_id_mapping, destination_ids} =
               Enum.reduce(join_records, {%{}, MapSet.new()}, fn join_record,
                                                                 {mapping, destination_ids} ->
@@ -826,7 +837,7 @@ defmodule Ash.Actions.Read.Relationships do
                 new_mapping =
                   Map.update(
                     mapping,
-                    destination_value,
+                    to_key.(destination_value),
                     [
                       source_value
                     ],
@@ -869,7 +880,9 @@ defmodule Ash.Actions.Read.Relationships do
                  {:ok,
                   Enum.flat_map(records, fn record ->
                     Enum.map(
-                      join_id_mapping[Map.get(record, relationship.destination_attribute)] || [],
+                      join_id_mapping[
+                        to_key.(Map.get(record, relationship.destination_attribute))
+                      ] || [],
                       fn lateral_join_source ->
                         Map.put(
                           record,

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -630,6 +630,9 @@ defmodule Ash.DataLayer.Ets do
         {:error, error}
 
       {:ok, root_data} ->
+        destination_type =
+          Ash.Resource.Info.attribute(query.resource, destination_attribute).type
+
         root_data
         |> Enum.reduce_while({:ok, []}, fn parent, {:ok, results} ->
           through_query
@@ -664,9 +667,11 @@ defmodule Ash.DataLayer.Ets do
                     Enum.flat_map(new_results, fn result ->
                       join_data
                       |> Enum.flat_map(fn join_row ->
-                        # TODO: use `Ash.Type.equal?`
-                        if Map.get(join_row, destination_attribute_on_join_resource) ==
-                             Map.get(result, destination_attribute) do
+                        if Ash.Type.equal?(
+                             destination_type,
+                             Map.get(join_row, destination_attribute_on_join_resource),
+                             Map.get(result, destination_attribute)
+                           ) do
                           [
                             Map.put(
                               result,

--- a/test/type/simple_equality_comparable_test.exs
+++ b/test/type/simple_equality_comparable_test.exs
@@ -42,6 +42,79 @@ defmodule Ash.Test.Type.SimpleEqualityComparableTest do
         destination_attribute: :parent_id,
         public?: true
       )
+
+      many_to_many :tags, Ash.Test.Type.SimpleEqualityComparableTest.Tag do
+        through(Ash.Test.Type.SimpleEqualityComparableTest.ParentTag)
+        source_attribute_on_join_resource(:parent_id)
+        destination_attribute_on_join_resource(:tag_id)
+        public?(true)
+      end
+    end
+  end
+
+  defmodule Tag do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults([:read, :destroy, create: :*, update: :*])
+
+      # Paginated read used to force the lateral-join attach path.
+      read :paginated do
+        pagination do
+          offset? true
+          default_limit 100
+          countable true
+        end
+      end
+    end
+
+    attributes do
+      attribute :id, :ci_string do
+        primary_key?(true)
+        allow_nil?(false)
+        public?(true)
+      end
+    end
+  end
+
+  defmodule ParentTag do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults([:read, :destroy, create: :*, update: :*])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    # A unique join makes the m2m eligible for the lateral-join path.
+    identities do
+      identity :unique_pair, [:parent_id, :tag_id], pre_check_with: Domain
+    end
+
+    relationships do
+      belongs_to :parent, Ash.Test.Type.SimpleEqualityComparableTest.Parent do
+        attribute_type(:ci_string)
+        public?(true)
+      end
+
+      belongs_to :tag, Ash.Test.Type.SimpleEqualityComparableTest.Tag do
+        attribute_type(:ci_string)
+        public?(true)
+      end
     end
   end
 
@@ -287,6 +360,60 @@ defmodule Ash.Test.Type.SimpleEqualityComparableTest do
       assert result["ALPHA"] == ["a1", "a2", "a3"]
       assert result["Beta"] == ["b1", "b2"]
       assert result["Gamma"] == []
+    end
+  end
+
+  describe "loading many_to_many across a CI string join key" do
+    setup do
+      for id <- ["Red", "Blue", "Green"] do
+        Tag
+        |> Ash.Changeset.for_create(:create, %{id: id})
+        |> Ash.create!()
+      end
+
+      for id <- ["ALPHA", "Beta"] do
+        Parent
+        |> Ash.Changeset.for_create(:create, %{id: id})
+        |> Ash.create!()
+      end
+
+      # Join rows whose parent_id and tag_id are cased differently from the
+      # records they reference — the m2m stitch must match case-insensitively.
+      for {parent_id, tag_id} <- [
+            {"alpha", "red"},
+            {"ALPHA", "BLUE"},
+            {"beta", "rEd"}
+          ] do
+        ParentTag
+        |> Ash.Changeset.for_create(:create, %{parent_id: parent_id, tag_id: tag_id})
+        |> Ash.create!()
+      end
+
+      :ok
+    end
+
+    test "separate-query attach path: stitches tags back onto parents regardless of case" do
+      parents = Parent |> Ash.read!() |> Ash.load!(:tags)
+
+      result =
+        Map.new(parents, fn parent ->
+          {to_string(parent.id), parent.tags |> Enum.map(&to_string(&1.id)) |> Enum.sort()}
+        end)
+
+      assert result == %{"ALPHA" => ["Blue", "Red"], "Beta" => ["Red"]}
+    end
+
+    test "lateral attach path: paginated tags stitch back to mixed-case parents" do
+      tags_query = Tag |> Ash.Query.for_read(:paginated) |> Ash.Query.page(limit: 100)
+      parents = Parent |> Ash.read!() |> Ash.load!(tags: tags_query)
+
+      result =
+        Map.new(parents, fn parent ->
+          %Ash.Page.Offset{results: results} = parent.tags
+          {to_string(parent.id), results |> Enum.map(&to_string(&1.id)) |> Enum.sort()}
+        end)
+
+      assert result == %{"ALPHA" => ["Blue", "Red"], "Beta" => ["Red"]}
     end
   end
 


### PR DESCRIPTION
When a `many_to_many` is loaded as separate queries, the join map was stitched onto destination records keyed on raw attribute values, so types whose `==` differs from their semantic equality (e.g. `ci_string`) were silently dropped. 

This now uses the same `simple_equality_comparable` functionality as `has_many` relationship attachment.

The ETS data layer's lateral-join path had the same latent bug (the final join-row match used raw `==`, flagged with a TODO); use `Ash.Type.equal?/3` there.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
