### PR TITLE
feat: allow data layers to provide default batch size for bulk actions

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -169,9 +169,14 @@ defmodule Ash.Actions.Create.Bulk do
 
         batch_size =
           cond do
-            action.manual != nil and manual_action_can_bulk? -> opts[:batch_size] || 100
-            action.manual == nil and data_layer_can_bulk? -> opts[:batch_size] || 100
-            true -> 1
+            action.manual != nil and manual_action_can_bulk? ->
+              opts[:batch_size] || 100
+
+            action.manual == nil and data_layer_can_bulk? ->
+              opts[:batch_size] || Ash.DataLayer.default_bulk_batch_size(resource, action) || 100
+
+            true ->
+              1
           end
 
         all_changes =

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -1045,8 +1045,11 @@ defmodule Ash.Actions.Destroy.Bulk do
   end
 
   defp do_atomic_batches(atomic_changeset, domain, stream, action, input, opts) do
-    batch_size = opts[:batch_size] || 100
     resource = opts[:resource]
+
+    batch_size =
+      opts[:batch_size] || Ash.DataLayer.default_bulk_batch_size(resource, action) || 100
+
     ref = make_ref()
     pkey = Ash.Resource.Info.primary_key(resource)
 

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -1379,8 +1379,11 @@ defmodule Ash.Actions.Update.Bulk do
          input,
          opts
        ) do
-    batch_size = opts[:batch_size] || 100
     resource = opts[:resource]
+
+    batch_size =
+      opts[:batch_size] || Ash.DataLayer.default_bulk_batch_size(resource, action) || 100
+
     ref = make_ref()
     pkey = Ash.Resource.Info.primary_key(resource)
 

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -342,6 +342,8 @@ defmodule Ash.DataLayer do
               {:ok, term} | {:error, term}
   @callback prefer_transaction?(Ash.Resource.t()) :: boolean
   @callback prefer_transaction_for_atomic_updates?(Ash.Resource.t()) :: boolean
+  @callback default_bulk_batch_size(Ash.Resource.t(), Ash.Resource.Actions.action()) ::
+              pos_integer() | nil
   @callback can?(Ash.Resource.t() | Spark.Dsl.t(), feature()) :: boolean
   @callback set_context(Ash.Resource.t(), data_layer_query(), map) ::
               {:ok, data_layer_query()} | {:error, term}
@@ -363,6 +365,7 @@ defmodule Ash.DataLayer do
                       set_context: 3,
                       prefer_transaction?: 1,
                       prefer_transaction_for_atomic_updates?: 1,
+                      default_bulk_batch_size: 2,
                       calculate: 3,
                       destroy: 2,
                       filter: 3,
@@ -475,6 +478,27 @@ defmodule Ash.DataLayer do
         Invalid value returned from #{inspect(data_layer_module)}.prefer_transaction?/1.
         The callback #{inspect(__MODULE__)}.prefer_transaction?/1 expects a boolean.
         """
+    end
+  end
+
+  @doc """
+  The data layer's preferred bulk batch size for the given action, or `nil`.
+
+  Data layers may implement `c:default_bulk_batch_size/2` to inform the default
+  chunk size used by bulk `create`/`update`/`destroy` when the caller does not
+  pass `:batch_size`. An explicit `:batch_size` option always takes precedence.
+  Returns `nil` when the data layer does not implement the callback.
+  """
+  @spec default_bulk_batch_size(Ash.Resource.t(), Ash.Resource.Actions.action()) ::
+          pos_integer() | nil
+  def default_bulk_batch_size(resource, action) do
+    data_layer = data_layer(resource)
+
+    if Code.ensure_loaded?(data_layer) &&
+         function_exported?(data_layer, :default_bulk_batch_size, 2) do
+      data_layer.default_bulk_batch_size(resource, action)
+    else
+      nil
     end
   end
 

--- a/test/actions/bulk/default_bulk_batch_size_test.exs
+++ b/test/actions/bulk/default_bulk_batch_size_test.exs
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Actions.DefaultBulkBatchSizeTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule CreateDataLayer do
+    @moduledoc false
+    use Spark.Dsl.Extension, sections: []
+    @behaviour Ash.DataLayer
+
+    @impl true
+    def can?(_, :create), do: true
+    def can?(_, :bulk_create), do: true
+    def can?(_, :read), do: true
+    def can?(_, _), do: false
+
+    @impl true
+    def resource_to_query(_resource, _domain), do: %{}
+
+    @impl true
+    def run_query(_query, _resource), do: {:ok, []}
+
+    @impl true
+    def create(resource, changeset) do
+      {:ok, struct(resource, changeset.attributes)}
+    end
+
+    @impl true
+    def bulk_create(resource, changesets, _opts) do
+      changesets = Enum.to_list(changesets)
+      send(self(), {:bulk_batch, :create, length(changesets)})
+
+      records =
+        Enum.map(changesets, fn changeset ->
+          resource
+          |> struct(changeset.attributes)
+          |> Ash.Actions.Helpers.Bulk.put_metadata(changeset)
+        end)
+
+      {:ok, records}
+    end
+
+    @impl true
+    def default_bulk_batch_size(_resource, %{name: :create_small}), do: 4
+    def default_bulk_batch_size(_resource, _action), do: 2
+  end
+
+  defmodule CreatePost do
+    @moduledoc false
+    use Ash.Resource, data_layer: CreateDataLayer, domain: Domain
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false, public?: true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:create, :read]
+      create :create_small
+    end
+  end
+
+  test "uses the data layer's default_bulk_batch_size when no batch_size option is given" do
+    Ash.bulk_create!(
+      [%{title: "a"}, %{title: "b"}, %{title: "c"}, %{title: "d"}, %{title: "e"}],
+      CreatePost,
+      :create,
+      return_records?: true
+    )
+
+    assert_received {:bulk_batch, :create, 2}
+    assert_received {:bulk_batch, :create, 2}
+    assert_received {:bulk_batch, :create, 1}
+  end
+
+  test "an explicit batch_size option overrides default_bulk_batch_size" do
+    Ash.bulk_create!(
+      [%{title: "a"}, %{title: "b"}, %{title: "c"}, %{title: "d"}, %{title: "e"}],
+      CreatePost,
+      :create,
+      batch_size: 3,
+      return_records?: true
+    )
+
+    assert_received {:bulk_batch, :create, 3}
+    assert_received {:bulk_batch, :create, 2}
+  end
+
+  test "default_bulk_batch_size receives the action, so different actions can size differently" do
+    Ash.bulk_create!(
+      [%{title: "a"}, %{title: "b"}, %{title: "c"}, %{title: "d"}, %{title: "e"}],
+      CreatePost,
+      :create_small,
+      return_records?: true
+    )
+
+    assert_received {:bulk_batch, :create, 4}
+    assert_received {:bulk_batch, :create, 1}
+  end
+
+  test "Ash.DataLayer.default_bulk_batch_size/2 returns the data layer's value when exported" do
+    action = Ash.Resource.Info.action(CreatePost, :create)
+    assert Ash.DataLayer.default_bulk_batch_size(CreatePost, action) == 2
+  end
+
+  defmodule EtsPost do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Domain
+
+    ets do
+      private? true
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: true, public?: true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:create, :read]
+    end
+  end
+
+  test "Ash.DataLayer.default_bulk_batch_size/2 returns nil when the data layer does not export it" do
+    action = Ash.Resource.Info.action(EtsPost, :create)
+    assert Ash.DataLayer.default_bulk_batch_size(EtsPost, action) == nil
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes (new @doc tag for the new callback)
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

This MR allows the data layer to specify a default batch size for create, update and destroy actions through the default_bulk_batch_size callback. 

closes #2771