### PR TITLE
Make attribute_in delegate to one_of (#1713)

### DIFF
--- a/lib/ash/resource/validation/attribute_in.ex
+++ b/lib/ash/resource/validation/attribute_in.ex
@@ -2,8 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 
+# remove in 4.0
 defmodule Ash.Resource.Validation.AttributeIn do
-  @moduledoc false
+  @moduledoc """
+  Deprecated. Use `Ash.Resource.Validation.OneOf` via `one_of/2` in `Ash.Resource.Validation.Builtins`.
+
+  This module remains for compatibility with references in DSL extensions and other code.
+  """
 
   @opt_schema [
     attribute: [

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -139,7 +139,9 @@ defmodule Ash.Resource.Validation.Builtins do
   end
 
   @doc """
-  Validates that an attribute is being changed to one of a set of specific values, or is in the the given list if it is not being changed.
+  Deprecated. Use `one_of/2` instead.
+
+  Delegates to `one_of/2` for backwards compatibility.
 
   ## Examples
 
@@ -150,7 +152,7 @@ defmodule Ash.Resource.Validation.Builtins do
   """
   @spec attribute_in(attribute :: atom, list :: [term]) :: Validation.ref()
   def attribute_in(attribute, list) do
-    {Validation.AttributeIn, attribute: attribute, list: list}
+    one_of(attribute, list)
   end
 
   @doc """

--- a/test/actions/validation_test.exs
+++ b/test/actions/validation_test.exs
@@ -176,6 +176,50 @@ defmodule Ash.Test.Actions.ValidationTest do
     end
   end
 
+  describe "attribute_in" do
+    defmodule AttributeInProfile do
+      @moduledoc false
+      use Ash.Resource,
+        domain: Domain,
+        data_layer: Ash.DataLayer.Ets
+
+      ets do
+        private? true
+      end
+
+      actions do
+        default_accept :*
+        defaults [:read, :destroy, create: :*, update: :*]
+      end
+
+      validations do
+        validate attribute_in(:status, ["foo", "bar"])
+      end
+
+      attributes do
+        uuid_primary_key :id
+
+        attribute :status, :string do
+          public?(true)
+        end
+      end
+    end
+
+    test "it succeeds if the value is in the list" do
+      AttributeInProfile
+      |> Ash.Changeset.for_create(:create, %{status: "foo"})
+      |> Ash.create!()
+    end
+
+    test "it fails if the value is not in the list" do
+      assert_raise(Ash.Error.Invalid, ~r/expected one of \"foo, bar\"/, fn ->
+        AttributeInProfile
+        |> Ash.Changeset.for_create(:create, %{status: "blart"})
+        |> Ash.create!()
+      end)
+    end
+  end
+
   describe "data_one_of" do
     defmodule StatusResource do
       @moduledoc false


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies



Fixes #1713

## Summary
- Delegate `attribute_in/2` to `one_of/2` in `Ash.Resource.Validation.Builtins`
- Document `Ash.Resource.Validation.AttributeIn` as deprecated with a remove-in-4.0 note (per @zachdaniel's feedback on the issue)
- Add tests for `attribute_in` mirroring basic `one_of` behavior

## Test plan
- [x] `mix test test/actions/validation_test.exs --only describe:"attribute_in"`
- [x] `mix check`
