### PR TITLE
fix: load and rewrite array-member union types correctly

### DIFF
--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -507,7 +507,7 @@ defmodule Ash.Type.Union do
               {:ok, values}
 
             our_load ->
-              Ash.Type.load(
+              load_union_values(
                 type_config[:type],
                 values,
                 our_load,
@@ -520,7 +520,7 @@ defmodule Ash.Type.Union do
               type_constraints = type_config[:constraints]
 
               if Ash.Type.can_load?(type, type_constraints) do
-                Ash.Type.load(type, values, [], type_constraints, context)
+                load_union_values(type, values, [], type_constraints, context)
               else
                 {:ok, values}
               end
@@ -559,6 +559,49 @@ defmodule Ash.Type.Union do
     else
       {:ok, unions}
     end
+  end
+
+  # Flatten array-member values into one batched leaf load, then regroup per union.
+  defp load_union_values({:array, inner} = type, values, load, constraints, context) do
+    shapes =
+      Enum.map(values, fn
+        value when is_list(value) -> length(value)
+        other -> other
+      end)
+
+    flat =
+      Enum.flat_map(values, fn
+        value when is_list(value) -> value
+        _ -> []
+      end)
+
+    inner_result =
+      case inner do
+        {:array, _} ->
+          load_union_values(inner, flat, load, constraints[:items] || [], context)
+
+        _ ->
+          Ash.Type.load(type, flat, load, constraints, context)
+      end
+
+    case inner_result do
+      {:ok, loaded} -> {:ok, regroup_union_values(loaded, shapes)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp load_union_values(type, values, load, constraints, context) do
+    Ash.Type.load(type, values, load, constraints, context)
+  end
+
+  defp regroup_union_values(loaded, shapes) do
+    {regrouped, []} =
+      Enum.map_reduce(shapes, loaded, fn
+        length, remaining when is_integer(length) -> Enum.split(remaining, length)
+        passthrough, remaining -> {passthrough, remaining}
+      end)
+
+    regrouped
   end
 
   def generator(constraints) do
@@ -665,7 +708,7 @@ defmodule Ash.Type.Union do
         constraints[:types][value.type][:type],
         &1,
         type_rewrites,
-        constraints[:types][value.type][:type]
+        constraints[:types][value.type][:constraints] || []
       )
     )
   end

--- a/test/calculations/calculation_with_union_type_test.exs
+++ b/test/calculations/calculation_with_union_type_test.exs
@@ -103,6 +103,12 @@ defmodule Ash.Test.Calculations.CalculationWithUnionTypeTest do
                         tag: :content_type,
                         tag_value: "text"
                       ],
+                      texts: [
+                        type: {:array, TextContent}
+                      ],
+                      grouped_texts: [
+                        type: {:array, {:array, TextContent}}
+                      ],
                       # Simple types for testing untagged unions
                       note: [
                         type: :string
@@ -140,5 +146,47 @@ defmodule Ash.Test.Calculations.CalculationWithUnionTypeTest do
              |> Ash.load!(content: [text: [:is_formatted], checklist: [:total_items]])
 
     assert %Ash.Union{type: :text, value: %{content_type: "text", text: "Text content"}} = content
+  end
+
+  test "load statement for calculations on an array member of a union type loads every element" do
+    assert %Author{content: content} =
+             Changeset.for_create(Author, :create, %{
+               content: %Ash.Union{
+                 type: :texts,
+                 value: [
+                   %{text: "first", content_type: "text"},
+                   %{text: "second", content_type: "text"},
+                   %{text: "third", content_type: "text"}
+                 ]
+               }
+             })
+             |> Ash.create!()
+             |> Ash.load!(content: [texts: [:is_formatted]])
+
+    assert %Ash.Union{type: :texts, value: value} = content
+
+    assert ["first", "second", "third"] = Enum.map(value, & &1.text)
+    assert [false, false, false] = Enum.map(value, & &1.is_formatted)
+  end
+
+  test "load statement for calculations on a nested array member of a union type preserves grouping" do
+    assert %Author{content: content} =
+             Changeset.for_create(Author, :create, %{
+               content: %Ash.Union{
+                 type: :grouped_texts,
+                 value: [
+                   [%{text: "a", content_type: "text"}, %{text: "b", content_type: "text"}],
+                   [%{text: "c", content_type: "text"}]
+                 ]
+               }
+             })
+             |> Ash.create!()
+             |> Ash.load!(content: [grouped_texts: [:is_formatted]])
+
+    assert %Ash.Union{type: :grouped_texts, value: [first_group, second_group]} = content
+
+    assert ["a", "b"] = Enum.map(first_group, & &1.text)
+    assert ["c"] = Enum.map(second_group, & &1.text)
+    assert [false, false] = Enum.map(first_group, & &1.is_formatted)
   end
 end


### PR DESCRIPTION
Ash.Type.Union.load/4 flattened the cross-union and intra-value array dimensions together for {:array, _} members, collapsing each union's list to a single element. This loads each union's value in a batched/recursive (for nested arrays) load.

Ash.Type.Union.rewrite/3 also passed the member type where constraints were expected, crashing on Access.get for array members.

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
