### PR TITLE
fix: include global changes when introspecting manage_relationship arguments

### DIFF
--- a/lib/ash/domain/info.ex
+++ b/lib/ash/domain/info.ex
@@ -126,8 +126,8 @@ defmodule Ash.Domain.Info do
       resource
       |> Ash.Resource.Info.actions()
       |> Enum.flat_map(fn action ->
-        action
-        |> Map.get(:changes, [])
+        resource
+        |> Ash.Resource.Info.action_changes(action)
         |> Enum.flat_map(fn
           %{change: {Ash.Resource.Change.ManageRelationship, opts}} ->
             related = Ash.Resource.Info.related(resource, opts[:relationship])

--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -880,7 +880,7 @@ defmodule Ash.Generator do
 
     arguments =
       Enum.filter(action.arguments, fn argument ->
-        argument.public? && !find_manage_change(argument, action)
+        argument.public? && !find_manage_change(argument, resource, action)
       end)
 
     resource
@@ -1209,8 +1209,10 @@ defmodule Ash.Generator do
 
   defp set_allow_nil(attributes, _), do: attributes
 
-  defp find_manage_change(argument, action) do
-    Enum.find_value(Map.get(action, :changes, []), fn
+  defp find_manage_change(argument, resource, action) do
+    resource
+    |> Ash.Resource.Info.action_changes(action)
+    |> Enum.find_value(fn
       %{change: {Ash.Resource.Change.ManageRelationship, opts}} ->
         if opts[:argument] == argument.name do
           opts

--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -318,6 +318,37 @@ defmodule Ash.Resource.Info do
     Extension.get_entities(resource, [:changes])
   end
 
+  @doc """
+  A list of all changes that apply to a given action, combining global changes with the action's own changes.
+
+  Global changes (declared in the top-level `changes` block) are filtered to the action's type and
+  prepended to the action's own changes, mirroring the order in which they are resolved at runtime.
+
+  Use this instead of reading `action.changes` directly whenever you need to introspect every change
+  that will run for an action (for example, to discover `manage_relationship/3` arguments), so that
+  changes declared globally are not missed.
+  """
+  @spec action_changes(
+          Spark.Dsl.t() | Ash.Resource.t(),
+          atom() | Ash.Resource.Actions.action()
+        ) :: list(Ash.Resource.Validation.t() | Ash.Resource.Change.t())
+  def action_changes(resource, action_or_name) do
+    action =
+      case action_or_name do
+        %{type: _type} = action -> action
+        name -> action(resource, name)
+      end
+
+    global_changes =
+      if action && action.type in [:create, :update, :destroy] do
+        changes(resource, action.type)
+      else
+        []
+      end
+
+    global_changes ++ Map.get(action || %{}, :changes, [])
+  end
+
   @spec preparations(Spark.Dsl.t() | Ash.Resource.t(), action_type :: :read | :action) ::
           list(Ash.Resource.Preparation.t())
   def preparations(resource, type \\ :read) do

--- a/test/generator/generator_test.exs
+++ b/test/generator/generator_test.exs
@@ -85,6 +85,42 @@ defmodule Ash.Test.GeneratorTest do
     end
   end
 
+  defmodule GlobalChangeAuthor do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+
+      update :new_post do
+        require_atomic? false
+        argument :posts, {:array, :map}, allow_nil?: false
+      end
+    end
+
+    changes do
+      change manage_relationship(:posts, type: :create), on: [:update]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, default: "Fred", public?: true
+    end
+
+    relationships do
+      has_many :posts, Ash.Test.GeneratorTest.Post,
+        destination_attribute: :author_id,
+        public?: true
+    end
+  end
+
   defmodule Post do
     @moduledoc false
     use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets, notifiers: [Notifier]
@@ -663,6 +699,18 @@ defmodule Ash.Test.GeneratorTest do
         post
         |> Ash.Changeset.for_update(:update, input)
         |> Ash.update!()
+      end
+    end
+
+    test "manage_relationship arguments declared on the action are not generated" do
+      check all(input <- Ash.Generator.action_input(Author, :new_post)) do
+        refute Map.has_key?(input, :posts)
+      end
+    end
+
+    test "manage_relationship arguments declared in a global changes block are not generated" do
+      check all(input <- Ash.Generator.action_input(GlobalChangeAuthor, :new_post)) do
+        refute Map.has_key?(input, :posts)
       end
     end
 


### PR DESCRIPTION
Fixes #1932

## Summary

`manage_relationship` can be declared on an action or in the global `changes` block. Runtime already handles both, but some introspection code only looked at `action.changes` and missed global changes.

This PR adds `Ash.Resource.Info.action_changes/2` to combine both lists and updates `Ash.Generator` and `Ash.Domain.Info` to use it. Includes regression tests.

## Test plan

- [x] `mix test test/generator/generator_test.exs`
- [x] `mix check`

# Contributor checklist

- [x ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies