### PR TITLE
fix: ensure modules are loaded before optional callback checks

### DIFF
--- a/lib/ash/notifier/notifier.ex
+++ b/lib/ash/notifier/notifier.ex
@@ -93,7 +93,7 @@ defmodule Ash.Notifier do
     notifier_statements =
       Enum.reduce(notifiers, %{}, fn notifier, acc ->
         statement =
-          if function_exported?(notifier, :load, 2) do
+          if implements_load?(notifier) do
             load(notifier, resource, action)
           else
             []
@@ -145,7 +145,7 @@ defmodule Ash.Notifier do
     notifier_statements =
       Enum.reduce(notifiers, %{}, fn notifier, acc ->
         statement =
-          if function_exported?(notifier, :load, 2) do
+          if implements_load?(notifier) do
             load(notifier, resource, action)
           else
             []
@@ -223,6 +223,13 @@ defmodule Ash.Notifier do
     |> List.flatten()
   end
 
+  # `function_exported?/3` does not load the module, so in interactive-mode
+  # VMs (dev, test) a notifier that has not been called yet would silently
+  # report no `load/2` and its dependencies would never be loaded.
+  defp implements_load?(notifier) do
+    Code.ensure_loaded?(notifier) and function_exported?(notifier, :load, 2)
+  end
+
   # Checks if the record already has NotifierDependencies calculations loaded
   # (meaning the action pipeline pre-loaded them).
   defp has_preloaded_notifier_data?(data) when is_struct(data) do
@@ -249,7 +256,7 @@ defmodule Ash.Notifier do
     notifier_statements =
       Enum.reduce(notifiers, %{}, fn notifier, acc ->
         statement =
-          if function_exported?(notifier, :load, 2) do
+          if implements_load?(notifier) do
             load(notifier, notification.resource, notification.action)
           else
             []

--- a/lib/ash/test.ex
+++ b/lib/ash/test.ex
@@ -88,6 +88,7 @@ defmodule Ash.Test do
     match
   end
 
+  @spec no_errors(Ash.Error.class_module() | nil) :: no_return
   defp no_errors(error_class) do
     message =
       if error_class do

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -1702,7 +1702,10 @@ defmodule Ash.Type do
   end
 
   defp splice_with_type(type, values, callback) do
-    if function_exported?(type, :splice_nil_values, 2) do
+    # `function_exported?/3` does not load the module; without ensuring the
+    # type module is loaded, its `splice_nil_values/2` override would be
+    # silently skipped (e.g. keyword values flattened by the default).
+    if Code.ensure_loaded?(type) and function_exported?(type, :splice_nil_values, 2) do
       type.splice_nil_values(values, callback)
     else
       splicing_nil_values(values, callback)

--- a/test/notifier/pubsub_test.exs
+++ b/test/notifier/pubsub_test.exs
@@ -241,6 +241,38 @@ defmodule Ash.Test.Notifier.PubSubTest do
     end
   end
 
+  defmodule LazilyNotifiedPost do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      notifiers: [Ash.Test.Support.LazyNotifier]
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      defaults [:read]
+
+      create :create do
+        accept :*
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+
+      attribute :name, :string do
+        public?(true)
+      end
+    end
+
+    calculations do
+      calculate :shout, :string, expr(name <> "!")
+    end
+  end
+
   setup do
     Application.put_env(PubSub, :notifier_test_pid, self())
 
@@ -541,6 +573,24 @@ defmodule Ash.Test.Notifier.PubSubTest do
 
       assert data.name == "charlie",
              "Expected name to be loaded via PubSub load but got: #{inspect(data.name)}"
+    end
+  end
+
+  describe "notifier load/2 when the notifier module is not yet loaded" do
+    test "dependencies are still loaded" do
+      # Simulates a freshly started interactive-mode VM (dev, test) where the
+      # notifier module has not been called - and therefore not loaded - yet.
+      # `function_exported?/3` alone reports false for unloaded modules.
+      :code.purge(Ash.Test.Support.LazyNotifier)
+      :code.delete(Ash.Test.Support.LazyNotifier)
+      refute :erlang.module_loaded(Ash.Test.Support.LazyNotifier)
+
+      LazilyNotifiedPost
+      |> Ash.Changeset.for_create(:create, %{name: "lazy"})
+      |> Ash.create!()
+
+      assert_receive {:lazy_notify, %Ash.Notifier.Notification{data: data}}
+      assert %{shout: "lazy!"} = data.calculations
     end
   end
 end

--- a/test/support/lazy_notifier.ex
+++ b/test/support/lazy_notifier.ex
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Support.LazyNotifier do
+  @moduledoc """
+  Notifier used to test that `load/2` dependencies are honored even when the
+  notifier module has not been loaded yet. Lives in test/support (compiled to
+  disk) so tests can `:code.delete/1` it and the VM can load it again.
+  """
+  use Ash.Notifier
+
+  def load(_resource, _action), do: [:shout]
+
+  def notify(notification) do
+    send(
+      Application.get_env(Ash.Test.Notifier.PubSubTest.PubSub, :notifier_test_pid),
+      {:lazy_notify, notification}
+    )
+  end
+end

--- a/test/type/composite_load_lazy_module_test.exs
+++ b/test/type/composite_load_lazy_module_test.exs
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Type.CompositeLoadLazyModuleTest do
+  @moduledoc false
+  # async: false — purges Ash.Type.Keyword to simulate a VM where the module
+  # has not been loaded yet (e.g. any `mix test` run where nothing compiles
+  # in-VM, so modules load lazily on first call).
+  use ExUnit.Case, async: false
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule NestedDoc do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: :embedded
+
+    attributes do
+      uuid_primary_key :id, writable?: true
+      attribute :note, :string, public?: true
+    end
+
+    actions do
+      defaults [:read]
+    end
+  end
+
+  test "keyword values keep their shape when Ash.Type.Keyword is not loaded yet" do
+    :code.purge(Ash.Type.Keyword)
+    :code.delete(Ash.Type.Keyword)
+    refute :erlang.module_loaded(Ash.Type.Keyword)
+
+    constraints = [
+      fields: [
+        nested: [type: :struct, constraints: [instance_of: NestedDoc]]
+      ]
+    ]
+
+    values = [[nested: %NestedDoc{id: Ash.UUID.generate(), note: "hello"}]]
+    context = %{domain: Domain, actor: nil, tenant: nil, tracer: nil, authorize?: false}
+
+    {:ok, [loaded]} = Ash.Type.load(Ash.Type.Keyword, values, nil, constraints, context)
+
+    assert Keyword.keyword?(loaded)
+    assert %NestedDoc{note: "hello"} = loaded[:nested]
+  end
+end


### PR DESCRIPTION

This PR fixes a bug that would prevent executing the `load/2` callback when module is lazily loaded (usually dev/tests environments). It is done by doing `Code.ensure_loaded?/1` before checking that the load function is exported

-----AI BELOW------

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2752
Fixes #2755

Two sites where an optional-callback check uses `function_exported?/3` without ensuring the module is loaded, so in interactive-mode VMs (dev, test — anywhere modules load lazily) the callback is silently skipped:

1. **Notifier `load/2`** (#2752): notifier dependencies are never loaded; most visibly, the first notification after VM start loses calc-transform payloads (`transform: :some_calc`), broadcasting nil. Fixed with a `Code.ensure_loaded?/1` guard shared by the three call sites. The regression test unloads a purpose-built notifier (placed in `test/support` so the VM can reload it from disk after `:code.delete/1` — modules defined inside test files cannot be reloaded) and asserts its `load/2` dependencies still arrive.

2. **`splice_nil_values/2`** (#2755): `Ash.Type.Keyword`'s override is missed and keyword values get flattened by the default implementation. Reproducible on main without this PR by running `mix test test/type/composite_load_test.exs` twice from a clean build — the first run passes because compiling in-VM loads every module, the second fails. This is also what the SimpleSat `mix test` leg of this PR's first CI run hit (restored build cache → lazy loading); the regression test purges `Ash.Type.Keyword` and asserts keyword shape is preserved.

Both regression tests fail without their lib change. Full suite passes locally (3572 tests, 0 failures). The `mix dialyzer` failures in CI are pre-existing — they fail identically on main's latest runs and the logs contain no mention of the files touched here.

_Prepared with AI assistance (Claude); reproduced, both fixes verified red/green against main, vetted by me._
