### PR TITLE
fix: propagate shared context when loading bulk create results

### DIFF
--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -1751,10 +1751,15 @@ defmodule Ash.Actions.Create.Bulk do
             resource |> Ash.Resource.Info.public_attributes() |> Enum.map(& &1.name)
           end
 
+        load_context =
+          (opts[:context] || %{})
+          |> Map.take([:shared])
+          |> Map.put(:private, %{just_created_by_action: action.name})
+
         case Ash.load(
                records,
                select,
-               context: %{private: %{just_created_by_action: action.name}},
+               context: load_context,
                reuse_values?: true,
                domain: domain,
                action: Ash.Resource.Info.primary_action(resource, :read) || action,
@@ -1774,7 +1779,7 @@ defmodule Ash.Actions.Create.Bulk do
             Ash.load(
               records,
               load_query,
-              context: %{private: %{just_created_by_action: action.name}},
+              context: load_context,
               domain: domain,
               tenant: opts[:tenant],
               action: Ash.Resource.Info.primary_action(resource, :read) || action,

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -177,6 +177,40 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     end
   end
 
+  defmodule CaptureSharedContext do
+    @moduledoc false
+    use Ash.Resource.Preparation
+
+    @impl true
+    def prepare(query, _opts, _context) do
+      send(self(), {:shared_context, query.context[:shared]})
+      query
+    end
+  end
+
+  defmodule PostWithSharedContextPreparation do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, create: :*]
+    end
+
+    preparations do
+      prepare CaptureSharedContext
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, public?: true
+    end
+  end
+
   defmodule Org do
     @moduledoc false
     use Ash.Resource,
@@ -730,6 +764,18 @@ defmodule Ash.Test.Actions.BulkCreateTest do
                sorted?: true,
                tenant: org.id
              )
+  end
+
+  test "passes shared context to preparations when returning created records" do
+    shared_context = %{some_id: Ash.UUID.generate()}
+
+    assert %Ash.BulkResult{records: [%{title: "title"}]} =
+             Ash.bulk_create!([%{title: "title"}], PostWithSharedContextPreparation, :create,
+               return_records?: true,
+               context: %{shared: shared_context}
+             )
+
+    assert_receive {:shared_context, ^shared_context}
   end
 
   test "runs before action hooks" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Propagate the action's `shared` context to the read pipeline used to load records returned by `Ash.bulk_create/4`.

Previously, the bulk-create return path replaced the load context with only `private.just_created_by_action`. As a result, global read preparations depending on `context.shared` did not receive the caller's shared context.

## Changes

- Preserve `context.shared` in both loads performed while processing bulk-create results.