### PR TITLE
improvement: add strict? constraint to Ash.Type.UUIDv7

### DIFF
--- a/lib/ash/type/uuid_v7.ex
+++ b/lib/ash/type/uuid_v7.ex
@@ -3,10 +3,24 @@
 # SPDX-License-Identifier: MIT
 
 defmodule Ash.Type.UUIDv7 do
+  @constraints [
+    strict?: [
+      type: :boolean,
+      default: false,
+      doc: """
+      Requires the value to actually be a version 7 UUID. Recommended for externally-supplied values: without it, any well-formed UUID passes input casting, but non-v7 values cannot be loaded back from storage.
+      """
+    ]
+  ]
+
   @moduledoc """
   Represents a UUID.
 
   A builtin type that can be referenced via `:uuid_v7`
+
+  ### Constraints
+
+  #{Spark.Options.docs(@constraints)}
   """
 
   use Ash.Type,
@@ -16,6 +30,21 @@ defmodule Ash.Type.UUIDv7 do
 
   @impl true
   def storage_type(_), do: :uuid
+
+  @impl true
+  def constraints, do: @constraints
+
+  @impl true
+  def apply_constraints(nil, _constraints), do: :ok
+
+  def apply_constraints(value, constraints) do
+    if Keyword.get(constraints, :strict?, false) and
+         not match?(<<_::48, 7::4, _::12, 0b10::2, _::62>>, Ash.UUIDv7.decode(value)) do
+      {:error, message: "must be a version 7 UUID"}
+    else
+      :ok
+    end
+  end
 
   @impl true
   def generator(_constraints) do

--- a/test/type/uuid_v7_test.exs
+++ b/test/type/uuid_v7_test.exs
@@ -81,4 +81,32 @@ defmodule Ash.Test.Type.UUIDv7Test do
 
     assert {:ok, ^uuid_v7} = Ash.Type.coerce(Ash.Type.UUIDv7, binary_uuid_v7)
   end
+
+  describe "strict? constraint" do
+    test "rejects a non-v7 uuid string that cast_input accepted" do
+      uuid_v4 = "550e8400-e29b-41d4-a716-446655440000"
+
+      assert {:ok, ^uuid_v4} = Ash.Type.cast_input(Ash.Type.UUIDv7, uuid_v4)
+
+      assert {:error, message: "must be a version 7 UUID"} =
+               Ash.Type.apply_constraints(Ash.Type.UUIDv7, uuid_v4, strict?: true)
+    end
+
+    test "accepts a version 7 uuid" do
+      uuid_v7 = "01903fa1-2523-7580-a9d6-84620dcbf2ba"
+
+      assert {:ok, ^uuid_v7} =
+               Ash.Type.apply_constraints(Ash.Type.UUIDv7, uuid_v7, strict?: true)
+    end
+
+    test "accepts nil" do
+      assert {:ok, nil} = Ash.Type.apply_constraints(Ash.Type.UUIDv7, nil, strict?: true)
+    end
+
+    test "is not enforced by default" do
+      uuid_v4 = "550e8400-e29b-41d4-a716-446655440000"
+
+      assert {:ok, ^uuid_v4} = Ash.Type.apply_constraints(Ash.Type.UUIDv7, uuid_v4, [])
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2794.

Adds an opt-in `strict?` constraint (default `false`) to `Ash.Type.UUIDv7`. When set, non-v7 uuids are rejected at constraint application with `must be a version 7 UUID`, so callers get an input validation error instead of a load failure after the row is written.

The default preserves current behavior, including the `match_v4_uuids?` compile config. When both are set, `strict?` wins: the raw v4 binary casts, then fails the constraint.

Usage:

```elixir
argument :id, :uuid_v7, constraints: [strict?: true]
```

Whether strictness should eventually become the default (the coherent semantics for a type named UUIDv7, but breaking for anyone currently feeding other versions through it) is left to #2794.
