### PR TITLE
docs: fix typos in docstrings and comments

### DIFF
--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -1863,7 +1863,7 @@ defmodule Ash.CodeInterface do
 
   @doc false
   def trim_double_newlines(str) do
-    # this actualy trims *triple* newlines
+    # this actually trims *triple* newlines
     str
     |> String.replace(~r/\n{3,}/, "\n\n")
     |> String.trim_trailing()

--- a/lib/ash/data_layer/mnesia/mnesia.ex
+++ b/lib/ash/data_layer/mnesia/mnesia.ex
@@ -377,7 +377,7 @@ defmodule Ash.DataLayer.Mnesia do
     if options[:upsert?] do
       # This uses a lot of the ETS datalayer as a reference point. It is
       # recommended to NOT use this and instead upsert on the pkey which should
-      # use the optmized approach in the `else` logic.
+      # use the optimized approach in the `else` logic.
       stream
       |> Enum.reduce_while({:ok, []}, fn changeset, {:ok, results} ->
         changeset =

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1694,7 +1694,7 @@ defmodule Ash.Query do
   Determines if the filter statement of a query is equivalent to the provided expression.
 
   This uses the satisfiability solver that is used when solving for policy authorizations. In complex scenarios, or when using
-  custom database expressions, (like fragments in ash_postgres), this function may return `:maybe`. Use `supserset_of?` to always return
+  custom database expressions, (like fragments in ash_postgres), this function may return `:maybe`. Use `superset_of?` to always return
   a boolean.
   """
   defmacro equivalent_to(query, expr) do
@@ -1730,7 +1730,7 @@ defmodule Ash.Query do
   Determines if the provided expression would return data that is a subset of the data returned by the filter on the query.
 
   This uses the satisfiability solver that is used when solving for policy authorizations. In complex scenarios, or when using
-  custom database expressions, (like fragments in ash_postgres), this function may return `:maybe`. Use `supserset_of?` to always return
+  custom database expressions, (like fragments in ash_postgres), this function may return `:maybe`. Use `superset_of?` to always return
   a boolean.
   """
   defmacro superset_of(query, expr) do

--- a/lib/ash/resource/record.ex
+++ b/lib/ash/resource/record.ex
@@ -8,7 +8,7 @@ defmodule Ash.Resource.Record do
 
   This module acts as a way to refer to the type via t:t()
   and will also act as a place for shared functionality for
-  instances of resouces in the future.
+  instances of resources in the future.
   """
   @type t :: struct()
 end


### PR DESCRIPTION
- Ash.Query: `supserset_of?` -> `superset_of?` in `equivalent_to/2` and `superset_of/2` docstrings (broken reference to the real `superset_of?` macro)
- Ash.Resource.Record: `resouces` -> `resources` in @moduledoc
- Ash.CodeInterface: `actualy` -> `actually` in a comment
- Ash.DataLayer.Mnesia: `optmized` -> `optimized` in a comment
