### PR TITLE
improvement: add `error_handler` to generic actions

### DIFF
--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -977,6 +977,7 @@ end
 | [`constraints`](#actions-action-constraints){: #actions-action-constraints } | `keyword` |  | Constraints for the return type. See `Ash.Type` for more. |
 | [`allow_nil?`](#actions-action-allow_nil?){: #actions-action-allow_nil? } | `boolean` | `false` | Whether or not the action can return nil. Unlike attributes & arguments, this defaults to `false`. |
 | [`run`](#actions-action-run){: #actions-action-run } | `(any, any -> any) \| module \| module` |  | Module may be an `Ash.Resource.Actions.Implementation` or `Reactor`. |
+| [`error_handler`](#actions-action-error_handler){: #actions-action-error_handler } | `mfa \| (any, any -> any)` |  | Sets the error handler on the action input. See `Ash.ActionInput.handle_errors/2` for more |
 | [`primary?`](#actions-action-primary?){: #actions-action-primary? } | `boolean` | `false` | Whether or not this action should be used when no action is specified by the caller. |
 | [`description`](#actions-action-description){: #actions-action-description } | `String.t` |  | An optional description for the action |
 | [`transaction?`](#actions-action-transaction?){: #actions-action-transaction? } | `boolean` |  | Whether or not the action should be run in transactions. Reads default to false, while create/update/destroy actions default to `true`. |

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -27,6 +27,7 @@ defmodule Ash.ActionInput do
     context: %{},
     valid?: true,
     errors: [],
+    handle_errors: nil,
     before_action: [],
     after_action: [],
     before_transaction: [],
@@ -101,6 +102,10 @@ defmodule Ash.ActionInput do
           domain: Ash.Domain.t() | nil,
           valid?: boolean(),
           errors: [Ash.Error.t()],
+          handle_errors:
+            nil
+            | (t(), error :: term ->
+                 :ignore | t() | (error :: term) | {error :: term, t()}),
           before_action: [before_action_fun],
           after_action: [after_action_fun],
           before_transaction: [before_transaction_fun],
@@ -252,6 +257,7 @@ defmodule Ash.ActionInput do
         end)
 
       input
+      |> handle_errors(input.action.error_handler)
       |> cast_params(params, opts)
       |> set_defaults()
       |> require_arguments()
@@ -960,8 +966,56 @@ defmodule Ash.ActionInput do
     |> handle_error(input)
   end
 
-  defp handle_error(error, input) do
+  defp handle_error(error, %{handle_errors: nil} = input) do
     %{input | valid?: false, errors: [error | input.errors]}
+  end
+
+  defp handle_error(error, input) do
+    input
+    |> input.handle_errors.(error)
+    |> case do
+      :ignore ->
+        %{input | valid?: false}
+
+      {:ignore, input} ->
+        %{input | valid?: false}
+
+      %__MODULE__{} = input ->
+        %{input | valid?: false}
+
+      {input, error} ->
+        %{input | valid?: false, errors: [error | input.errors]}
+
+      error ->
+        %{input | valid?: false, errors: [error | input.errors]}
+    end
+  end
+
+  @doc """
+  Sets a custom error handler on the action input.
+
+  The error handler should be a two argument function or an mfa, in which case the first two arguments will be set
+  to the action input and the error, w/ the supplied arguments following those. The input will be marked
+  as invalid regardless of the outcome of this callback.
+
+  Any errors generated are passed to `handle_errors`, which can return any of the following:
+
+  * `:ignore` - the error is discarded.
+  * `input` - a new (or the same) action input. The error is not added.
+  * `{input, error}` - a new (or the same) error and action input. The error is added to the input.
+  * `anything_else` - is treated as a new, transformed version of the error. The result is added as an error to the input.
+  """
+  @spec handle_errors(
+          t(),
+          (t(), error :: term -> :ignore | t() | (error :: term) | {error :: term, t()})
+          | {module, atom, [term]}
+        ) :: t()
+  def handle_errors(input, {m, f, a}) do
+    %{input | handle_errors: &apply(m, f, [&1, &2 | a])}
+  end
+
+  def handle_errors(input, func) do
+    %{input | handle_errors: func}
   end
 
   defp to_change_errors(keyword) do

--- a/lib/ash/actions/action.ex
+++ b/lib/ash/actions/action.ex
@@ -84,8 +84,9 @@ defmodule Ash.Actions.Action do
         case result do
           {:error, error} ->
             error =
-              Ash.Error.to_error_class(
-                error,
+              input
+              |> handle_run_errors(error)
+              |> Ash.Error.to_error_class(
                 bread_crumbs:
                   "Error returned from: #{inspect(input.resource)}.#{input.action.name}"
               )
@@ -129,6 +130,14 @@ defmodule Ash.Actions.Action do
   end
 
   defp validate_allow_nil(_result, _input, _in_transaction?), do: :ok
+
+  defp handle_run_errors(%{handle_errors: nil}, error), do: error
+
+  defp handle_run_errors(input, error) do
+    input
+    |> Ash.ActionInput.add_error(error)
+    |> Map.fetch!(:errors)
+  end
 
   defp maybe_load(:ok, _input, _domain, _opts), do: :ok
   defp maybe_load({:ok, nil}, _input, _domain, _opts), do: {:ok, nil}

--- a/lib/ash/actions/action.ex
+++ b/lib/ash/actions/action.ex
@@ -22,7 +22,12 @@ defmodule Ash.Actions.Action do
     end
   rescue
     e ->
-      reraise Ash.Error.to_error_class(e,
+      error =
+        e
+        |> Ash.Error.to_ash_error(__STACKTRACE__)
+        |> then(&handle_run_errors(input, &1))
+
+      reraise Ash.Error.to_error_class(error,
                 stacktrace: __STACKTRACE__,
                 bread_crumbs: [
                   "Exception raised in: #{inspect(input.resource)}.#{input.action.name}"

--- a/lib/ash/resource/actions/action/action.ex
+++ b/lib/ash/resource/actions/action/action.ex
@@ -10,6 +10,7 @@ defmodule Ash.Resource.Actions.Action do
     :description,
     :returns,
     :run,
+    :error_handler,
     constraints: [],
     touches_resources: [],
     skip_unknown_inputs: [],
@@ -34,6 +35,7 @@ defmodule Ash.Resource.Actions.Action do
           touches_resources: [Ash.Resource.t()],
           constraints: Keyword.t(),
           run: {module, Keyword.t()},
+          error_handler: mfa() | (Ash.ActionInput.t(), term() -> term()) | nil,
           returns: Ash.Type.t() | nil,
           primary?: boolean,
           transaction?: boolean,
@@ -91,6 +93,11 @@ defmodule Ash.Resource.Actions.Action do
                   doc: """
                   Module may be an `Ash.Resource.Actions.Implementation` or `Reactor`.
                   """
+                ],
+                error_handler: [
+                  type: {:or, [:mfa, {:fun, 2}]},
+                  doc:
+                    "Sets the error handler on the action input. See `Ash.ActionInput.handle_errors/2` for more"
                 ]
               ]
               |> Spark.Options.merge(

--- a/test/actions/generic_action_error_handler_test.exs
+++ b/test/actions/generic_action_error_handler_test.exs
@@ -55,6 +55,16 @@ defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
 
         run fn _input, _ -> {:error, "from the run"} end
       end
+
+      action :raises_with_handler, :string do
+        error_handler fn _input, error ->
+          Ash.Error.Unknown.UnknownError.exception(
+            error: "handled #{Exception.message(error)}"
+          )
+        end
+
+        run fn _input, _ -> raise "boom" end
+      end
     end
 
     attributes do
@@ -99,5 +109,17 @@ defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
 
     assert Exception.message(error) =~ "handled"
     assert Exception.message(error) =~ "from the run"
+  end
+
+  test "exceptions raised in the run implementation are piped through the handler" do
+    error =
+      assert_raise Ash.Error.Unknown, fn ->
+        Post
+        |> Ash.ActionInput.for_action(:raises_with_handler, %{})
+        |> Ash.run_action()
+      end
+
+    assert Exception.message(error) =~ "handled"
+    assert Exception.message(error) =~ "boom"
   end
 end

--- a/test/actions/generic_action_error_handler_test.exs
+++ b/test/actions/generic_action_error_handler_test.exs
@@ -45,6 +45,16 @@ defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
 
         run fn input, _ -> {:ok, input.arguments.name} end
       end
+
+      action :run_errors_with_fun_handler, :string do
+        error_handler fn _input, error ->
+          Ash.Error.Unknown.UnknownError.exception(
+            error: "handled #{Exception.message(error)}"
+          )
+        end
+
+        run fn _input, _ -> {:error, "from the run"} end
+      end
     end
 
     attributes do
@@ -79,5 +89,15 @@ defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
 
     refute input.valid?
     assert input.errors == []
+  end
+
+  test "errors returned from the run implementation are piped through the handler" do
+    assert {:error, %Ash.Error.Unknown{errors: [error]}} =
+             Post
+             |> Ash.ActionInput.for_action(:run_errors_with_fun_handler, %{})
+             |> Ash.run_action()
+
+    assert Exception.message(error) =~ "handled"
+    assert Exception.message(error) =~ "from the run"
   end
 end

--- a/test/actions/generic_action_error_handler_test.exs
+++ b/test/actions/generic_action_error_handler_test.exs
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      action :with_fun_handler, :string do
+        argument :name, :string, allow_nil?: false
+
+        error_handler fn _input, _error ->
+          Ash.Error.Unknown.UnknownError.exception(error: "handled by fun")
+        end
+
+        run fn input, _ -> {:ok, input.arguments.name} end
+      end
+
+      action :with_mfa_handler, :string do
+        argument :name, :string, allow_nil?: false
+
+        error_handler {__MODULE__, :replace_error, ["handled by mfa"]}
+
+        run fn input, _ -> {:ok, input.arguments.name} end
+      end
+
+      action :with_ignoring_handler, :string do
+        argument :name, :string, allow_nil?: false
+
+        error_handler fn _input, _error -> :ignore end
+
+        run fn input, _ -> {:ok, input.arguments.name} end
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+
+    def replace_error(_input, _error, message) do
+      Ash.Error.Unknown.UnknownError.exception(error: message)
+    end
+  end
+
+  test "a function error handler transforms errors raised during input building" do
+    assert {:error, %Ash.Error.Unknown{errors: [error]}} =
+             Post
+             |> Ash.ActionInput.for_action(:with_fun_handler, %{})
+             |> Ash.run_action()
+
+    assert Exception.message(error) =~ "handled by fun"
+  end
+
+  test "an mfa error handler transforms errors raised during input building" do
+    assert {:error, %Ash.Error.Unknown{errors: [error]}} =
+             Post
+             |> Ash.ActionInput.for_action(:with_mfa_handler, %{})
+             |> Ash.run_action()
+
+    assert Exception.message(error) =~ "handled by mfa"
+  end
+
+  test "returning :ignore discards the error but keeps the input invalid" do
+    input = Ash.ActionInput.for_action(Post, :with_ignoring_handler, %{})
+
+    refute input.valid?
+    assert input.errors == []
+  end
+end

--- a/test/actions/generic_action_error_handler_test.exs
+++ b/test/actions/generic_action_error_handler_test.exs
@@ -48,9 +48,7 @@ defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
 
       action :run_errors_with_fun_handler, :string do
         error_handler fn _input, error ->
-          Ash.Error.Unknown.UnknownError.exception(
-            error: "handled #{Exception.message(error)}"
-          )
+          Ash.Error.Unknown.UnknownError.exception(error: "handled #{Exception.message(error)}")
         end
 
         run fn _input, _ -> {:error, "from the run"} end
@@ -58,9 +56,7 @@ defmodule Ash.Test.Actions.GenericActionErrorHandlerTest do
 
       action :raises_with_handler, :string do
         error_handler fn _input, error ->
-          Ash.Error.Unknown.UnknownError.exception(
-            error: "handled #{Exception.message(error)}"
-          )
+          Ash.Error.Unknown.UnknownError.exception(error: "handled #{Exception.message(error)}")
         end
 
         run fn _input, _ -> raise "boom" end


### PR DESCRIPTION
## Summary

Generic actions run on `Ash.ActionInput` rather than a changeset, so the `error_handler` DSL option available on create/update/destroy actions had no equivalent. This adds it, and routes both errors *returned* from and exceptions *raised* by the action's `run` implementation through the handler.

## Changes

- **`lib/ash/action_input.ex`** — added a `handle_errors` field (default `nil`) to the struct + typespec, a `handle_errors/2` setter (2-arity fun or mfa), and dispatch in `handle_error/2` that interprets the same return values as the changeset (`:ignore`, `{:ignore, input}`, an `%ActionInput{}`, `{input, error}`, or a transformed error). Wired into `for_action/4` before casting/validation so those errors flow through the handler.
- **`lib/ash/actions/action.ex`**:
  - Errors returned from the `run` implementation (and other run-phase errors) are piped through the input's handler at the single chokepoint in `run_with_lifecycle`, mirroring `Ash.Changeset.add_error` at the commit stage of create/update/destroy.
  - Exceptions raised in the implementation are converted to an Ash error, routed through the handler, then reraised as an error class.
- **`lib/ash/resource/actions/action/action.ex`** — added `:error_handler` to the struct + typespec and exposed the `error_handler` option on the generic action schema.
- **`documentation/dsls/DSL-Ash.Resource.md`** — regenerated cheat sheet.
- **`test/actions/generic_action_error_handler_test.exs`** — covers fun handler, mfa handler, `:ignore`, errors returned from `run`, and exceptions raised in `run`.

## Scope / notes

- Read actions still don't support `error_handler` (they run on `Ash.Query`, which has no `handle_errors`). This change is scoped to generic actions only.