### PR TITLE
fix manifest reachability for repeated action roots

### DIFF
--- a/lib/ash/info/manifest/generator/reachability.ex
+++ b/lib/ash/info/manifest/generator/reachability.ex
@@ -46,7 +46,15 @@ defmodule Ash.Info.Manifest.Generator.Reachability do
         {resource, action_names} = normalize_entry(entry)
 
         if MapSet.member?(visited, resource) do
-          {resources, types, visited}
+          # The resource structure was already traversed, but an explicit
+          # action root still needs its action surface types discovered.
+          case action_names do
+            nil ->
+              {resources, types, visited}
+
+            action_names ->
+              traverse_action_arguments(resource, action_names, resources, types, visited, opts)
+          end
         else
           {found_resources, found_types, new_visited} =
             traverse_resource(

--- a/test/ash/info/manifest/reachability_test.exs
+++ b/test/ash/info/manifest/reachability_test.exs
@@ -67,5 +67,18 @@ defmodule Ash.Test.Info.Manifest.Generator.ReachabilityTest do
       # Todo has :metadata attribute of type TodoMetadata (embedded resource)
       assert MapSet.member?(resource_set, Ash.Test.Manifest.TodoMetadata)
     end
+
+    test "traverses explicit action roots for already structurally visited resources" do
+      {_resources, types} =
+        Reachability.find_reachable([
+          Ash.Test.Manifest.User,
+          {Ash.Test.Manifest.Post, [:get_custom_metadata, :update_internal_code]}
+        ])
+
+      assert Ash.Test.Manifest.Types.EmailString in types
+      assert Ash.Test.Manifest.CustomMetadata in types
+      assert Ash.Test.Manifest.InputParsing.Options in types
+      assert Ash.Test.Manifest.InputParsing.PreferencesKeyword in types
+    end
   end
 end

--- a/test/support/manifest/resources/post.ex
+++ b/test/support/manifest/resources/post.ex
@@ -30,6 +30,10 @@ defmodule Ash.Test.Manifest.Post do
     end
 
     attribute :metadata, :map, public?: true
+
+    attribute :internal_code, Ash.Test.Manifest.Types.EmailString do
+      public? false
+    end
   end
 
   relationships do
@@ -42,5 +46,21 @@ defmodule Ash.Test.Manifest.Post do
 
   actions do
     defaults [:create, :read, :update, :destroy]
+
+    update :update_internal_code do
+      accept [:internal_code]
+
+      metadata :preferences, Ash.Test.Manifest.InputParsing.PreferencesKeyword do
+        allow_nil? false
+      end
+    end
+
+    action :get_custom_metadata, Ash.Test.Manifest.InputParsing.Options do
+      argument :metadata, Ash.Test.Manifest.CustomMetadata, allow_nil?: false
+
+      run fn _input, _context ->
+        {:ok, %{cache_enabled_1?: true, retry_limit: 3}}
+      end
+    end
   end
 end


### PR DESCRIPTION
# Traversal bug

Discovered that a Typedstruct didnt make it properly into ash_lua because it was already visited briefly from another path so it was skipped when the type had to be fully traversed.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
