### PR TITLE
Fix atomic negated validation errors

### DIFF
--- a/lib/ash/resource/validation/negate.ex
+++ b/lib/ash/resource/validation/negate.ex
@@ -115,7 +115,7 @@ defmodule Ash.Resource.Validation.Negate do
     {:atomic, fields, Ash.Expr.expr(not (^condition)),
      Ash.Expr.expr(
        error(^InvalidChanges, %{
-         fields: fields,
+         fields: ^fields,
          message: ^message,
          vars: ^Map.new(vars)
        })

--- a/test/resource/validation/negate_test.exs
+++ b/test/resource/validation/negate_test.exs
@@ -6,12 +6,18 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  require Ash.Query
+
   alias Ash.Resource.Validation.Negate
 
   alias Ash.Test.Domain, as: Domain
 
   defmodule Post do
-    use Ash.Resource, domain: Domain
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
 
     actions do
       default_accept :*
@@ -24,6 +30,13 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
       attribute :status, :atom do
         public?(true)
       end
+    end
+
+    validations do
+      validate negate(changing(:status)),
+        on: :update,
+        where: [data_one_of(:status, [:published])],
+        message: "The status of a published post cannot be changed."
     end
   end
 
@@ -76,6 +89,43 @@ defmodule Ash.Test.Resource.Validation.NegateTest do
       assert_raise ArgumentError, ~r/must implement `describe\/1`/, fn ->
         Negate.init(validation: CustomValidationNoDescribe)
       end
+    end
+
+    test "conditionally rejects changing an attribute in an atomic update" do
+      draft = Ash.create!(Post, %{status: :draft})
+      published = Ash.create!(Post, %{status: :published})
+
+      assert %Ash.BulkResult{
+               status: :success,
+               records: [%Post{status: :archived}]
+             } =
+               Post
+               |> Ash.Query.filter(id == ^draft.id)
+               |> Ash.bulk_update(:update, %{status: :archived},
+                 strategy: :atomic,
+                 return_records?: true,
+                 return_errors?: true
+               )
+
+      assert %Ash.BulkResult{
+               status: :error,
+               errors: [
+                 %Ash.Error.Invalid{
+                   errors: [
+                     %Ash.Error.Changes.InvalidChanges{
+                       fields: [:status],
+                       message: "The status of a published post cannot be changed."
+                     }
+                   ]
+                 }
+               ]
+             } =
+               Post
+               |> Ash.Query.filter(id == ^published.id)
+               |> Ash.bulk_update(:update, %{status: :archived},
+                 strategy: :atomic,
+                 return_errors?: true
+               )
     end
   end
 end


### PR DESCRIPTION
Adds a missed pin operator to the error expression generated by `Negate`, and a test covering the validation through an atomic update.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
