### PR TITLE
fix: preserve changeset context in `generate_many/2`

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -339,6 +339,9 @@ defmodule Ash.Generator do
         input,
         Map.to_list(changeset_opts)
       )
+      |> Ash.Changeset.set_context(%{
+        private: %{generator_context: Map.get(changeset_opts, :context, %{})}
+      })
       |> then(fn changeset ->
         if opts[:after_action] do
           Ash.Changeset.after_action(changeset, fn _changeset, record ->
@@ -823,7 +826,7 @@ defmodule Ash.Generator do
           authorize?: first.context[:private][:authorize?],
           tenant: first.tenant,
           tracer: first.context[:private][:tracer],
-          context: first.context
+          context: first.context[:private][:generator_context] || %{}
         ]
 
         opts =

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -823,7 +823,7 @@ defmodule Ash.Generator do
           authorize?: first.context[:private][:authorize?],
           tenant: first.tenant,
           tracer: first.context[:private][:tracer],
-          context: Map.delete(first.context, :private)
+          context: first.context
         ]
 
         opts =

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -822,7 +822,8 @@ defmodule Ash.Generator do
           actor: first.context[:private][:actor],
           authorize?: first.context[:private][:authorize?],
           tenant: first.tenant,
-          tracer: first.context[:private][:tracer]
+          tracer: first.context[:private][:tracer],
+          context: Map.delete(first.context, :private)
         ]
 
         opts =

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -235,6 +235,47 @@ defmodule Ash.Test.GeneratorTest do
     end
   end
 
+  defmodule ScopedThing do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      create :create do
+        accept [:name]
+
+        change fn changeset, _ctx ->
+          case changeset.context[:shared][:scope_id] do
+            nil ->
+              Ash.Changeset.add_error(changeset, "scope_id missing from context.shared")
+
+            scope_id ->
+              Ash.Changeset.force_change_attribute(changeset, :scope_id, scope_id)
+          end
+        end
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :name, :string do
+        public?(true)
+        allow_nil? false
+      end
+
+      attribute :scope_id, :integer do
+        public?(true)
+      end
+    end
+  end
+
   defmodule ActionOverrides do
     @moduledoc false
     use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
@@ -386,6 +427,14 @@ defmodule Ash.Test.GeneratorTest do
         overrides: opts
       )
     end
+
+    def scoped_thing(opts \\ []) do
+      changeset_generator(ScopedThing, :create,
+        defaults: [name: sequence(:name, &"Thing #{&1}")],
+        context: %{shared: %{scope_id: 42}},
+        overrides: opts
+      )
+    end
   end
 
   setup do
@@ -403,6 +452,15 @@ defmodule Ash.Test.GeneratorTest do
       import Generator
       assert [%Post{title: "Post 0"}, %Post{title: "Post 1"}] = generate_many(post(), 2)
       assert [%Post{title: "Post 2"}, %Post{title: "Post 3"}] = generate_many(seed_post(), 2)
+    end
+
+    test "generate_many preserves the changeset context (including context.shared) like generate" do
+      import Generator
+
+      assert %ScopedThing{scope_id: 42} = generate(scoped_thing())
+
+      assert [%ScopedThing{scope_id: 42}, %ScopedThing{scope_id: 42}, %ScopedThing{scope_id: 42}] =
+               generate_many(scoped_thing(), 3)
     end
 
     test "after_action works with generate" do

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -251,12 +251,21 @@ defmodule Ash.Test.GeneratorTest do
         accept [:name]
 
         change fn changeset, _ctx ->
-          case changeset.context[:shared][:scope_id] do
-            nil ->
-              Ash.Changeset.add_error(changeset, "scope_id missing from context.shared")
+          changeset =
+            case changeset.context[:shared][:scope_id] do
+              nil ->
+                Ash.Changeset.add_error(changeset, "scope_id missing from context.shared")
 
-            scope_id ->
-              Ash.Changeset.force_change_attribute(changeset, :scope_id, scope_id)
+              scope_id ->
+                Ash.Changeset.force_change_attribute(changeset, :scope_id, scope_id)
+            end
+
+          case changeset.context[:private][:custom] do
+            nil ->
+              Ash.Changeset.add_error(changeset, "custom missing from context.private")
+
+            custom ->
+              Ash.Changeset.force_change_attribute(changeset, :custom, custom)
           end
         end
       end
@@ -271,6 +280,10 @@ defmodule Ash.Test.GeneratorTest do
       end
 
       attribute :scope_id, :integer do
+        public?(true)
+      end
+
+      attribute :custom, :string do
         public?(true)
       end
     end
@@ -431,7 +444,7 @@ defmodule Ash.Test.GeneratorTest do
     def scoped_thing(opts \\ []) do
       changeset_generator(ScopedThing, :create,
         defaults: [name: sequence(:name, &"Thing #{&1}")],
-        context: %{shared: %{scope_id: 42}},
+        context: %{shared: %{scope_id: 42}, private: %{custom: "kept"}},
         overrides: opts
       )
     end
@@ -454,13 +467,16 @@ defmodule Ash.Test.GeneratorTest do
       assert [%Post{title: "Post 2"}, %Post{title: "Post 3"}] = generate_many(seed_post(), 2)
     end
 
-    test "generate_many preserves the changeset context (including context.shared) like generate" do
+    test "generate_many preserves the changeset context (shared and custom private) like generate" do
       import Generator
 
-      assert %ScopedThing{scope_id: 42} = generate(scoped_thing())
+      assert %ScopedThing{scope_id: 42, custom: "kept"} = generate(scoped_thing())
 
-      assert [%ScopedThing{scope_id: 42}, %ScopedThing{scope_id: 42}, %ScopedThing{scope_id: 42}] =
-               generate_many(scoped_thing(), 3)
+      assert [
+               %ScopedThing{scope_id: 42, custom: "kept"},
+               %ScopedThing{scope_id: 42, custom: "kept"},
+               %ScopedThing{scope_id: 42, custom: "kept"}
+             ] = generate_many(scoped_thing(), 3)
     end
 
     test "after_action works with generate" do

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -251,6 +251,14 @@ defmodule Ash.Test.GeneratorTest do
         accept [:name]
 
         change fn changeset, _ctx ->
+          # Record whatever `marker` this changeset *started* with, then set a
+          # marker tailored to this specific changeset. If `generate_many/2`
+          # forwarded the whole changeset context (post-change) instead of only
+          # the context provided to the generator, the first record's marker
+          # would leak into every record's `seen_marker`.
+          seen_marker = changeset.context[:shared][:marker]
+          name = Ash.Changeset.get_attribute(changeset, :name)
+
           changeset =
             case changeset.context[:shared][:scope_id] do
               nil ->
@@ -260,13 +268,18 @@ defmodule Ash.Test.GeneratorTest do
                 Ash.Changeset.force_change_attribute(changeset, :scope_id, scope_id)
             end
 
-          case changeset.context[:private][:custom] do
-            nil ->
-              Ash.Changeset.add_error(changeset, "custom missing from context.private")
+          changeset =
+            case changeset.context[:private][:custom] do
+              nil ->
+                Ash.Changeset.add_error(changeset, "custom missing from context.private")
 
-            custom ->
-              Ash.Changeset.force_change_attribute(changeset, :custom, custom)
-          end
+              custom ->
+                Ash.Changeset.force_change_attribute(changeset, :custom, custom)
+            end
+
+          changeset
+          |> Ash.Changeset.force_change_attribute(:seen_marker, seen_marker)
+          |> Ash.Changeset.set_context(%{shared: %{marker: name}})
         end
       end
     end
@@ -284,6 +297,10 @@ defmodule Ash.Test.GeneratorTest do
       end
 
       attribute :custom, :string do
+        public?(true)
+      end
+
+      attribute :seen_marker, :string do
         public?(true)
       end
     end
@@ -467,15 +484,19 @@ defmodule Ash.Test.GeneratorTest do
       assert [%Post{title: "Post 2"}, %Post{title: "Post 3"}] = generate_many(seed_post(), 2)
     end
 
-    test "generate_many preserves the changeset context (shared and custom private) like generate" do
+    test "generate_many forwards only the generator's context, like generate" do
       import Generator
 
-      assert %ScopedThing{scope_id: 42, custom: "kept"} = generate(scoped_thing())
+      # `scope_id`/`custom` confirm the provided context (shared + private) is
+      # carried over; `seen_marker: nil` confirms a change-set, per-changeset
+      # context is NOT leaked from the first record onto the rest of the batch.
+      assert %ScopedThing{scope_id: 42, custom: "kept", seen_marker: nil} =
+               generate(scoped_thing())
 
       assert [
-               %ScopedThing{scope_id: 42, custom: "kept"},
-               %ScopedThing{scope_id: 42, custom: "kept"},
-               %ScopedThing{scope_id: 42, custom: "kept"}
+               %ScopedThing{scope_id: 42, custom: "kept", seen_marker: nil},
+               %ScopedThing{scope_id: 42, custom: "kept", seen_marker: nil},
+               %ScopedThing{scope_id: 42, custom: "kept", seen_marker: nil}
              ] = generate_many(scoped_thing(), 3)
     end
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

`generate_many/2` routed through `Ash.bulk_create!` but only forwarded a few `context[:private]` keys, dropping the user-supplied changeset `:context` (including `context.shared`). This made it diverge from `generate/1`, which preserves context — create-time changes reading `changeset.context` would see it empty under `generate_many/2`.

Forward the non-private context to `Ash.bulk_create!`, which merges it into each changeset. Added a regression test covering the divergence.
