### PR TITLE
Allow partial identity join sorting

### DIFF
--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -2056,14 +2056,81 @@ defmodule Ash.Actions.Read.Relationships do
 
     is_unique_on_join_keys? =
       Enum.any?(Ash.Resource.Info.identities(relationship.through), fn identity ->
-        is_nil(identity.where) && identity.nils_distinct? &&
-          Enum.all?(identity.keys, &(&1 in join_keys))
+        Enum.all?(identity.keys, &(&1 in join_keys)) &&
+          identity_where_matches_join_keys?(identity, join_keys)
       end)
 
     not (primary_key_is_join_keys? || is_unique_on_join_keys?)
   end
 
   defp is_many_to_many_not_unique_on_join?(_, _, _), do: false
+
+  defp identity_where_matches_join_keys?(%{where: nil} = identity, _join_keys) do
+    identity.nils_distinct?
+  end
+
+  defp identity_where_matches_join_keys?(%{where: where, keys: keys}, join_keys) do
+    case join_key_non_nil_refs(where, join_keys) do
+      {:ok, refs} ->
+        Enum.all?(keys, &(&1 in refs))
+
+      :error ->
+        false
+    end
+  end
+
+  defp join_key_non_nil_refs(
+         %Ash.Query.BooleanExpression{op: :and, left: left, right: right},
+         join_keys
+       ) do
+    with {:ok, left_refs} <- join_key_non_nil_refs(left, join_keys),
+         {:ok, right_refs} <- join_key_non_nil_refs(right, join_keys) do
+      {:ok, Enum.uniq(left_refs ++ right_refs)}
+    end
+  end
+
+  defp join_key_non_nil_refs(expr, join_keys) do
+    case non_nil_ref_name(expr) do
+      {:ok, name} ->
+        non_nil_join_key_ref(name, join_keys)
+
+      :error ->
+        :error
+    end
+  end
+
+  defp non_nil_ref_name(%Ash.Query.Operator.IsNil{left: ref, right: false}) do
+    ref_name(ref)
+  end
+
+  defp non_nil_ref_name(%Ash.Query.Not{
+         expression: %Ash.Query.Call{name: :is_nil, args: [ref]}
+       }) do
+    ref_name(ref)
+  end
+
+  defp non_nil_ref_name(%Ash.Query.Not{
+         expression: %Ash.Query.Operator.IsNil{left: ref, right: true}
+       }) do
+    ref_name(ref)
+  end
+
+  defp non_nil_ref_name(_), do: :error
+
+  defp ref_name(%Ash.Query.Ref{relationship_path: [], attribute: %{name: name}}), do: {:ok, name}
+
+  defp ref_name(%Ash.Query.Ref{relationship_path: [], attribute: name}) when is_atom(name),
+    do: {:ok, name}
+
+  defp ref_name(_), do: :error
+
+  defp non_nil_join_key_ref(name, join_keys) do
+    if name in join_keys do
+      {:ok, [name]}
+    else
+      :error
+    end
+  end
 
   # Returns a function that converts a value of `type` into a term safe for use
   # as a Map key (i.e. comparable with `==`). Callers use this to build O(n+m)

--- a/lib/ash/actions/read/relationships.ex
+++ b/lib/ash/actions/read/relationships.ex
@@ -2057,7 +2057,7 @@ defmodule Ash.Actions.Read.Relationships do
     is_unique_on_join_keys? =
       Enum.any?(Ash.Resource.Info.identities(relationship.through), fn identity ->
         Enum.all?(identity.keys, &(&1 in join_keys)) &&
-          identity_where_matches_join_keys?(identity, join_keys)
+          identity_where_safe_for_join_keys?(identity.where, join_keys)
       end)
 
     not (primary_key_is_join_keys? || is_unique_on_join_keys?)
@@ -2065,37 +2065,23 @@ defmodule Ash.Actions.Read.Relationships do
 
   defp is_many_to_many_not_unique_on_join?(_, _, _), do: false
 
-  defp identity_where_matches_join_keys?(%{where: nil} = identity, _join_keys) do
-    identity.nils_distinct?
-  end
+  defp identity_where_safe_for_join_keys?(nil, _join_keys), do: true
 
-  defp identity_where_matches_join_keys?(%{where: where, keys: keys}, join_keys) do
-    case join_key_non_nil_refs(where, join_keys) do
-      {:ok, refs} ->
-        Enum.all?(keys, &(&1 in refs))
-
-      :error ->
-        false
-    end
-  end
-
-  defp join_key_non_nil_refs(
+  defp identity_where_safe_for_join_keys?(
          %Ash.Query.BooleanExpression{op: :and, left: left, right: right},
          join_keys
        ) do
-    with {:ok, left_refs} <- join_key_non_nil_refs(left, join_keys),
-         {:ok, right_refs} <- join_key_non_nil_refs(right, join_keys) do
-      {:ok, Enum.uniq(left_refs ++ right_refs)}
-    end
+    identity_where_safe_for_join_keys?(left, join_keys) &&
+      identity_where_safe_for_join_keys?(right, join_keys)
   end
 
-  defp join_key_non_nil_refs(expr, join_keys) do
+  defp identity_where_safe_for_join_keys?(expr, join_keys) do
     case non_nil_ref_name(expr) do
       {:ok, name} ->
-        non_nil_join_key_ref(name, join_keys)
+        name in join_keys
 
       :error ->
-        :error
+        false
     end
   end
 
@@ -2123,14 +2109,6 @@ defmodule Ash.Actions.Read.Relationships do
     do: {:ok, name}
 
   defp ref_name(_), do: :error
-
-  defp non_nil_join_key_ref(name, join_keys) do
-    if name in join_keys do
-      {:ok, [name]}
-    else
-      :error
-    end
-  end
 
   # Returns a function that converts a value of `type` into a term safe for use
   # as a Map key (i.e. comparable with `==`). Callers use this to build O(n+m)


### PR DESCRIPTION
## Summary

Allows `many_to_many` relationship sorting through `parent(join_relationship.field)` when the join resource has a partial identity that proves the join keys are non-nil.

Previously, Ash only treated join keys as unique when they matched the primary key or a non-partial identity. This rejected valid polymorphic join resources like:

```elixir
relationships do
  belongs_to :post, Post, allow_nil?: true
  belongs_to :comment, Comment, allow_nil?: true
  belongs_to :user, User, allow_nil?: true
  belongs_to :staff_group, StaffGroup, allow_nil?: true
end

identities do
  identity :post_user, [:post_id, :user_id],
    where: expr(not is_nil(post_id) and not is_nil(user_id))
end
```

In that example, the partial identity still guarantees a single join row for each post/user pair when both join keys are present. That makes sorting by a join attribute safe:

```elixir
many_to_many :sorted_notification_users, User do
  through NotificationRecipient
  join_relationship :user_notification_recipients
  source_attribute_on_join_resource :post_id
  destination_attribute_on_join_resource :user_id
  sort [expr_sort(parent(user_notification_recipients.order), :integer)]
end
```

## Notes

A regression test is being added in `ash_postgres` with this polymorphic join resource shape.
  
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
