### PR TITLE
fix: respect actor from scope: in bulk actions under require_actor?

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -10,6 +10,7 @@ defmodule Ash.Actions.Create.Bulk do
   @spec run(Ash.Domain.t(), Ash.Resource.t(), atom(), Enumerable.t(map), Keyword.t()) ::
           Ash.BulkResult.t()
   def run(domain, resource, action_name, inputs, opts) do
+    opts = Ash.Actions.Helpers.apply_scope_to_opts(opts)
     action = Ash.Resource.Info.action(resource, action_name)
 
     opts =

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -61,6 +61,7 @@ defmodule Ash.Actions.Destroy.Bulk do
   end
 
   def run(domain, %Ash.Query{} = query, action, input, opts, not_atomic_reason) do
+    opts = Ash.Actions.Helpers.apply_scope_to_opts(opts)
     action_name = action.name
 
     Ash.Tracer.span :bulk_destroy,
@@ -455,6 +456,7 @@ defmodule Ash.Actions.Destroy.Bulk do
   end
 
   def run(domain, stream, action, input, opts, not_atomic_reason) do
+    opts = Ash.Actions.Helpers.apply_scope_to_opts(opts)
     resource = opts[:resource]
 
     opts = select(opts, resource)

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -18,6 +18,7 @@ defmodule Ash.Actions.Update.Bulk do
   end
 
   def run(domain, %Ash.Query{} = query, action, input, opts, not_atomic_reason) do
+    opts = Ash.Actions.Helpers.apply_scope_to_opts(opts)
     action_name = if is_atom(action), do: action, else: action.name
 
     span_type =
@@ -474,6 +475,7 @@ defmodule Ash.Actions.Update.Bulk do
   end
 
   def run(domain, stream, action, input, opts, not_atomic_reason) do
+    opts = Ash.Actions.Helpers.apply_scope_to_opts(opts)
     resource = opts[:resource]
 
     opts = set_strategy(opts, resource, Keyword.get(opts, :input_was_stream?, true))

--- a/lib/ash/actions/update/update_many.ex
+++ b/lib/ash/actions/update/update_many.ex
@@ -32,7 +32,7 @@ defmodule Ash.Actions.Update.UpdateMany do
   def run(domain, resource, action, inputs, opts) do
     action = get_action!(resource, action)
     pkey = Ash.Resource.Info.primary_key(resource)
-    opts = Keyword.put(opts, :domain, domain)
+    opts = Ash.Actions.Helpers.apply_scope_to_opts(opts) |> Keyword.put(:domain, domain)
     strategy = List.wrap(opts[:strategy] || [:atomic_batches])
     changeset_opts = changeset_opts(domain, opts)
 

--- a/test/scope_test.exs
+++ b/test/scope_test.exs
@@ -43,6 +43,42 @@ defmodule Ash.ScopeTest do
     end
   end
 
+  defmodule RequireActorDomain do
+    use Ash.Domain, validate_config_inclusion?: false
+
+    authorization do
+      require_actor? true
+      authorize :when_requested
+    end
+
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  defmodule Post do
+    use Ash.Resource, domain: RequireActorDomain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      defaults [:read, :destroy, create: [:title]]
+
+      update :publish do
+        accept []
+        change set_attribute(:published, true)
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, public?: true
+      attribute :published, :boolean, default: false, public?: true
+    end
+  end
+
   describe "Ash.Scope.to_opts/1 with Map" do
     test "handles nested shared context pattern" do
       context = %{
@@ -203,6 +239,134 @@ defmodule Ash.ScopeTest do
       context_opts = Ash.Context.to_opts(context)
 
       assert scope_opts == context_opts
+    end
+  end
+
+  describe "bulk actions resolve the actor from scope: (require_actor? true)" do
+    setup do
+      actor = %{id: Ash.UUID.generate()}
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "hello"}, actor: actor)
+        |> Ash.create!()
+
+      %{actor: actor, scope: %MyScope{actor: actor}, post: post}
+    end
+
+    for strategy <- [:stream, :atomic_batches, :atomic] do
+      @strategy strategy
+
+      test "bulk_update (list input), strategy #{strategy}", %{post: post, scope: scope} do
+        assert %Ash.BulkResult{status: :success, records: [%Post{published: true}]} =
+                 Ash.bulk_update([post], :publish, %{},
+                   scope: scope,
+                   strategy: @strategy,
+                   return_records?: true,
+                   return_errors?: true
+                 )
+      end
+
+      test "bulk_update (query input), strategy #{strategy}", %{scope: scope} do
+        assert %Ash.BulkResult{status: :success} =
+                 Ash.bulk_update(Post, :publish, %{},
+                   scope: scope,
+                   strategy: @strategy,
+                   return_records?: true,
+                   return_errors?: true
+                 )
+      end
+
+      test "bulk_destroy, strategy #{strategy}", %{post: post, scope: scope} do
+        assert %Ash.BulkResult{status: :success} =
+                 Ash.bulk_destroy([post], :destroy, %{},
+                   scope: scope,
+                   strategy: @strategy,
+                   return_errors?: true
+                 )
+      end
+    end
+
+    test "bulk_create", %{scope: scope} do
+      assert %Ash.BulkResult{status: :success, records: [_, _]} =
+               Ash.bulk_create([%{title: "a"}, %{title: "b"}], Post, :create,
+                 scope: scope,
+                 return_records?: true,
+                 return_errors?: true
+               )
+    end
+
+    test "update_many", %{post: post, scope: scope} do
+      assert %Ash.BulkResult{status: :success} =
+               Ash.update_many([{post, %{}}], Post, :publish,
+                 scope: scope,
+                 return_records?: true,
+                 return_errors?: true
+               )
+    end
+  end
+
+  describe "bulk action telemetry reflects the actor resolved from scope:" do
+    setup do
+      actor = %{id: Ash.UUID.generate()}
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "hello"}, actor: actor)
+        |> Ash.create!()
+
+      %{actor: actor, scope: %MyScope{actor: actor}, post: post}
+    end
+
+    test "bulk_update span metadata carries the scope actor", %{
+      post: post,
+      actor: actor,
+      scope: scope
+    } do
+      assert %Ash.BulkResult{status: :success} =
+               Ash.bulk_update([post], :publish, %{},
+                 scope: scope,
+                 strategy: :stream,
+                 tracer: Ash.Tracer.Simple,
+                 return_records?: true,
+                 return_errors?: true
+               )
+
+      span = Enum.find(Ash.Tracer.Simple.gather_spans(), &(&1.type == :bulk_update))
+      assert span, "expected a :bulk_update span"
+      assert span.metadata.actor == actor
+    end
+
+    test "bulk_create span metadata carries the scope actor", %{actor: actor, scope: scope} do
+      assert %Ash.BulkResult{status: :success} =
+               Ash.bulk_create([%{title: "a"}], Post, :create,
+                 scope: scope,
+                 tracer: Ash.Tracer.Simple,
+                 return_records?: true,
+                 return_errors?: true
+               )
+
+      span = Enum.find(Ash.Tracer.Simple.gather_spans(), &(&1.type == :bulk_create))
+      assert span, "expected a :bulk_create span"
+      assert span.metadata.actor == actor
+    end
+
+    test "bulk_destroy span metadata carries the scope actor", %{
+      post: post,
+      actor: actor,
+      scope: scope
+    } do
+      assert %Ash.BulkResult{status: :success} =
+               Ash.bulk_destroy([post], :destroy, %{},
+                 scope: scope,
+                 strategy: :stream,
+                 tracer: Ash.Tracer.Simple,
+                 return_errors?: true
+               )
+
+      span = Enum.find(Ash.Tracer.Simple.gather_spans(), &(&1.type == :bulk_destroy))
+      assert span, "expected a :bulk_destroy span"
+      assert span.metadata.actor == actor
     end
   end
 end


### PR DESCRIPTION
Bulk actions (bulk_create/update/destroy, update_many) resolved `scope:`
  into `actor:` too late — after the `require_actor?` check — so a domain with
  `require_actor? true` wrongly raised "no actor" even when scope carried one.

  Fix: resolve scope at the top of each bulk `run` (and update_many), like the
  single-record path already does. 
  
  Bonus: this is also before the tracing span, so span metadata now shows the
  actor from scope instead of nil.

  Tests added in scope_test.exs (all 4 APIs × strategies + telemetry).

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
