### PR TITLE
docs: `Ash.Generator.sequence` does not generate globally unique values

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -543,7 +543,7 @@ defmodule Ash.Generator do
   end
 
   @doc """
-  Generate globally unique values.
+  Generate sequential unique values.
 
   This is useful for generating values that are unique within a given test or processes that it spawns, such as email addresses,
   or for generating values that are unique across a single resource, such as identifiers. The values will be unique
@@ -554,7 +554,8 @@ defmodule Ash.Generator do
   > that will be the test. In the rare case where you are running async processes that need to share a sequence
   > that is not created in the test process, you can initialize a sequence in the test using `initialize_sequence/1`.
   >
-  > If you need a globally unique value, use a value like `System.unique_integer([:positive])` in your values instead.
+  > If you need a globally unique value, for example to satisfy a unique database constraint, use a value
+  > like `System.unique_integer([:positive])` instead.
   >
   > For example:
   >


### PR DESCRIPTION
<img width="874" height="458" alt="Screenshot 2026-06-12 at 3 45 22 pm" src="https://github.com/user-attachments/assets/f80813df-379e-4923-b346-64319452454c" />

Fixing this fun gotcha ☝️ 

And there are cases where you need globally unique values, such as for values used in database unique constraints (which are checked outside the scope of a transaction in PostgreSQL). Got a bunch of PostgreSQL deadlocks when running my test suite that led me to find this!

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
