### PR TITLE
fix: pass NotLoaded/ForbiddenField through Ash.Type.rewrite/4 for array types

### DIFF
--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -1737,6 +1737,8 @@ defmodule Ash.Type do
   """
   def rewrite(_type, nil, _rewrites, _constraints), do: nil
   def rewrite(_type, [], _rewrites, _constraints), do: []
+  def rewrite(_type, %Ash.NotLoaded{} = value, _rewrites, _constraints), do: value
+  def rewrite(_type, %Ash.ForbiddenField{} = value, _rewrites, _constraints), do: value
 
   def rewrite({:array, type}, value, rewrites, constraints) when is_list(value) do
     item_constraints = constraints[:items] || []

--- a/test/policy/field_policy_test.exs
+++ b/test/policy/field_policy_test.exs
@@ -93,6 +93,25 @@ defmodule Ash.Test.Policy.FieldPolicyTest do
     end
   end
 
+  describe "loadable array of an embedded type under field policies (#2764)" do
+    test "an {:array, embedded} field forbidden by field policy returns ForbiddenField, not a crash",
+         %{user: user, admin: admin, post: post} do
+      # `admin_notes` is `{:array, AdminNote}`: a loadable embedded type visible only to admins
+      assert %Ash.ForbiddenField{field: :admin_notes, type: :attribute} =
+               Post
+               |> Ash.Query.filter(id == ^post.id)
+               |> Ash.read_one!(authorize?: true, actor: user)
+               |> Map.get(:admin_notes)
+
+      # an admin can still read the field
+      assert [] =
+               Post
+               |> Ash.Query.filter(id == ^post.id)
+               |> Ash.read_one!(authorize?: true, actor: admin)
+               |> Map.get(:admin_notes)
+    end
+  end
+
   describe "rendering fields" do
     test "when creating as a user that cannot see the field, its value is not displayed", %{
       representative: rep,

--- a/test/support/policy_field/resources/admin_note.ex
+++ b/test/support/policy_field/resources/admin_note.ex
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Support.PolicyField.AdminNote do
+  @moduledoc false
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute :body, :string do
+      public?(true)
+    end
+  end
+end

--- a/test/support/policy_field/resources/post.ex
+++ b/test/support/policy_field/resources/post.ex
@@ -32,6 +32,14 @@ defmodule Ash.Test.Support.PolicyField.Post do
     attribute :description, :string do
       public?(true)
     end
+
+    # Loadable array of an embedded resource, visible only to admins (see field policy below).
+    # For a non-admin actor the value becomes %Ash.ForbiddenField{} during a
+    # read, which cleanup_field_auth hands to Ash.Type.rewrite/4 (regression cover for #2764).
+    attribute :admin_notes, {:array, Ash.Test.Support.PolicyField.AdminNote} do
+      public?(true)
+      default([])
+    end
   end
 
   relationships do
@@ -62,6 +70,10 @@ defmodule Ash.Test.Support.PolicyField.Post do
 
     field_policy :reporter_id do
       forbid_if always()
+    end
+
+    field_policy :admin_notes do
+      authorize_if actor_attribute_equals(:role, :admin)
     end
 
     field_policy :* do

--- a/test/type/type_test.exs
+++ b/test/type/type_test.exs
@@ -110,6 +110,18 @@ defmodule Ash.Test.Type.TypeTest do
              Ash.Type.storage_type({:array, StorageByConstraint}, [])
   end
 
+  test "rewrite/4 passes %Ash.NotLoaded{} and %Ash.ForbiddenField{} through for {:array, _} types" do
+    # Regression test for #2764. rewrite/4 only handled `{:array, _}` when the value was a
+    # list, so a NotLoaded or ForbiddenField value (for example an unselected array of an
+    # embedded resource reaching field policy cleanup) fell through to the generic clause
+    # and tried to `apply` on the `{:array, _}` type tuple, raising ArgumentError.
+    not_loaded = %Ash.NotLoaded{type: :attribute, field: :things}
+    forbidden = %Ash.ForbiddenField{type: :attribute, field: :things}
+
+    assert ^not_loaded = Ash.Type.rewrite({:array, :string}, not_loaded, [], [])
+    assert ^forbidden = Ash.Type.rewrite({:array, :string}, forbidden, [], [])
+  end
+
   test "returns error for invalid keys" do
     foo = {:foo, [type: :string]}
     bar = {:bar, [type: :integer]}


### PR DESCRIPTION
## Problem

`Ash.Type.rewrite/4` handles `{:array, _}` only when the value is a list:

```elixir
def rewrite(_type, nil, _, _), do: nil
def rewrite(_type, [], _, _), do: []
def rewrite({:array, type}, value, _, _) when is_list(value), do: # recurse
def rewrite(type, item, _, _) when not is_list(item), do: get_type(type).rewrite(item, ...)
```

So a `%Ash.NotLoaded{}` / `%Ash.ForbiddenField{}` value for an `{:array, _}` attribute falls
through to the generic clause, which calls `apply({:array, _}, :rewrite, ...)` and raises
`ArgumentError: ... must always be an atom`.

The practical effect is that any app with field policies and an {:array, embedded_resource} attribute will hit an ArgumentError at runtime whenever you do an authorized read and leave the embedded attribute unloaded (not selected) or forbidden. The read 500s instead of returning data. See the example in #2764.

Reproduces on 3.23 through 3.29.3 and `main`.

Fixes #2764.

## Fix
Change the code so that reading a resource with an unloaded {:array, _} attribute returns data instead of crashing. Let rewrite/4 pass %Ash.NotLoaded{} through untouched. This is consistent with the existing `nil` / `[]` clauses.

## Tests

`test/type/type_test.exs` asserts `rewrite/4` passes both sentinels through for `{:array, _}`
types (fails on `main` with the `ArgumentError`, passes with the fix).

`test/policy/field_policy_test.exs` adds a test with a concrete example of 
an embedded array type with a field policy.

Verified on Erlang 29.0 / Elixir 1.20.0.