### PR TITLE
fix: enforce sortable fasle consistently

### DIFF
--- a/lib/ash/resource/info.ex
+++ b/lib/ash/resource/info.ex
@@ -982,6 +982,9 @@ defmodule Ash.Resource.Info do
       nil ->
         false
 
+      %{sortable?: false} ->
+        false
+
       %{type: {:array, _}} ->
         false
 

--- a/lib/ash/sort/sort.ex
+++ b/lib/ash/sort/sort.ex
@@ -252,14 +252,12 @@ defmodule Ash.Sort do
           [] ->
             case do_get_field(resource, field, only_public?, input) do
               {:ok, field} ->
-                if type_sortable?(resource, field) do
+                with :ok <- validate_sortable(resource, field) do
                   case field do
                     %Ash.Query.Aggregate{} = field -> {:ok, field}
                     %Ash.Query.Calculation{} = field -> {:ok, field}
                     %{name: name} -> {:ok, name}
                   end
-                else
-                  {:error, UnsortableField.exception(field: field.name, resource: resource)}
                 end
 
               {:error, error} ->
@@ -382,6 +380,84 @@ defmodule Ash.Sort do
     do_type_sortable?(resource, field.type, field.constraints)
   end
 
+  defp validate_sortable(resource, %{sortable?: false} = field) do
+    {:error, UnsortableField.exception(field: field_name(field), resource: resource)}
+  end
+
+  defp validate_sortable(resource, field) do
+    with :ok <- validate_expression_refs(resource, field) do
+      if type_sortable?(resource, field) do
+        :ok
+      else
+        {:error, UnsortableField.exception(field: field_name(field), resource: resource)}
+      end
+    end
+  end
+
+  defp validate_expression_refs(
+         resource,
+         %Ash.Query.Calculation{module: module, opts: opts, context: context}
+       ) do
+    if Ash.Resource.Calculation.has_expression?(module) do
+      module
+      |> Ash.Resource.Calculation.expression(opts, context)
+      |> Ash.Filter.hydrate_refs(%{resource: resource, public?: false})
+      |> case do
+        {:ok, expression} ->
+          expression
+          |> Ash.Filter.list_refs(false, false, true)
+          |> Enum.reduce_while(:ok, fn ref, :ok ->
+            case validate_expression_ref(resource, ref) do
+              :ok -> {:cont, :ok}
+              {:error, error} -> {:halt, {:error, error}}
+            end
+          end)
+
+        {:error, error} ->
+          {:error, error}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp validate_expression_refs(_resource, _field), do: :ok
+
+  defp validate_expression_ref(
+         resource,
+         %Ash.Query.Ref{attribute: field, relationship_path: relationship_path}
+       ) do
+    with {:ok, related} <- validate_sortable_relationship_path(resource, relationship_path) do
+      case field do
+        %{sortable?: false} ->
+          {:error, UnsortableField.exception(field: field_name(field), resource: related)}
+
+        _ ->
+          :ok
+      end
+    end
+  end
+
+  defp validate_sortable_relationship_path(resource, []) do
+    {:ok, resource}
+  end
+
+  defp validate_sortable_relationship_path(resource, [first | rest]) do
+    case Ash.Resource.Info.relationship(resource, first) do
+      %{sortable?: false, name: name} ->
+        {:error, UnsortableField.exception(field: name, resource: resource)}
+
+      %{sortable?: true, destination: destination} ->
+        validate_sortable_relationship_path(destination, rest)
+
+      _ ->
+        {:error, NoSuchField.exception(field: first, resource: resource)}
+    end
+  end
+
+  defp field_name(%Ash.Query.Calculation{calc_name: name}) when not is_nil(name), do: name
+  defp field_name(%{name: name}), do: name
+
   defp aggregate_type(resource, aggregate) do
     attribute =
       if aggregate.field do
@@ -466,17 +542,11 @@ defmodule Ash.Sort do
       {:error, error} ->
         {:error, error}
 
-      {:ok, %{sortable?: true} = field} ->
-        {type, constraints} = get_type(resource, field)
-
-        if do_type_sortable?(resource, type, constraints) do
+      {:ok, field} ->
+        with :ok <- validate_sortable(resource, field) do
+          {type, constraints} = get_type(resource, field)
           {:ok, Enum.reverse(acc), field, type, constraints}
-        else
-          {:error, UnsortableField.exception(field: field.name, resource: resource)}
         end
-
-      {:ok, %{name: name}} ->
-        {:error, UnsortableField.exception(field: name, resource: resource)}
     end
   end
 

--- a/test/resource/info_test.exs
+++ b/test/resource/info_test.exs
@@ -40,6 +40,7 @@ defmodule Ash.Test.Resource.InfoTest do
       end
 
       attribute :points, :integer
+      attribute :unsortable, :string, sortable?: false
     end
 
     aggregates do
@@ -187,13 +188,15 @@ defmodule Ash.Test.Resource.InfoTest do
                :private,
                :tags,
                :tags_join_assoc,
-               :title
+               :title,
+               :unsortable
              ] = Info.fields(Post) |> Enum.map(& &1.name) |> Enum.sort()
     end
 
     test "determine if field is sortable" do
       assert true == Info.sortable?(Post, :title)
       assert true == Info.sortable?(Post, :points)
+      assert false == Info.sortable?(Post, :unsortable)
       assert false == Info.sortable?(Post, :points, include_private?: false)
       assert false == Info.sortable?(Post, :authors)
       assert false == Info.sortable?(Post, :tags)

--- a/test/sort/sort_test.exs
+++ b/test/sort/sort_test.exs
@@ -19,6 +19,7 @@ defmodule Ash.Test.Sort.SortTest do
     attributes do
       uuid_primary_key :id
       attribute :name, :string, public?: true
+      attribute :unsortable_name, :string, public?: true, sortable?: false
       attribute :private_name, :string
     end
 
@@ -57,12 +58,28 @@ defmodule Ash.Test.Sort.SortTest do
         public? true
       end
 
+      attribute :unsortable_title, :string, public?: true, sortable?: false
       attribute :points, :integer
+    end
+
+    aggregates do
+      count :comment_count, :comments_by_author, public?: true, sortable?: false
+    end
+
+    calculations do
+      calculate :title_calculation, :string, expr(title),
+        public?: true,
+        sortable?: false
     end
 
     relationships do
       belongs_to :author, Author do
         public? true
+      end
+
+      belongs_to :unsortable_author, Author do
+        public? true
+        sortable? false
       end
 
       belongs_to :private_author, Author
@@ -131,7 +148,6 @@ defmodule Ash.Test.Sort.SortTest do
     attributes do
       uuid_primary_key :id
       attribute :name, :string, public?: true
-      attribute :secret_name, :string, public?: true, sortable?: false
     end
 
     actions do
@@ -149,7 +165,6 @@ defmodule Ash.Test.Sort.SortTest do
 
     relationships do
       belongs_to :author, NoSortAuthor, public?: true
-      belongs_to :private_author, NoSortAuthor, public?: true, sortable?: false
     end
 
     actions do
@@ -275,24 +290,98 @@ defmodule Ash.Test.Sort.SortTest do
                Ash.Sort.parse_input(NoSortAuthor, "name")
     end
 
-    test "returns UnsortableField error for field with sortable?: false" do
-      assert {:error, %Ash.Error.Query.UnsortableField{field: :secret_name}} =
-               Ash.Sort.parse_input(NoSortAuthor, "secret_name")
-    end
-
     test "returns UnsortableField error for relationship field with unsortable type" do
       assert {:error, %Ash.Error.Query.UnsortableField{field: :name}} =
                Ash.Sort.parse_input(NoSortPost, "author.name")
     end
 
-    test "returns UnsortableField error for relationship field with sortable?: false" do
-      assert {:error, %Ash.Error.Query.UnsortableField{field: :secret_name}} =
-               Ash.Sort.parse_input(NoSortPost, "author.secret_name")
+    test "parse_input rejects top-level fields configured with sortable?: false" do
+      for field <- [:unsortable_title, :comment_count, :title_calculation] do
+        assert {:error,
+                %Ash.Error.Query.UnsortableField{
+                  resource: Ash.Test.Sort.SortTest.Post,
+                  field: ^field
+                }} = Ash.Sort.parse_input(Post, field)
+      end
     end
 
-    test "returns UnsortableField error for relationship with sortable?: false" do
-      assert {:error, %Ash.Error.Query.UnsortableField{field: :private_author}} =
-               Ash.Sort.parse_input(NoSortPost, "private_author.name")
+    test "sort_input rejects top-level fields configured with sortable?: false" do
+      for field <- [:unsortable_title, :comment_count, :title_calculation] do
+        assert %Ash.Query{
+                 valid?: false,
+                 errors: [
+                   %Ash.Error.Query.UnsortableField{
+                     resource: Ash.Test.Sort.SortTest.Post,
+                     field: ^field
+                   }
+                 ]
+               } = Ash.Query.sort_input(Post, field)
+      end
+    end
+
+    test "sort rejects top-level fields configured with sortable?: false" do
+      for field <- [:unsortable_title, :comment_count, :title_calculation] do
+        assert %Ash.Query{
+                 valid?: false,
+                 errors: [
+                   %Ash.Error.Query.UnsortableField{
+                     resource: Ash.Test.Sort.SortTest.Post,
+                     field: ^field
+                   }
+                 ]
+               } = Ash.Query.sort(Post, field)
+      end
+    end
+
+    test "expression sorts reject references to unsortable fields and relationships" do
+      require Ash.Sort
+
+      assert %Ash.Query{
+               valid?: false,
+               errors: [
+                 %Ash.Error.Query.UnsortableField{
+                   resource: Ash.Test.Sort.SortTest.Post,
+                   field: :unsortable_title
+                 }
+               ]
+             } = Ash.Query.sort(Post, Ash.Sort.expr_sort(unsortable_title, :string))
+
+      assert %Ash.Query{
+               valid?: false,
+               errors: [
+                 %Ash.Error.Query.UnsortableField{
+                   resource: Ash.Test.Sort.SortTest.Author,
+                   field: :unsortable_name
+                 }
+               ]
+             } = Ash.Query.sort(Post, Ash.Sort.expr_sort(author.unsortable_name, :string))
+
+      assert %Ash.Query{
+               valid?: false,
+               errors: [
+                 %Ash.Error.Query.UnsortableField{
+                   resource: Ash.Test.Sort.SortTest.Post,
+                   field: :unsortable_author
+                 }
+               ]
+             } = Ash.Query.sort(Post, Ash.Sort.expr_sort(unsortable_author.name, :string))
+    end
+
+    test "nested sorts enforce field and relationship flags" do
+      assert {:ok, [{%Ash.Query.Calculation{}, :asc}]} =
+               Ash.Sort.parse_input(Post, "author.name")
+
+      assert {:error,
+              %Ash.Error.Query.UnsortableField{
+                resource: Ash.Test.Sort.SortTest.Author,
+                field: :unsortable_name
+              }} = Ash.Sort.parse_input(Post, "author.unsortable_name")
+
+      assert {:error,
+              %Ash.Error.Query.UnsortableField{
+                resource: Ash.Test.Sort.SortTest.Post,
+                field: :unsortable_author
+              }} = Ash.Sort.parse_input(Post, "unsortable_author.name")
     end
   end
 end


### PR DESCRIPTION
# Problem
Top-level sorts only checked whether the data layer supported the field type, allowing fields configured with sortable?: false to be sorted. Expression sorts could bypass the restriction by referencing unsortable fields or traversing unsortable relationships. This makes sortable unusable for use right now as a wrong sort could kill our production database.

# Summary

Enforces sortable?: false consistently across Ash.Sort.parse_input/2, Ash.Query.sort_input/3, Ash.Query.sort/3, and Ash.Resource.Info.sortable?/3.
Adds ETS-backed regression coverage for attributes, aggregates, calculations, expressions, and nested sorts.

# AI Disclosure

I manually verified the bug. I used AI to analyse the problem and generate the fix. I manually reviewed and iterated on the fix and manually tested it with our production code

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
