### PR TITLE
Add filter option to update/destroy actions

### DIFF
--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -880,12 +880,14 @@ multiple actions of each type in a large application.
    * pipe_through
    * metadata
    * argument
+   * filter
  * [destroy](#actions-destroy)
    * change
    * validate
    * pipe_through
    * metadata
    * argument
+   * filter
 
 
 ### Examples
@@ -1823,6 +1825,7 @@ Declares a `update` action. For calling this action, see the `Ash.Domain` docume
  * [pipe_through](#actions-update-pipe_through)
  * [metadata](#actions-update-metadata)
  * [argument](#actions-update-argument)
+ * [filter](#actions-update-filter)
 
 
 ### Examples
@@ -2088,6 +2091,40 @@ argument :password_confirmation, :string
 
 Target: `Ash.Resource.Actions.Argument`
 
+### actions.update.filter
+```elixir
+filter filter
+```
+
+
+Applies a filter. Can use `^arg/1`, `^context/1` and `^actor/1` templates. Multiple filters are combined with *and*.
+
+
+
+### Examples
+```
+filter expr(first_name == "fred")
+filter expr(last_name == "weasley" and magician == true)
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`filter`](#actions-update-filter-filter){: #actions-update-filter-filter .spark-required} | `any` |  | The filter to apply. Can use `^arg/1`, `^context/1` and `^actor/1` templates. Multiple filters are combined with *and*. |
+
+
+
+
+
+
+### Introspection
+
+Target: `Ash.Resource.Dsl.Filter`
+
 
 
 
@@ -2112,6 +2149,7 @@ See `Ash.Resource.Change.Builtins.cascade_destroy/2` for cascading destroy opera
  * [pipe_through](#actions-destroy-pipe_through)
  * [metadata](#actions-destroy-metadata)
  * [argument](#actions-destroy-argument)
+ * [filter](#actions-destroy-filter)
 
 
 ### Examples
@@ -2380,6 +2418,40 @@ argument :password_confirmation, :string
 ### Introspection
 
 Target: `Ash.Resource.Actions.Argument`
+
+### actions.destroy.filter
+```elixir
+filter filter
+```
+
+
+Applies a filter. Can use `^arg/1`, `^context/1` and `^actor/1` templates. Multiple filters are combined with *and*.
+
+
+
+### Examples
+```
+filter expr(first_name == "fred")
+filter expr(last_name == "weasley" and magician == true)
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`filter`](#actions-destroy-filter-filter){: #actions-destroy-filter-filter .spark-required} | `any` |  | The filter to apply. Can use `^arg/1`, `^context/1` and `^actor/1` templates. Multiple filters are combined with *and*. |
+
+
+
+
+
+
+### Introspection
+
+Target: `Ash.Resource.Dsl.Filter`
 
 
 

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -126,6 +126,13 @@ defmodule Ash.Actions.Destroy.Bulk do
 
         query = %{query | domain: domain}
 
+        query =
+          if Map.get(action, :filter) do
+            Ash.Query.do_filter(query, action.filter)
+          else
+            query
+          end
+
         fully_atomic_changeset =
           cond do
             not_atomic_reason ->

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -86,6 +86,13 @@ defmodule Ash.Actions.Update.Bulk do
 
         query = %{query | domain: domain}
 
+        query =
+          if is_map(action) && Map.get(action, :filter) do
+            Ash.Query.do_filter(query, action.filter)
+          else
+            query
+          end
+
         fully_atomic_changeset =
           cond do
             not_atomic_reason ->

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -3136,6 +3136,16 @@ defmodule Ash.Changeset do
     |> timeout(changeset.timeout || opts[:timeout])
     |> set_tenant(opts[:tenant] || changeset.tenant || changeset.data.__metadata__[:tenant])
     |> Map.put(:action_type, action.type)
+    |> apply_action_filter(action)
+  end
+
+  defp apply_action_filter(changeset, %{filter: nil}), do: changeset
+
+  defp apply_action_filter(changeset, action) do
+    case Map.get(action, :filter) do
+      nil -> changeset
+      action_filter -> filter(changeset, action_filter)
+    end
   end
 
   defp reset_arguments(%{arguments: arguments} = changeset) do

--- a/lib/ash/resource/actions/destroy.ex
+++ b/lib/ash/resource/actions/destroy.ex
@@ -12,6 +12,7 @@ defmodule Ash.Resource.Actions.Destroy do
     :description,
     :error_handler,
     :multitenancy,
+    :filter,
     manual: nil,
     require_atomic?: Application.compile_env(:ash, :require_atomic_by_default?, true),
     skip_unknown_inputs: [],
@@ -27,6 +28,7 @@ defmodule Ash.Resource.Actions.Destroy do
     require_attributes: [],
     allow_nil_input: [],
     changes: [],
+    filters: [],
     reject: [],
     transaction?: true,
     public?: true,
@@ -40,6 +42,8 @@ defmodule Ash.Resource.Actions.Destroy do
           name: atom,
           manual: module | nil,
           multitenancy: atom,
+          filter: any,
+          filters: [any],
           action_select: list(atom) | nil,
           notifiers: list(module),
           arguments: list(Ash.Resource.Actions.Argument.t()),
@@ -118,8 +122,23 @@ defmodule Ash.Resource.Actions.Destroy do
   def opt_schema, do: @opt_schema
 
   def transform(%{manual: manual} = action) when not is_nil(manual) do
-    {:ok, %{action | require_atomic?: false}}
+    {:ok, %{action | require_atomic?: false} |> concat_filters()}
   end
 
-  def transform(action), do: {:ok, action}
+  def transform(action), do: {:ok, concat_filters(action)}
+
+  defp concat_filters(%{filters: [filter]} = action) do
+    %{action | filter: filter.filter}
+  end
+
+  defp concat_filters(%{filters: [first | rest]} = action) do
+    filter =
+      Enum.reduce(rest, first.filter, fn filter, acc ->
+        Ash.Query.BooleanExpression.new(:and, filter.filter, acc)
+      end)
+
+    %{action | filter: filter}
+  end
+
+  defp concat_filters(action), do: action
 end

--- a/lib/ash/resource/actions/update.ex
+++ b/lib/ash/resource/actions/update.ex
@@ -11,6 +11,7 @@ defmodule Ash.Resource.Actions.Update do
     :description,
     :error_handler,
     :multitenancy,
+    :filter,
     accept: nil,
     require_attributes: [],
     allow_nil_input: [],
@@ -27,6 +28,7 @@ defmodule Ash.Resource.Actions.Update do
     skip_global_validations?: false,
     arguments: [],
     changes: [],
+    filters: [],
     reject: [],
     metadata: [],
     transaction?: true,
@@ -41,6 +43,8 @@ defmodule Ash.Resource.Actions.Update do
           name: atom,
           manual: module | nil,
           multitenancy: atom,
+          filter: any,
+          filters: [any],
           skip_unknown_inputs: list(atom | String.t()),
           atomic_upgrade?: boolean(),
           action_select: list(atom) | nil,
@@ -115,8 +119,23 @@ defmodule Ash.Resource.Actions.Update do
   def opt_schema, do: @opt_schema
 
   def transform(%{manual: manual} = action) when not is_nil(manual) do
-    {:ok, %{action | require_atomic?: false}}
+    {:ok, %{action | require_atomic?: false} |> concat_filters()}
   end
 
-  def transform(action), do: {:ok, action}
+  def transform(action), do: {:ok, concat_filters(action)}
+
+  defp concat_filters(%{filters: [filter]} = action) do
+    %{action | filter: filter.filter}
+  end
+
+  defp concat_filters(%{filters: [first | rest]} = action) do
+    filter =
+      Enum.reduce(rest, first.filter, fn filter, acc ->
+        Ash.Query.BooleanExpression.new(:and, filter.filter, acc)
+      end)
+
+    %{action | filter: filter}
+  end
+
+  defp concat_filters(action), do: action
 end

--- a/lib/ash/resource/change/builtins.ex
+++ b/lib/ash/resource/change/builtins.ex
@@ -14,8 +14,8 @@ defmodule Ash.Resource.Change.Builtins do
 
   This ensures that only things matching the provided filter are updated or destroyed.
   """
-  @spec filter(expr :: Ash.Expr.t()) :: Ash.Resource.Change.ref()
-  def filter(filter) do
+  @spec filter_where(expr :: Ash.Expr.t()) :: Ash.Resource.Change.ref()
+  def filter_where(filter) do
     {Ash.Resource.Change.Filter, filter: filter}
   end
 

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -727,6 +727,9 @@ defmodule Ash.Resource.Dsl do
       ],
       arguments: [
         @action_argument
+      ],
+      filters: [
+        @filter
       ]
     ],
     deprecations: [
@@ -773,6 +776,9 @@ defmodule Ash.Resource.Dsl do
       ],
       arguments: [
         @action_argument
+      ],
+      filters: [
+        @filter
       ]
     ],
     target: Ash.Resource.Actions.Destroy,

--- a/test/actions/bulk/bulk_destroy_test.exs
+++ b/test/actions/bulk/bulk_destroy_test.exs
@@ -256,7 +256,7 @@ defmodule Ash.Test.Actions.BulkDestroyTest do
       end
 
       destroy :destroy_with_filter do
-        change filter(expr(title == "foo"))
+        change filter_where(expr(title == "foo"))
       end
 
       destroy :soft do

--- a/test/actions/bulk/bulk_update_test.exs
+++ b/test/actions/bulk/bulk_update_test.exs
@@ -422,7 +422,7 @@ defmodule Ash.Test.Actions.BulkUpdateTest do
       end
 
       update :update_with_filter do
-        change filter(expr(title == "foo"))
+        change filter_where(expr(title == "foo"))
       end
 
       update :update_fails_on_title2 do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Implements #1350 - adds a `filter` option to `update` and `destroy` actions, bringing them to parity with `read` actions which have supported this since early on.

## What this enables

```elixir
update :publish do
  filter expr(status == :draft)
end

destroy :soft_delete do
  filter expr(is_nil(deleted_at))
end
```

The filter is enforced at the action level and cannot be bypassed by the caller. Multiple filters can be declared and are combined with `and`. Filters support `^actor/1`, `^arg/1` and `^context/1` templates, identical to read action filters.

## Changes

#### `lib/ash/resource/actions/update.ex` and `lib/ash/resource/actions/destroy.ex`

Both action structs gain two new fields: `filters` (plural) which holds the raw list of filter entities as declared in the DSL, and `filter` (singular) which holds the final merged expression. The `transform/1` callback now calls `concat_filters/1` which collapses the list into a single expression joined with `:and`, or leaves `filter` as `nil` if none were declared. This is the same pattern the `Read` action already uses.

#### `lib/ash/resource/dsl.ex`

Adds `filters: [@filter]` to the entities list for both `@update` and `@destroy` DSL entities. This is what makes `filter expr(...)` valid syntax inside `update` and `destroy` blocks. The `@filter` entity already existed and was already used by `@read` - this change simply registers it for the two new contexts.

#### `lib/ash/changeset/changeset.ex`

Adds `|> apply_action_filter(action)` at the end of `prepare_changeset_for_action/3`. This is the function that wires a changeset to its action before any user-provided changes are applied - making it the right place to apply an action-level filter that callers cannot override. The private `apply_action_filter/2` helper uses `Map.get/2` rather than direct field access so it is safe when called for `create` actions, which do not have a `filter` field.

#### `lib/ash/actions/update/bulk.ex` and `lib/ash/actions/destroy/bulk.ex`

In bulk operations, Ash runs a read query first to fetch the records it will update or destroy. By applying `action.filter` to that read query via `Ash.Query.do_filter/2`, we ensure only eligible records are ever fetched from the data layer. Without this, the filter would still be enforced per-changeset, but Ash would wastefully fetch ineligible records first and then reject them one by one. This satisfies the requirement in the issue that the filter be "lifted to the read action when used in a bulk update/destroy scenario."

#### `lib/ash/resource/change/builtins.ex`

Renames `filter/1` to `filter_where/1`. This was required to resolve a compile error introduced by the DSL change above. When Spark processes a `filters: [@filter]` child entity inside `@update` or `@destroy`, it auto-generates a module and injects a `filter/1` macro into the DSL scope of that action. The existing `Change.Builtins.filter/1` was also imported into that same scope, causing Elixir to raise a conflicting import error. Since Spark's `imports:` field only accepts plain module names with no `except` support, the only clean resolution is to rename the builtin. `filter_where` is also a more descriptive name - it reads as "apply this change only where this condition is true."

#### `test/actions/bulk/bulk_update_test.exs` and `test/actions/bulk/bulk_destroy_test.exs`

Updated two test resources that used `change filter(...)` to use the renamed `change filter_where(...)` instead.