### PR TITLE
relate_actor with field: raises BadMapError for belongs_to relationships

### DIFF
--- a/lib/ash/resource/change/relate_actor.ex
+++ b/lib/ash/resource/change/relate_actor.ex
@@ -73,7 +73,7 @@ defmodule Ash.Resource.Change.RelateActor do
         Changeset.force_change_attribute(
           changeset,
           relationship.source_attribute,
-          Map.get(actor, relationship.destination_attribute)
+          resolve_fk_value(actor, relationship)
         )
         |> Changeset.after_action(fn _changeset, record ->
           {:ok, Map.put(record, relationship.name, actor)}
@@ -106,7 +106,7 @@ defmodule Ash.Resource.Change.RelateActor do
       actor when relationship.type == :belongs_to ->
         {:atomic,
          %{
-           relationship.source_attribute => Map.get(actor, relationship.destination_attribute)
+           relationship.source_attribute => resolve_fk_value(actor, relationship)
          }}
 
       _ ->
@@ -129,6 +129,15 @@ defmodule Ash.Resource.Change.RelateActor do
       """
     end
   end
+
+  # When `field:` is used, `resolve_actor/2` may return a scalar value
+  # (e.g. a UUID string) rather than a map/struct. In that case, use
+  # the value directly as the FK instead of extracting destination_attribute.
+  defp resolve_fk_value(actor, relationship) when is_map(actor) do
+    Map.get(actor, relationship.destination_attribute)
+  end
+
+  defp resolve_fk_value(actor, _relationship), do: actor
 
   defp resolve_actor(actor, opts) do
     field = opts[:field]

--- a/test/resource/changes/relate_actor_test.exs
+++ b/test/resource/changes/relate_actor_test.exs
@@ -90,6 +90,10 @@ defmodule Ash.Test.Resource.Changes.RelateActorTest do
       create :create_possibly_without_actor do
         change relate_actor(:author, allow_nil?: true)
       end
+
+      create :create_with_actor_scalar_field do
+        change relate_actor(:author, field: :author_id)
+      end
     end
   end
 
@@ -349,6 +353,26 @@ defmodule Ash.Test.Resource.Changes.RelateActorTest do
       |> Ash.create!()
 
     assert post.account_id == account.id
+  end
+
+  test "relate_actor change with field extracting a scalar value" do
+    # When field: extracts a scalar (e.g. a UUID string) rather than a
+    # related record struct, the belongs_to branch should use the scalar
+    # directly as the FK value instead of calling Map.get on it.
+    author =
+      Author
+      |> Ash.Changeset.for_create(:create)
+      |> Ash.create!()
+
+    # Use a plain map as actor where :author_id is a raw UUID string
+    actor = %{author_id: author.id}
+
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create_with_actor_scalar_field, %{text: "foo"}, actor: actor)
+      |> Ash.create!()
+
+    assert post.author_id == author.id
   end
 
   test "relate_actor change with field when field is nil" do


### PR DESCRIPTION
## issue

relate_actor(:relationship, field: :some_field) raises BadMapError when used with a belongs_to relationship and the field: value resolves to a scalar (e.g. a UUID string) rather than a related record struct.

## reproduction

```elixir
# Actor is a map/struct where :user_id is a raw UUID string
actor = %{user_id: "some-uuid-matching-a-user-id"}
Post
|> Ash.Changeset.for_create(:create, %{title: "Hello"}, actor: actor)
|> Ash.create!()
# => ** (BadMapError) expected a map, got: "some-uuid-matching-a-user-id"
```

Where the Post resource has:

```elixir
belongs_to :creator, User do
  source_attribute :created_by
end

create :create do
  change relate_actor(:creator, field: :user_id)
end
```
