### PR TITLE
Guard ash.set.domains when Igniter is unavailable

### DIFF
--- a/lib/mix/tasks/ash.set.domains.ex
+++ b/lib/mix/tasks/ash.set.domains.ex
@@ -2,41 +2,43 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule Mix.Tasks.Ash.Set.Domains do
-  use Igniter.Mix.Task
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.Ash.Set.Domains do
+    use Igniter.Mix.Task
 
-  @shortdoc "Dynamically discovers and updates Ash domains in config.exs"
+    @shortdoc "Dynamically discovers and updates Ash domains in config.exs"
 
-  @moduledoc """
-  Scans your application layout for Ash domains and automatically updates the
-  `:ash_domains` configuration array inside `config/config.exs`.
+    @moduledoc """
+    Scans your application layout for Ash domains and automatically updates the
+    `:ash_domains` configuration array inside `config/config.exs`.
 
-  ## Example
+    ## Example
 
-      $ mix ash.set.domains
-  """
+        $ mix ash.set.domains
+    """
 
-  @impl Igniter.Mix.Task
-  def igniter(igniter, _argv) do
-    app_name = Igniter.Project.Application.app_name(igniter)
+    @impl Igniter.Mix.Task
+    def igniter(igniter, _argv) do
+      app_name = Igniter.Project.Application.app_name(igniter)
 
-    Mix.shell().info("🔍 Scanning for Ash domains in :#{app_name}...")
+      Mix.shell().info("🔍 Scanning for Ash domains in :#{app_name}...")
 
-    {igniter, domains} = Ash.Mix.Tasks.Helpers.discover_domains(igniter)
+      {igniter, domains} = Ash.Mix.Tasks.Helpers.discover_domains(igniter)
 
-    if Enum.empty?(domains) do
-      Mix.shell().error("❌ No modules utilizing `use Ash.Domain` were found.")
-      igniter
-    else
-      Mix.shell().info("✨ Found #{length(domains)} domain(s). Patching configuration...")
+      if Enum.empty?(domains) do
+        Mix.shell().error("❌ No modules utilizing `use Ash.Domain` were found.")
+        igniter
+      else
+        Mix.shell().info("✨ Found #{length(domains)} domain(s). Patching configuration...")
 
-      igniter
-      |> Igniter.Project.Config.configure(
-        "config.exs",
-        app_name,
-        [:ash_domains],
-        domains
-      )
+        igniter
+        |> Igniter.Project.Config.configure(
+          "config.exs",
+          app_name,
+          [:ash_domains],
+          domains
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

Wraps `Mix.Tasks.Ash.Set.Domains` in an Igniter availability check.

Igniter is an optional Ash dependency, but the task unconditionally called `use Igniter.Mix.Task`. This caused Ash compilation to fail in consumer environments where Igniter was not installed, such as production-only dependency builds.

This follows the existing pattern used by Ash’s other Igniter-backed Mix tasks.

# Testing

- Ran `mix test test/mix/tasks/ash.set.domains_test.exs`
  - 2 tests passed
- Verified the source compiles when Igniter is unavailable

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies