### PR TITLE
fix: ensure manual action module is loaded before bulk dispatch

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -149,7 +149,7 @@ defmodule Ash.Actions.Create.Bulk do
         manual_action_can_bulk? =
           case action.manual do
             {mod, _opts} ->
-              function_exported?(mod, :bulk_create, 3)
+              Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_create, 3)
 
             _ ->
               false
@@ -1244,7 +1244,7 @@ defmodule Ash.Actions.Create.Bulk do
                       %{}
                   end
 
-                if function_exported?(mod, :bulk_create, 3) do
+                if Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_create, 3) do
                   Ash.Resource.ManualCreate.bulk_create(
                     mod,
                     batch,

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1147,7 +1147,7 @@ defmodule Ash.Actions.Destroy.Bulk do
     manual_action_can_bulk? =
       case action.manual do
         {mod, _opts} ->
-          function_exported?(mod, :bulk_destroy, 3)
+          Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_destroy, 3)
 
         _ ->
           false
@@ -2097,7 +2097,7 @@ defmodule Ash.Actions.Destroy.Bulk do
                     [] -> %{}
                   end
 
-                if function_exported?(mod, :bulk_destroy, 3) do
+                if Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_destroy, 3) do
                   Ash.Resource.ManualDestroy.bulk_destroy(
                     mod,
                     batch,

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1496,7 +1496,7 @@ defmodule Ash.Actions.Update.Bulk do
     manual_action_can_bulk? =
       case action.manual do
         {mod, _opts} ->
-          function_exported?(mod, :bulk_update, 3)
+          Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_update, 3)
 
         _ ->
           false
@@ -2705,7 +2705,7 @@ defmodule Ash.Actions.Update.Bulk do
                     [] -> %{}
                   end
 
-                if function_exported?(mod, :bulk_update, 3) do
+                if Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_update, 3) do
                   Ash.Resource.ManualUpdate.bulk_update(
                     mod,
                     batch,

--- a/test/actions/bulk/bulk_destroy_manual_test.exs
+++ b/test/actions/bulk/bulk_destroy_manual_test.exs
@@ -7,6 +7,7 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
   use ExUnit.Case, async: false
 
   alias Ash.Test.Actions.BulkDestroyManualTest.Helpers
+  alias Ash.Test.BulkTestChanges.SoftDestroyManual
   alias Ash.Test.Domain, as: Domain
 
   defmodule Notifier do
@@ -268,6 +269,13 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
         manual DestroyManualOk
       end
 
+      destroy :soft_destroy_manual do
+        soft? true
+        require_atomic? false
+        change set_attribute(:deleted, true)
+        manual SoftDestroyManual
+      end
+
       create :create do
         accept [:name]
       end
@@ -279,6 +287,12 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
       attribute :name, :string do
         public? true
         allow_nil? false
+      end
+
+      attribute :deleted, :boolean do
+        public? true
+        allow_nil? false
+        default false
       end
     end
   end
@@ -655,5 +669,27 @@ defmodule Ash.Test.Actions.BulkDestroyManualTest do
     assert result.notifications == []
     assert result.error_count == 0
     assert result.errors == nil
+  end
+
+  # A soft destroy is run as a bulk update. The update bulk runner picks the
+  # manual bulk_update/3 callback via function_exported?/3, which returns false
+  # for a module that isn't loaded yet. Without a Code.ensure_loaded?/1 guard the
+  # callback is skipped and the per-record path runs with a :bulk_destroy context
+  # it doesn't expect. Unloading the module forces the runtime to reload it.
+  test "bulk_destroy with a manual soft destroy works when the manual module isn't loaded" do
+    [author] = create_authors() |> Enum.take(1)
+
+    :code.purge(SoftDestroyManual)
+    :code.delete(SoftDestroyManual)
+    refute :erlang.function_exported(SoftDestroyManual, :bulk_update, 3)
+
+    result =
+      Ash.bulk_destroy([author], :soft_destroy_manual, %{},
+        return_records?: true,
+        return_errors?: true,
+        strategy: :stream
+      )
+
+    assert result.status == :success
   end
 end

--- a/test/support/bulk_test_changes.ex
+++ b/test/support/bulk_test_changes.ex
@@ -414,4 +414,28 @@ defmodule Ash.Test.BulkTestChanges do
       end)
     end
   end
+
+  defmodule SoftDestroyManual do
+    @moduledoc """
+    Manual soft destroy. Soft deletes are run by Ash as updates, so the destroy
+    is dispatched through the update bulk pipeline and `update/3` +
+    `bulk_update/3` are the callbacks invoked.
+
+    Lives here (rather than inline in a test) so the runtime can reload it from
+    disk after a test unloads it.
+    """
+    use Ash.Resource.ManualDestroy
+    use Ash.Resource.ManualUpdate
+
+    def destroy(changeset, _opts, _ctx), do: {:ok, changeset.data}
+
+    def update(changeset, _opts, _ctx), do: Ash.Changeset.apply_attributes(changeset)
+
+    def bulk_update(changesets, _opts, _ctx) do
+      Enum.map(changesets, fn changeset ->
+        {:ok, record} = Ash.Changeset.apply_attributes(changeset)
+        {:ok, record, changeset}
+      end)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The bulk runners decide whether to invoke a manual action's bulk callback (`bulk_create/3`, `bulk_update/3`, `bulk_destroy/3`) with `function_exported?/3`:

```elixir
manual_action_can_bulk? =
  case action.manual do
    {mod, _opts} -> function_exported?(mod, :bulk_update, 3)
    _ -> false
  end
```

`function_exported?/3` returns `false` for a module that **hasn't been loaded yet** — it does not attempt to load it. So in any process where the manual module isn't already loaded, the bulk callback is silently skipped and execution falls back to the per-record path.

For a **soft destroy** this is fatal. A soft destroy is run as a bulk *update*, so the per-record fallback calls `process_non_bulk_result(..., :bulk_update, ...)`, which reads `changeset.context[:bulk_update]`. But a soft-destroy changeset carries a `:bulk_destroy` context, so `:bulk_update` is `nil` and it crashes:

```
** (BadMapError) expected a map, got: nil
    (ash) lib/ash/actions/bulk_manual_action_helpers.ex:138: ...process_non_bulk_result/6
    (ash) lib/ash/actions/update/bulk.ex: ...run_batch/12
```

Because it depends on whether the module happens to be loaded, the failure is intermittent: it surfaces in isolated/async processes (e.g. the first relevant test in a fresh process) and disappears once anything else has loaded the module.

Ash already guards every other optional-callback check this way (e.g. throughout `Ash.DataLayer`: `Code.ensure_loaded?(mod) && function_exported?(...)`). The manual-action bulk dispatch sites are the only exceptions.

## Fix

Guard all six manual-action bulk dispatch sites with `Code.ensure_loaded?/1`, matching the existing convention:

```elixir
Code.ensure_loaded?(mod) and function_exported?(mod, :bulk_update, 3)
```

- `Ash.Actions.Create.Bulk` (2 sites — `:bulk_create`)
- `Ash.Actions.Update.Bulk` (2 sites — `:bulk_update`)
- `Ash.Actions.Destroy.Bulk` (2 sites — `:bulk_destroy`)

## Why the test uses a manual action

The bug lives entirely in the `case action.manual do {mod, _} -> ...` branch. It only triggers for an action whose `action.manual` is a `{module, opts}` tuple where that module defines a `bulk_*` callback that isn't currently loaded. A plain (non-manual) action has `action.manual == nil`, never reaches this code, and cannot reproduce the issue — so the test resource must use a manual action.

This is not an exotic configuration. Extensions wrap **every** tracked action into a manual action transparently. For example, [`ash_events`](https://github.com/ash-project/ash_events) rewrites each event-tracked action — including a plain `destroy ... soft? true` — into `action.manual = {AshEvents.DestroyActionWrapper, opts}` so it can intercept the write and log an event. The resource author writes an ordinary soft destroy and never sees a manual action, but the *compiled* action is manual. A single shared wrapper module backs every tracked resource, so as soon as one bulk soft-destroy runs before that module is loaded, it hits this crash — regardless of which resource it is.

## Test

Added to the existing `bulk_destroy_manual_test.exs` (with a `SoftDestroyManual` module in the shared `test/support/bulk_test_changes.ex`). It unloads the manual module, runs a soft destroy, and asserts success. The support module is the minimal stand-in for a wrapper like `AshEvents.DestroyActionWrapper`: it `use`s both `ManualDestroy` and `ManualUpdate` (a soft destroy runs as an update, so `update/3` + `bulk_update/3` are invoked), and lives in `test/support` so the runtime can reload it from disk after the test unloads it.

Verified the test fails without the fix (`BadMapError`) and passes with it. Full `test/actions/bulk` suite: 411 passing.