### PR TITLE
fix: narrow input/2 spec to no_return for resources without actions

### DIFF
--- a/lib/ash/resource.ex
+++ b/lib/ash/resource.ex
@@ -419,15 +419,18 @@ defmodule Ash.Resource do
       @doc """
       Same as `input/1`, except restricts the keys to values accepted by the action provided.
       """
-      @spec input(values :: map | Keyword.t(), action :: atom) :: map | no_return
       # when there are no actions, `@arguments_by_action` is an empty map literal,
       # which the type system can prove `Map.fetch/2` will always fail on, producing
-      # a warning everywhere such a resource is defined
+      # a warning everywhere such a resource is defined. In that case the function
+      # only ever raises, so its spec must be `no_return` (a `map` success typing
+      # would never match, producing a Dialyzer `invalid_contract` warning).
       if Enum.empty?(@arguments_by_action) do
+        @spec input(values :: map | Keyword.t(), action :: atom) :: no_return
         def input(_opts, action) do
           raise ArgumentError, message: "No such action #{inspect(action)}"
         end
       else
+        @spec input(values :: map | Keyword.t(), action :: atom) :: map | no_return
         def input(opts, action) do
           case Map.fetch(@arguments_by_action, action) do
             :error ->


### PR DESCRIPTION
## Problem

Resources that define **no actions** produce a Dialyzer `invalid_contract` warning for the generated `input/2` function:

```
lib/ash/resource.ex:1:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
MyApp.SomeResource.input/2

Success typing:
(_, _) :: none()

But the spec is:
(values :: map() | Keyword.t(), action :: atom()) :: map() | no_return()
```

In `Ash.Resource`, when `@arguments_by_action` is empty, the generated `input/2` clause only ever raises:

```elixir
@spec input(values :: map | Keyword.t(), action :: atom) :: map | no_return
if Enum.empty?(@arguments_by_action) do
  def input(_opts, action) do
    raise ArgumentError, message: "No such action #{inspect(action)}"
  end
else
  def input(opts, action) do
    ...
  end
end
```

The existing comment already notes that the empty-`@arguments_by_action` case was special-cased to silence the Elixir compiler's set-theoretic type warnings. However, the shared `@spec` still declares `:: map | no_return`. Since the no-actions clause always raises, its success typing is `none()`, which does not match the `map` part of the spec — hence Dialyzer flags `invalid_contract` in every downstream resource that has no actions.

## Fix

Move the `@spec` into each compile-time branch so the always-raising clause is correctly specced as `:: no_return`:

```elixir
if Enum.empty?(@arguments_by_action) do
  @spec input(values :: map | Keyword.t(), action :: atom) :: no_return
  def input(_opts, action) do
    raise ArgumentError, message: "No such action #{inspect(action)}"
  end
else
  @spec input(values :: map | Keyword.t(), action :: atom) :: map | no_return
  def input(opts, action) do
    ...
  end
end
```

Behavior is unchanged — only the type contract is corrected for the no-actions case.

## Reproduction

Any action-less resource triggers the warning:

```elixir
defmodule NoActions do
  use Ash.Resource, domain: nil, validate_domain_inclusion?: false

  attributes do
    uuid_primary_key :id
  end
end
```

Running `mix dialyzer` reports `invalid_contract` for `NoActions.input/2`. With this change the warning is gone.