### PR TITLE
feat: support before_transaction? option on validations

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -58,6 +58,7 @@ spark_locals_without_parens = [
   base_filter: 1,
   batch_size: 1,
   before_action?: 1,
+  before_transaction?: 1,
   belongs_to: 2,
   belongs_to: 3,
   broadcast_type: 1,

--- a/documentation/dsls/DSL-Ash.Resource.md
+++ b/documentation/dsls/DSL-Ash.Resource.md
@@ -1106,6 +1106,7 @@ validate present([:first_name, :last_name], at_least: 1)
 | [`message`](#actions-action-validate-message){: #actions-action-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#actions-action-validate-description){: #actions-action-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#actions-action-validate-before_action?){: #actions-action-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#actions-action-validate-before_transaction?){: #actions-action-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 
 
 
@@ -1307,6 +1308,7 @@ validate changing(:email)
 | [`message`](#actions-create-validate-message){: #actions-create-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#actions-create-validate-description){: #actions-create-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#actions-create-validate-before_action?){: #actions-create-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#actions-create-validate-before_transaction?){: #actions-create-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 | [`always_atomic?`](#actions-create-validate-always_atomic?){: #actions-create-validate-always_atomic? } | `boolean` | `false` | By default, validations are only run atomically if all changes will be run atomically or if there is no `validate/3` callback defined. Set this to `true` to run it atomically always. |
 
 
@@ -1633,6 +1635,7 @@ validate present([:first_name, :last_name], at_least: 1)
 | [`message`](#actions-read-validate-message){: #actions-read-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#actions-read-validate-description){: #actions-read-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#actions-read-validate-before_action?){: #actions-read-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#actions-read-validate-before_transaction?){: #actions-read-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 
 
 
@@ -1943,6 +1946,7 @@ validate changing(:email)
 | [`message`](#actions-update-validate-message){: #actions-update-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#actions-update-validate-description){: #actions-update-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#actions-update-validate-before_action?){: #actions-update-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#actions-update-validate-before_transaction?){: #actions-update-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 | [`always_atomic?`](#actions-update-validate-always_atomic?){: #actions-update-validate-always_atomic? } | `boolean` | `false` | By default, validations are only run atomically if all changes will be run atomically or if there is no `validate/3` callback defined. Set this to `true` to run it atomically always. |
 
 
@@ -2236,6 +2240,7 @@ validate changing(:email)
 | [`message`](#actions-destroy-validate-message){: #actions-destroy-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#actions-destroy-validate-description){: #actions-destroy-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#actions-destroy-validate-before_action?){: #actions-destroy-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#actions-destroy-validate-before_transaction?){: #actions-destroy-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 | [`always_atomic?`](#actions-destroy-validate-always_atomic?){: #actions-destroy-validate-always_atomic? } | `boolean` | `false` | By default, validations are only run atomically if all changes will be run atomically or if there is no `validate/3` callback defined. Set this to `true` to run it atomically always. |
 
 
@@ -3023,6 +3028,7 @@ validate present([:first_name, :last_name], at_least: 1)
 | [`message`](#validations-validate-message){: #validations-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#validations-validate-description){: #validations-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#validations-validate-before_action?){: #validations-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#validations-validate-before_transaction?){: #validations-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 | [`always_atomic?`](#validations-validate-always_atomic?){: #validations-validate-always_atomic? } | `boolean` | `false` | By default, validations are only run atomically if all changes will be run atomically or if there is no `validate/3` callback defined. Set this to `true` to run it atomically always. |
 
 
@@ -3181,6 +3187,7 @@ validate changing(:email)
 | [`message`](#pipelines-pipeline-validate-message){: #pipelines-pipeline-validate-message } | `String.t` |  | If provided, overrides any message set by the validation error |
 | [`description`](#pipelines-pipeline-validate-description){: #pipelines-pipeline-validate-description } | `String.t` |  | An optional description for the validation |
 | [`before_action?`](#pipelines-pipeline-validate-before_action?){: #pipelines-pipeline-validate-before_action? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_action hook |
+| [`before_transaction?`](#pipelines-pipeline-validate-before_transaction?){: #pipelines-pipeline-validate-before_transaction? } | `boolean` | `false` | If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`. |
 | [`always_atomic?`](#pipelines-pipeline-validate-always_atomic?){: #pipelines-pipeline-validate-always_atomic? } | `boolean` | `false` | By default, validations are only run atomically if all changes will be run atomically or if there is no `validate/3` callback defined. Set this to `true` to run it atomically always. |
 
 

--- a/lib/ash/action_input.ex
+++ b/lib/ash/action_input.ex
@@ -1305,20 +1305,34 @@ defmodule Ash.ActionInput do
   end
 
   defp validate(input, validation, tracer, metadata, actor) do
-    if validation.before_action? do
-      before_action(input, fn input ->
-        if validation.only_when_valid? and not input.valid? do
-          input
-        else
-          do_validation(input, validation, tracer, metadata, actor)
-        end
-      end)
-    else
-      if validation.only_when_valid? and not input.valid? do
+    cond do
+      validation.before_transaction? ->
+        before_transaction(
+          input,
+          fn input ->
+            if validation.only_when_valid? and not input.valid? do
+              input
+            else
+              do_validation(input, validation, tracer, metadata, actor)
+            end
+          end,
+          prepend?: true
+        )
+
+      validation.before_action? ->
+        before_action(input, fn input ->
+          if validation.only_when_valid? and not input.valid? do
+            input
+          else
+            do_validation(input, validation, tracer, metadata, actor)
+          end
+        end)
+
+      validation.only_when_valid? and not input.valid? ->
         input
-      else
+
+      true ->
         do_validation(input, validation, tracer, metadata, actor)
-      end
     end
   end
 
@@ -1760,14 +1774,11 @@ defmodule Ash.ActionInput do
             {:halt, {:error, error}}
 
           %Ash.ActionInput{} = input ->
-            cont =
-              if input.valid? do
-                :cont
-              else
-                :halt
-              end
-
-            {cont, {:ok, input}}
+            if input.valid? do
+              {:cont, {:ok, input}}
+            else
+              {:halt, {:error, input.errors}}
+            end
 
           other ->
             raise """

--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -1866,49 +1866,90 @@ defmodule Ash.Actions.Create.Bulk do
             )
 
           batch =
-            if module.has_batch_validate?() &&
-                 module.batch_callbacks?(batch, opts, validation_context) do
-              Ash.Actions.Helpers.Bulk.run_batch_validation(
-                validation,
-                batch,
-                validation_context,
-                actor
-              )
-            else
-              Enum.map(batch, fn changeset ->
-                cond do
-                  !module.has_validate?() ->
-                    Ash.Changeset.add_error(
-                      changeset,
-                      Ash.Error.Framework.CanNotBeAtomic.exception(
-                        resource: changeset.resource,
-                        change: module,
-                        reason: "Create actions cannot be made atomic"
+            cond do
+              validation.before_transaction? and
+                (module.has_validate?() or module.has_batch_validate?()) and
+                  Enum.all?(validation.where || [], fn {where_mod, _opts} ->
+                    where_mod.has_validate?()
+                  end) ->
+                Enum.map(batch, fn changeset ->
+                  Ash.Changeset.before_transaction(
+                    changeset,
+                    fn changeset ->
+                      Ash.Actions.Helpers.Bulk.run_before_transaction_validation(
+                        changeset,
+                        validation,
+                        validation_context,
+                        actor
                       )
-                    )
+                    end,
+                    prepend?: true
+                  )
+                end)
 
-                  invalid =
-                      Enum.find(validation.where, fn {where_mod, _} ->
-                        !where_mod.has_validate?()
-                      end) ->
-                    {invalid_mod, _} = invalid
+              module.has_batch_validate?() &&
+                  module.batch_callbacks?(batch, opts, validation_context) ->
+                Ash.Actions.Helpers.Bulk.run_batch_validation(
+                  validation,
+                  batch,
+                  validation_context,
+                  actor
+                )
 
-                    Ash.Changeset.add_error(
-                      changeset,
-                      Ash.Error.Framework.CanNotBeAtomic.exception(
-                        resource: changeset.resource,
-                        change: invalid_mod,
-                        reason: "Create actions cannot be made atomic"
+              true ->
+                Enum.map(batch, fn changeset ->
+                  cond do
+                    !module.has_validate?() ->
+                      Ash.Changeset.add_error(
+                        changeset,
+                        Ash.Error.Framework.CanNotBeAtomic.exception(
+                          resource: changeset.resource,
+                          change: module,
+                          reason: "Create actions cannot be made atomic"
+                        )
                       )
-                    )
 
-                  validation.only_when_valid? && !changeset.valid? ->
-                    changeset
+                    invalid =
+                        Enum.find(validation.where, fn {where_mod, _} ->
+                          !where_mod.has_validate?()
+                        end) ->
+                      {invalid_mod, _} = invalid
 
-                  Enum.all?(validation.where || [], fn {where_mod, where_opts} ->
-                    where_opts =
+                      Ash.Changeset.add_error(
+                        changeset,
+                        Ash.Error.Framework.CanNotBeAtomic.exception(
+                          resource: changeset.resource,
+                          change: invalid_mod,
+                          reason: "Create actions cannot be made atomic"
+                        )
+                      )
+
+                    validation.only_when_valid? && !changeset.valid? ->
+                      changeset
+
+                    Enum.all?(validation.where || [], fn {where_mod, where_opts} ->
+                      where_opts =
+                          templated_opts(
+                            where_opts,
+                            actor,
+                            changeset.to_tenant,
+                            changeset.arguments,
+                            changeset.context,
+                            changeset
+                          )
+
+                      {:ok, where_opts} = Ash.Resource.Validation.init(where_mod, where_opts)
+
+                      Ash.Resource.Validation.validate(
+                        where_mod,
+                        changeset,
+                        where_opts,
+                        struct(Ash.Resource.Validation.Context, context)
+                      ) == :ok
+                    end) ->
+                      opts =
                         templated_opts(
-                          where_opts,
+                          opts,
                           actor,
                           changeset.to_tenant,
                           changeset.arguments,
@@ -1916,56 +1957,37 @@ defmodule Ash.Actions.Create.Bulk do
                           changeset
                         )
 
-                    {:ok, where_opts} = Ash.Resource.Validation.init(where_mod, where_opts)
+                      {:ok, opts} = Ash.Resource.Validation.init(module, opts)
 
-                    Ash.Resource.Validation.validate(
-                      where_mod,
-                      changeset,
-                      where_opts,
-                      struct(Ash.Resource.Validation.Context, context)
-                    ) == :ok
-                  end) ->
-                    opts =
-                      templated_opts(
-                        opts,
-                        actor,
-                        changeset.to_tenant,
-                        changeset.arguments,
-                        changeset.context,
-                        changeset
-                      )
+                      case Ash.Resource.Validation.validate(
+                             module,
+                             changeset,
+                             opts,
+                             struct(
+                               Ash.Resource.Validation.Context,
+                               Map.put(context, :message, validation.message)
+                             )
+                           ) do
+                        :ok ->
+                          changeset
 
-                    {:ok, opts} = Ash.Resource.Validation.init(module, opts)
+                        {:error, error} ->
+                          error = Ash.Error.to_ash_error(error)
 
-                    case Ash.Resource.Validation.validate(
-                           module,
-                           changeset,
-                           opts,
-                           struct(
-                             Ash.Resource.Validation.Context,
-                             Map.put(context, :message, validation.message)
-                           )
-                         ) do
-                      :ok ->
-                        changeset
+                          if validation.message do
+                            error =
+                              Ash.Error.override_validation_message(error, validation.message)
 
-                      {:error, error} ->
-                        error = Ash.Error.to_ash_error(error)
+                            Ash.Changeset.add_error(changeset, error)
+                          else
+                            Ash.Changeset.add_error(changeset, error)
+                          end
+                      end
 
-                        if validation.message do
-                          error =
-                            Ash.Error.override_validation_message(error, validation.message)
-
-                          Ash.Changeset.add_error(changeset, error)
-                        else
-                          Ash.Changeset.add_error(changeset, error)
-                        end
-                    end
-
-                  true ->
-                    changeset
-                end
-              end)
+                    true ->
+                      changeset
+                  end
+                end)
             end
 
           %{

--- a/lib/ash/actions/helpers/bulk.ex
+++ b/lib/ash/actions/helpers/bulk.ex
@@ -566,4 +566,89 @@ defmodule Ash.Actions.Helpers.Bulk do
       Enum.concat(validated, non_matches)
     end
   end
+
+  @doc """
+  Runs a `before_transaction?` validation against a single changeset, inside its
+  `before_transaction` hook.
+
+  The `only_when_valid?` check is deferred to hook time, matching the semantics of
+  non-bulk actions. Dispatches to `batch_validate/3` (with a single element batch)
+  when the validation module defines it, and to `validate/3` otherwise.
+  """
+  def run_before_transaction_validation(
+        changeset,
+        %{validation: {module, opts}} = validation,
+        validation_context,
+        actor
+      ) do
+    cond do
+      validation.only_when_valid? and not changeset.valid? ->
+        changeset
+
+      module.has_batch_validate?() and
+          module.batch_callbacks?([changeset], opts, validation_context) ->
+        [changeset] = run_batch_validation(validation, [changeset], validation_context, actor)
+
+        changeset
+
+      true ->
+        where_passes? =
+          Enum.all?(validation.where || [], fn {where_module, where_opts} ->
+            where_opts =
+              Ash.Actions.Helpers.templated_opts(
+                where_opts,
+                actor,
+                changeset.to_tenant,
+                changeset.arguments,
+                changeset.context,
+                changeset
+              )
+
+            {:ok, where_opts} = Ash.Resource.Validation.init(where_module, where_opts)
+
+            Ash.Resource.Validation.validate(
+              where_module,
+              changeset,
+              where_opts,
+              validation_context
+            ) == :ok
+          end)
+
+        if where_passes? do
+          opts =
+            Ash.Actions.Helpers.templated_opts(
+              opts,
+              actor,
+              changeset.to_tenant,
+              changeset.arguments,
+              changeset.context,
+              changeset
+            )
+
+          {:ok, opts} = Ash.Resource.Validation.init(module, opts)
+
+          case Ash.Resource.Validation.validate(
+                 module,
+                 changeset,
+                 opts,
+                 validation_context
+               ) do
+            :ok ->
+              changeset
+
+            {:error, error} ->
+              error =
+                if validation.message do
+                  Ash.Error.override_validation_message(error, validation.message)
+                else
+                  error
+                end
+
+              Ash.Changeset.add_error(changeset, error)
+          end
+        else
+          changeset
+        end
+    end
+  end
 end

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -180,7 +180,11 @@ defmodule Ash.Actions.Read do
 
         case result do
           %Ash.Query{} = query ->
-            {:cont, {:ok, query}}
+            if query.valid? do
+              {:cont, {:ok, query}}
+            else
+              {:halt, {:error, query.errors}}
+            end
 
           {:error, error} ->
             {:halt, {:error, error}}

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -3557,19 +3557,40 @@ defmodule Ash.Actions.Update.Bulk do
             )
 
           batch =
-            if module.has_batch_validate?() &&
-                 module.batch_callbacks?(batch, validation_opts, validation_context) do
-              Ash.Actions.Helpers.Bulk.run_batch_validation(
-                validation,
-                batch,
-                validation_context,
-                actor
-              )
-            else
-              if module.has_validate?() &&
-                   Enum.all?(validation.where, fn {module, _opts} ->
-                     module.has_validate?()
-                   end) do
+            cond do
+              validation.before_transaction? and
+                (module.has_validate?() or module.has_batch_validate?()) and
+                  Enum.all?(validation.where, fn {module, _opts} ->
+                    module.has_validate?()
+                  end) ->
+                Enum.map(batch, fn changeset ->
+                  Ash.Changeset.before_transaction(
+                    changeset,
+                    fn changeset ->
+                      Ash.Actions.Helpers.Bulk.run_before_transaction_validation(
+                        changeset,
+                        validation,
+                        validation_context,
+                        actor
+                      )
+                    end,
+                    prepend?: true
+                  )
+                end)
+
+              module.has_batch_validate?() &&
+                  module.batch_callbacks?(batch, validation_opts, validation_context) ->
+                Ash.Actions.Helpers.Bulk.run_batch_validation(
+                  validation,
+                  batch,
+                  validation_context,
+                  actor
+                )
+
+              module.has_validate?() &&
+                  Enum.all?(validation.where, fn {module, _opts} ->
+                    module.has_validate?()
+                  end) ->
                 if validation.before_action? do
                   Enum.map(batch, fn changeset ->
                     Ash.Changeset.before_action(changeset, fn changeset ->
@@ -3587,17 +3608,16 @@ defmodule Ash.Actions.Update.Bulk do
                 else
                   validate_batch_non_atomically(validation, batch, validation_context, actor)
                 end
-              else
-                if module.atomic?() do
-                  validate_batch_atomically(validation, batch, validation_context, context, actor)
-                else
-                  raise """
-                  Cannot use a non-atomic validation with an atomic condition.
 
-                  Attempting to run action: `#{inspect(resource)}.#{action.name}`
-                  """
-                end
-              end
+              module.atomic?() ->
+                validate_batch_atomically(validation, batch, validation_context, context, actor)
+
+              true ->
+                raise """
+                Cannot use a non-atomic validation with an atomic condition.
+
+                Attempting to run action: `#{inspect(resource)}.#{action.name}`
+                """
             end
 
           %{

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -1177,23 +1177,30 @@ defmodule Ash.Changeset do
 
   @doc false
   def run_atomic_validation(changeset, %{where: where} = validation, context) do
-    if validation.before_action? do
-      {:not_atomic,
-       "before_action? validation `#{inspect(elem(validation.validation, 0))}` cannot be run atomically. " <>
-         "To use before_action? validations, set `require_atomic? false` or use `strategy: [:stream]`."}
-    else
-      with {:atomic, condition} <- atomic_condition(where, changeset, context) do
-        case condition do
-          false ->
-            changeset
+    cond do
+      validation.before_transaction? ->
+        {:not_atomic,
+         "before_transaction? validation `#{inspect(elem(validation.validation, 0))}` cannot be run atomically. " <>
+           "To use before_transaction? validations, set `require_atomic? false` or use `strategy: [:stream]`."}
 
-          true ->
-            do_run_atomic_validation(changeset, validation, context)
+      validation.before_action? ->
+        {:not_atomic,
+         "before_action? validation `#{inspect(elem(validation.validation, 0))}` cannot be run atomically. " <>
+           "To use before_action? validations, set `require_atomic? false` or use `strategy: [:stream]`."}
 
-          where_condition ->
-            do_run_atomic_validation(changeset, validation, context, where_condition)
+      true ->
+        with {:atomic, condition} <- atomic_condition(where, changeset, context) do
+          case condition do
+            false ->
+              changeset
+
+            true ->
+              do_run_atomic_validation(changeset, validation, context)
+
+            where_condition ->
+              do_run_atomic_validation(changeset, validation, context, where_condition)
+          end
         end
-      end
     end
   end
 
@@ -2023,7 +2030,7 @@ defmodule Ash.Changeset do
   - Require any accepted attributes that are `allow_nil?` false
   - Set any default values for attributes
   - Run action changes & validations
-  - Run validations, or add them in `before_action` hooks if using `d:Ash.Resource.Dsl.actions.create.validate|before_action?`. Any global validations are skipped if the action has `skip_global_validations?` set to `true`.
+  - Run validations, or add them in `before_action` hooks if using `d:Ash.Resource.Dsl.actions.create.validate|before_action?`, or in `before_transaction` hooks (before any other `before_transaction` hooks) if using `d:Ash.Resource.Dsl.actions.create.validate|before_transaction?`. Any global validations are skipped if the action has `skip_global_validations?` set to `true`.
 
   ## Examples
 
@@ -2131,7 +2138,7 @@ defmodule Ash.Changeset do
   - Require any accepted attributes that are `allow_nil?` false
   - Set any default values for attributes
   - Run action changes & validations
-  - Run validations, or add them in `before_action` hooks if using `d:Ash.Resource.Dsl.actions.update.validate|before_action?`. Any global validations are skipped if the action has `skip_global_validations?` set to `true`.
+  - Run validations, or add them in `before_action` hooks if using `d:Ash.Resource.Dsl.actions.update.validate|before_action?`, or in `before_transaction` hooks (before any other `before_transaction` hooks) if using `d:Ash.Resource.Dsl.actions.update.validate|before_transaction?`. Any global validations are skipped if the action has `skip_global_validations?` set to `true`.
 
   ## Examples
 
@@ -2214,7 +2221,7 @@ defmodule Ash.Changeset do
   - Require any accepted attributes that are `allow_nil?` false
   - Set any default values for attributes
   - Run action changes & validations
-  - Run validations, or add them in `before_action` hooks if using `d:Ash.Resource.Dsl.actions.destroy.validate|before_action?`. Any global validations are skipped if the action has `skip_global_validations?` set to `true`.
+  - Run validations, or add them in `before_action` hooks if using `d:Ash.Resource.Dsl.actions.destroy.validate|before_action?`, or in `before_transaction` hooks (before any other `before_transaction` hooks) if using `d:Ash.Resource.Dsl.actions.destroy.validate|before_transaction?`. Any global validations are skipped if the action has `skip_global_validations?` set to `true`.
 
   ## Examples
 
@@ -4239,20 +4246,34 @@ defmodule Ash.Changeset do
          Enum.all?(validation.where, fn {module, _} ->
            module.has_validate?()
          end) do
-      if validation.before_action? do
-        before_action(changeset, fn changeset ->
-          if validation.only_when_valid? and not changeset.valid? do
-            changeset
-          else
-            do_validation(changeset, validation, tracer, metadata, actor)
-          end
-        end)
-      else
-        if validation.only_when_valid? and not changeset.valid? do
+      cond do
+        validation.before_transaction? ->
+          before_transaction(
+            changeset,
+            fn changeset ->
+              if validation.only_when_valid? and not changeset.valid? do
+                changeset
+              else
+                do_validation(changeset, validation, tracer, metadata, actor)
+              end
+            end,
+            prepend?: true
+          )
+
+        validation.before_action? ->
+          before_action(changeset, fn changeset ->
+            if validation.only_when_valid? and not changeset.valid? do
+              changeset
+            else
+              do_validation(changeset, validation, tracer, metadata, actor)
+            end
+          end)
+
+        validation.only_when_valid? and not changeset.valid? ->
           changeset
-        else
+
+        true ->
           do_validation(changeset, validation, tracer, metadata, actor)
-        end
       end
     else
       if changeset.action.type == :create do

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -1119,20 +1119,34 @@ defmodule Ash.Query do
   end
 
   defp validate(query, validation, tracer, metadata, actor) do
-    if validation.before_action? do
-      before_action(query, fn query ->
-        if validation.only_when_valid? and not query.valid? do
-          query
-        else
-          do_validation(query, validation, tracer, metadata, actor)
-        end
-      end)
-    else
-      if validation.only_when_valid? and not query.valid? do
+    cond do
+      validation.before_transaction? ->
+        before_transaction(
+          query,
+          fn query ->
+            if validation.only_when_valid? and not query.valid? do
+              query
+            else
+              do_validation(query, validation, tracer, metadata, actor)
+            end
+          end,
+          prepend?: true
+        )
+
+      validation.before_action? ->
+        before_action(query, fn query ->
+          if validation.only_when_valid? and not query.valid? do
+            query
+          else
+            do_validation(query, validation, tracer, metadata, actor)
+          end
+        end)
+
+      validation.only_when_valid? and not query.valid? ->
         query
-      else
+
+      true ->
         do_validation(query, validation, tracer, metadata, actor)
-      end
     end
   end
 

--- a/lib/ash/resource/validation.ex
+++ b/lib/ash/resource/validation.ex
@@ -27,6 +27,7 @@ defmodule Ash.Resource.Validation do
     :description,
     :message,
     :before_action?,
+    :before_transaction?,
     :always_atomic?,
     where: [],
     on: [],
@@ -162,6 +163,12 @@ defmodule Ash.Resource.Validation do
       type: :boolean,
       default: false,
       doc: "If set to `true`, the validation will be run in a before_action hook"
+    ],
+    before_transaction?: [
+      type: :boolean,
+      default: false,
+      doc:
+        "If set to `true`, the validation will be run in a before_transaction hook, before any other before_transaction hooks (and outside the transaction). Takes precedence over `before_action?`."
     ],
     always_atomic?: [
       type: :boolean,

--- a/lib/ash/resource/verifiers/verify_actions_atomic.ex
+++ b/lib/ash/resource/verifiers/verify_actions_atomic.ex
@@ -49,15 +49,21 @@ defmodule Ash.Resource.Verifiers.VerifyActionsAtomic do
             _ ->
               false
           end)
+          |> Enum.reject(fn
+            %{validation: {module, _}} = validation ->
+              # before_transaction? validations run in a before_transaction hook,
+              # so they can never be run atomically
+              module.atomic?() && !validation.before_transaction?
+
+            %{change: {module, _}} ->
+              module.atomic?()
+          end)
           |> Enum.map(fn
             %{change: {module, _}} ->
               module
 
             %{validation: {module, _}} ->
               module
-          end)
-          |> Enum.reject(fn module ->
-            module.atomic?()
           end)
           |> case do
             [] ->

--- a/test/actions/before_transaction_validation_test.exs
+++ b/test/actions/before_transaction_validation_test.exs
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Actions.BeforeTransactionValidationTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule RecordingValidation do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def supports(_opts), do: [Ash.Changeset, Ash.Query, Ash.ActionInput]
+
+    @impl true
+    def validate(subject, opts, _context) do
+      send(self(), {:ran, opts[:tag]})
+
+      name =
+        case subject do
+          %Ash.Changeset{} = changeset -> Ash.Changeset.get_attribute(changeset, :name)
+          %Ash.ActionInput{} = input -> input.arguments[:name]
+          _ -> nil
+        end
+
+      cond do
+        opts[:fail?] -> {:error, field: :name, message: "forced failure"}
+        name == "bad" -> {:error, field: :name, message: "name is bad"}
+        true -> :ok
+      end
+    end
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      create :create do
+        accept [:name]
+
+        change before_transaction(fn changeset, _context ->
+                 send(self(), {:ran, :user_hook})
+                 changeset
+               end)
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      update :update do
+        require_atomic? false
+        accept [:name]
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      update :atomic_update do
+        require_atomic? true
+        accept [:name]
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      read :read_with_validation do
+        prepare fn query, _context ->
+          Ash.Query.before_transaction(query, fn query ->
+            send(self(), {:ran, :user_hook})
+            query
+          end)
+        end
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      read :read_failing do
+        validate {RecordingValidation, tag: :validation, fail?: true}, before_transaction?: true
+      end
+
+      action :generic_action, :string do
+        argument :name, :string, allow_nil?: false
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+
+        run fn _input, _context -> {:ok, "ran"} end
+      end
+
+      create :create_with_required_argument do
+        accept [:name]
+        argument :req, :string, allow_nil?: false
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      create :create_only_when_valid do
+        accept [:name]
+        argument :req, :string, allow_nil?: false
+
+        validate {RecordingValidation, tag: :validation},
+          before_transaction?: true,
+          only_when_valid?: true
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+    end
+  end
+
+  defmodule GlobalPost do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    validations do
+      validate {RecordingValidation, tag: :global_validation},
+        before_transaction?: true,
+        on: [:create]
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      create :create do
+        accept [:name]
+        delay_global_validations? true
+
+        change before_transaction(fn changeset, _context ->
+                 send(self(), {:ran, :user_hook})
+                 changeset
+               end)
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+    end
+  end
+
+  describe "create actions" do
+    test "a passing before_transaction? validation allows the create" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "ok"})
+        |> Ash.create!()
+
+      assert post.name == "ok"
+      assert_received {:ran, :validation}
+    end
+
+    test "a failing before_transaction? validation surfaces the error and prevents the create" do
+      assert_raise Ash.Error.Invalid, ~r/name is bad/, fn ->
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "bad"})
+        |> Ash.create!()
+      end
+    end
+
+    test "the validation runs before user before_transaction hooks" do
+      Post
+      |> Ash.Changeset.for_create(:create, %{name: "ok"})
+      |> Ash.create!()
+
+      assert_received {:ran, first}
+      assert_received {:ran, second}
+      assert first == :validation
+      assert second == :user_hook
+    end
+
+    test "a failing validation short-circuits later before_transaction hooks" do
+      assert_raise Ash.Error.Invalid, fn ->
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "bad"})
+        |> Ash.create!()
+      end
+
+      assert_received {:ran, :validation}
+      refute_received {:ran, :user_hook}
+    end
+  end
+
+  describe "update actions" do
+    test "a failing before_transaction? validation prevents the update" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "ok"})
+        |> Ash.create!()
+
+      assert_raise Ash.Error.Invalid, ~r/name is bad/, fn ->
+        post
+        |> Ash.Changeset.for_update(:update, %{name: "bad"})
+        |> Ash.update!()
+      end
+    end
+
+    test "an atomic action with a before_transaction? validation cannot be run atomically" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "ok"})
+        |> Ash.create!()
+
+      assert_raise Ash.Error.Framework, ~r/cannot be run atomically/, fn ->
+        post
+        |> Ash.Changeset.for_update(:atomic_update, %{name: "ok"})
+        |> Ash.update!()
+      end
+    end
+  end
+
+  describe "generic actions" do
+    test "a passing before_transaction? validation allows the action" do
+      assert {:ok, "ran"} =
+               Post
+               |> Ash.ActionInput.for_action(:generic_action, %{name: "ok"})
+               |> Ash.run_action()
+
+      assert_received {:ran, :validation}
+    end
+
+    test "a failing before_transaction? validation surfaces the error" do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Post
+               |> Ash.ActionInput.for_action(:generic_action, %{name: "bad"})
+               |> Ash.run_action()
+    end
+  end
+
+  describe "delay_global_validations? interplay" do
+    test "a global before_transaction? validation still runs in the before_transaction hook" do
+      GlobalPost
+      |> Ash.Changeset.for_create(:create, %{name: "ok"})
+      |> Ash.create!()
+
+      assert_received {:ran, first}
+      assert_received {:ran, second}
+      assert first == :global_validation
+      assert second == :user_hook
+    end
+
+    test "a failing global before_transaction? validation prevents the create" do
+      assert_raise Ash.Error.Invalid, ~r/name is bad/, fn ->
+        GlobalPost
+        |> Ash.Changeset.for_create(:create, %{name: "bad"})
+        |> Ash.create!()
+      end
+
+      assert_received {:ran, :global_validation}
+      refute_received {:ran, :user_hook}
+    end
+  end
+
+  describe "changesets that are invalid before hooks run" do
+    test "before_transaction hooks are not reached, so the validation does not run" do
+      # the required argument is missing, making the changeset invalid at build
+      # time. Actions do not run before_transaction hooks for changesets that are
+      # already invalid, so the validation is never invoked and the original
+      # error surfaces.
+      result =
+        Post
+        |> Ash.Changeset.for_create(:create_with_required_argument, %{name: "ok"})
+        |> Ash.create()
+
+      assert {:error, %Ash.Error.Invalid{}} = result
+      refute_received {:ran, :validation}
+    end
+
+    test "only_when_valid? validations are also skipped for invalid changesets" do
+      result =
+        Post
+        |> Ash.Changeset.for_create(:create_only_when_valid, %{name: "ok"})
+        |> Ash.create()
+
+      assert {:error, %Ash.Error.Invalid{}} = result
+      refute_received {:ran, :validation}
+    end
+
+    test "only_when_valid? validations run at hook time on valid changesets" do
+      Post
+      |> Ash.Changeset.for_create(:create_only_when_valid, %{name: "ok", req: "given"})
+      |> Ash.create!()
+
+      assert_received {:ran, :validation}
+    end
+  end
+
+  describe "read actions" do
+    test "the validation runs before user before_transaction hooks on reads" do
+      Post
+      |> Ash.Query.for_read(:read_with_validation)
+      |> Ash.read!()
+
+      assert_received {:ran, first}
+      assert_received {:ran, second}
+      assert first == :validation
+      assert second == :user_hook
+    end
+
+    test "a failing before_transaction? validation surfaces the error on reads" do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Post
+               |> Ash.Query.for_read(:read_failing)
+               |> Ash.read()
+    end
+  end
+end

--- a/test/actions/bulk/bulk_before_transaction_validation_test.exs
+++ b/test/actions/bulk/bulk_before_transaction_validation_test.exs
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Actions.Bulk.BulkBeforeTransactionValidationTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule RecordingValidation do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(changeset, opts, _context) do
+      send(self(), {:ran, opts[:tag]})
+
+      if Ash.Changeset.get_attribute(changeset, :name) == "bad" do
+        {:error, field: :name, message: "name is bad"}
+      else
+        :ok
+      end
+    end
+  end
+
+  defmodule BatchRecordingValidation do
+    @moduledoc false
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(changeset, opts, _context) do
+      send(self(), {:ran, {opts[:tag], :validate}})
+
+      if Ash.Changeset.get_attribute(changeset, :name) == "bad" do
+        {:error, field: :name, message: "name is bad"}
+      else
+        :ok
+      end
+    end
+
+    @impl true
+    def batch_validate(changesets, opts, _context) do
+      send(self(), {:ran, {opts[:tag], :batch_validate, length(changesets)}})
+
+      Enum.map(changesets, fn changeset ->
+        if Ash.Changeset.get_attribute(changeset, :name) == "bad" do
+          Ash.Changeset.add_error(changeset, field: :name, message: "name is bad")
+        else
+          changeset
+        end
+      end)
+    end
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      create :create do
+        accept [:name]
+
+        change before_transaction(fn changeset, _context ->
+                 send(self(), {:ran, :user_hook})
+                 changeset
+               end)
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      create :batch_create do
+        accept [:name]
+
+        validate {BatchRecordingValidation, tag: :batch_validation}, before_transaction?: true
+      end
+
+      create :plain_create do
+        accept [:name]
+      end
+
+      update :update do
+        require_atomic? false
+        accept [:name]
+
+        change before_transaction(fn changeset, _context ->
+                 send(self(), {:ran, :user_hook})
+                 changeset
+               end)
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      update :update_just_validation do
+        require_atomic? false
+        accept [:name]
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      destroy :destroy do
+        require_atomic? false
+
+        change before_transaction(fn changeset, _context ->
+                 send(self(), {:ran, :user_hook})
+                 changeset
+               end)
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      destroy :destroy_just_validation do
+        require_atomic? false
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      destroy :soft_destroy do
+        require_atomic? false
+        soft? true
+        change set_attribute(:archived?, true)
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+      attribute :archived?, :boolean, public?: true, default: false
+    end
+  end
+
+  defmodule StrictPost do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private? true
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read]
+
+      create :create do
+        accept [:name, :title]
+
+        validate {RecordingValidation, tag: :validation}, before_transaction?: true
+      end
+
+      create :create_only_when_valid do
+        accept [:name, :title]
+
+        validate {RecordingValidation, tag: :validation},
+          before_transaction?: true,
+          only_when_valid?: true
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string, public?: true
+      attribute :title, :string, public?: true, allow_nil?: false
+    end
+  end
+
+  defp create_post!(name) do
+    Post
+    |> Ash.Changeset.for_create(:plain_create, %{name: name})
+    |> Ash.create!()
+  end
+
+  describe "bulk create" do
+    test "a passing before_transaction? validation allows the create" do
+      result =
+        Ash.bulk_create([%{name: "ok"}], Post, :create,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert [%{name: "ok"}] = result.records
+      assert_received {:ran, :validation}
+    end
+
+    test "the validation runs before other before_transaction hooks" do
+      result = Ash.bulk_create([%{name: "ok"}], Post, :create, return_errors?: true)
+
+      assert result.status == :success
+      assert_received {:ran, first}
+      assert_received {:ran, second}
+      assert first == :validation
+      assert second == :user_hook
+    end
+
+    test "a failing validation surfaces as an invalid error and short-circuits later hooks" do
+      result =
+        Ash.bulk_create([%{name: "bad"}], Post, :create,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      assert result.error_count == 1
+
+      assert [
+               %Ash.Error.Invalid{
+                 errors: [
+                   %Ash.Error.Changes.InvalidAttribute{field: :name, message: "name is bad"}
+                 ]
+               }
+             ] = result.errors
+
+      assert_received {:ran, :validation}
+      refute_received {:ran, :user_hook}
+    end
+
+    test "a mixed batch creates the valid records and errors on the invalid ones" do
+      result =
+        Ash.bulk_create([%{name: "ok"}, %{name: "bad"}], Post, :create,
+          return_records?: true,
+          return_errors?: true,
+          stop_on_error?: false
+        )
+
+      assert result.status == :partial_success
+      assert [%{name: "ok"}] = result.records
+      assert result.error_count == 1
+    end
+
+    test "the validation is not run at build time when the changeset becomes invalid before hooks" do
+      # :title is allow_nil?: false, so the changeset becomes invalid when required
+      # values are checked, which happens after validations are dispatched but before
+      # before_transaction hooks run. The validation must not run for such changesets.
+      result =
+        Ash.bulk_create([%{name: "ok"}], StrictPost, :create,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      refute_received {:ran, :validation}
+    end
+
+    test "only_when_valid? validations are also skipped for changesets that become invalid" do
+      result =
+        Ash.bulk_create([%{name: "ok"}], StrictPost, :create_only_when_valid,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      refute_received {:ran, :validation}
+    end
+
+    test "batch-capable validations run per changeset in the hook phase" do
+      result =
+        Ash.bulk_create([%{name: "ok"}, %{name: "also ok"}], Post, :batch_create,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      # at hook time the validation runs once per changeset, not once per batch
+      assert_received {:ran, {:batch_validation, :batch_validate, 1}}
+      assert_received {:ran, {:batch_validation, :batch_validate, 1}}
+      refute_received {:ran, {:batch_validation, :batch_validate, 2}}
+    end
+
+    test "a failing batch-capable validation surfaces errors" do
+      result =
+        Ash.bulk_create([%{name: "bad"}], Post, :batch_create,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      assert result.error_count == 1
+    end
+  end
+
+  describe "bulk update" do
+    test "the validation runs before other before_transaction hooks" do
+      post = create_post!("ok")
+
+      result =
+        Ash.bulk_update([post], :update, %{name: "new"},
+          strategy: [:stream],
+          resource: Post,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert [%{name: "new"}] = result.records
+      assert_received {:ran, first}
+      assert_received {:ran, second}
+      assert first == :validation
+      assert second == :user_hook
+    end
+
+    test "a failing validation surfaces the error and short-circuits later hooks" do
+      post = create_post!("ok")
+
+      result =
+        Ash.bulk_update([post], :update, %{name: "bad"},
+          strategy: [:stream],
+          resource: Post,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      assert result.error_count == 1
+
+      assert [
+               %Ash.Error.Invalid{
+                 errors: [
+                   %Ash.Error.Changes.InvalidAttribute{field: :name, message: "name is bad"}
+                 ]
+               }
+             ] = result.errors
+
+      assert_received {:ran, :validation}
+      refute_received {:ran, :user_hook}
+    end
+
+    test "an atomic-only strategy reports that the validation cannot be run atomically" do
+      create_post!("ok")
+
+      result =
+        Ash.bulk_update(Post, :update_just_validation, %{name: "new"},
+          strategy: [:atomic],
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      assert [error] = result.errors
+      assert Exception.message(error) =~ "cannot be run atomically"
+      refute_received {:ran, :validation}
+    end
+
+    test "an atomic strategy falls back to streaming when allowed" do
+      create_post!("ok")
+
+      result =
+        Ash.bulk_update(Post, :update_just_validation, %{name: "new"},
+          strategy: [:atomic, :stream],
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert [%{name: "new"}] = result.records
+      assert_received {:ran, :validation}
+    end
+  end
+
+  describe "bulk destroy" do
+    test "the validation runs before other before_transaction hooks" do
+      post = create_post!("ok")
+
+      result =
+        Ash.bulk_destroy([post], :destroy, %{},
+          strategy: [:stream],
+          resource: Post,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert_received {:ran, first}
+      assert_received {:ran, second}
+      assert first == :validation
+      assert second == :user_hook
+      assert {:error, %Ash.Error.Invalid{}} = Ash.get(Post, post.id)
+    end
+
+    test "a failing validation surfaces the error and prevents the destroy" do
+      post = create_post!("bad")
+
+      result =
+        Ash.bulk_destroy([post], :destroy, %{},
+          strategy: [:stream],
+          resource: Post,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      assert result.error_count == 1
+
+      assert [
+               %Ash.Error.Invalid{
+                 errors: [
+                   %Ash.Error.Changes.InvalidAttribute{field: :name, message: "name is bad"}
+                 ]
+               }
+             ] = result.errors
+
+      assert_received {:ran, :validation}
+      refute_received {:ran, :user_hook}
+      assert %{name: "bad"} = Ash.get!(Post, post.id)
+    end
+
+    test "an atomic strategy falls back to streaming when allowed" do
+      post = create_post!("ok")
+
+      result =
+        Ash.bulk_destroy(Post, :destroy_just_validation, %{},
+          strategy: [:atomic, :stream],
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert_received {:ran, :validation}
+      assert {:error, %Ash.Error.Invalid{}} = Ash.get(Post, post.id)
+    end
+
+    test "a soft destroy runs the validation and archives the record" do
+      post = create_post!("ok")
+
+      result =
+        Ash.bulk_destroy([post], :soft_destroy, %{},
+          strategy: [:stream],
+          resource: Post,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert_received {:ran, :validation}
+      assert %{name: "ok", archived?: true} = Ash.get!(Post, post.id)
+    end
+
+    test "a failing validation prevents a soft destroy" do
+      post = create_post!("bad")
+
+      result =
+        Ash.bulk_destroy([post], :soft_destroy, %{},
+          strategy: [:stream],
+          resource: Post,
+          return_errors?: true
+        )
+
+      assert result.status == :error
+      assert result.error_count == 1
+      assert_received {:ran, :validation}
+      assert %{name: "bad", archived?: false} = Ash.get!(Post, post.id)
+    end
+  end
+end

--- a/test/resource/verify_actions_atomic_test.exs
+++ b/test/resource/verify_actions_atomic_test.exs
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.VerifyActionsAtomicTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  import Ash.Test.Helpers
+
+  test "an atomic-capable validation marked before_transaction? warns on require_atomic? actions" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defposts do
+          attributes do
+            attribute :name, :string, public?: true
+          end
+
+          actions do
+            default_accept :*
+
+            update :atomic_update do
+              require_atomic? true
+              validate attribute_equals(:name, "fred"), before_transaction?: true
+            end
+          end
+        end
+      end)
+
+    assert output =~ "cannot be done atomically"
+  end
+
+  test "an atomic-capable validation without before_transaction? does not warn" do
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defposts do
+          attributes do
+            attribute :name, :string, public?: true
+          end
+
+          actions do
+            default_accept :*
+
+            update :atomic_update do
+              require_atomic? true
+              validate attribute_equals(:name, "fred")
+            end
+          end
+        end
+      end)
+
+    refute output =~ "cannot be done atomically"
+  end
+end


### PR DESCRIPTION
## What

Adds a `before_transaction?: true` option to validations (both action-level `validate` and global `validations`), as a counterpart to `before_action?`, for validations that must run outside the transaction — e.g. validations that call external services.

```elixir
create :create do
  validate {MyValidation, []}, before_transaction?: true
end
```

## Semantics

- The validation runs in a `before_transaction` hook, **prepended** so it runs before any other `before_transaction` hooks, and therefore outside the transaction.
- Takes precedence over `before_action?` when both are set.
- `only_when_valid?` is re-checked at hook time rather than at build time.
- If the changeset/query/input is already invalid before hooks run, `before_transaction` hooks are never reached, so the validation does not run and the original error surfaces (matching existing hook behavior).
- A failing validation makes the subject invalid, which short-circuits any later `before_transaction` hooks.
- Supported on changesets (create/update/destroy), queries (read actions), and action inputs (generic actions).
- Global validations keep running in the `before_transaction` hook even when the action sets `delay_global_validations? true` (`before_transaction?` wins over the `before_action?` rewrite).

## Bulk actions

`Ash.bulk_create`, `Ash.bulk_update`, and `Ash.bulk_destroy` (including soft destroys) run these validations in the `before_transaction` hook of each changeset, before other hooks. Previously the bulk create dispatch ran them silently at build time. The `before_transaction?` dispatch also takes precedence over the `batch_validate/3` fast path — batch-capable validations are invoked per changeset at hook time.

## Atomicity

`before_transaction?` validations can never run atomically:

- `run_atomic_validation/3` returns `{:not_atomic, ...}` with a message telling users to set `require_atomic? false` or use `strategy: [:stream]`.
- Actions with `require_atomic? true` raise `Ash.Error.Framework` at runtime.
- Bulk actions with `strategy: [:atomic]` return a `NoMatchingBulkStrategy` error carrying that reason; when `:stream` is allowed they fall back to streaming.
- The `VerifyActionsAtomic` verifier now warns at compile time when a `require_atomic?` action has a `before_transaction?` validation, even if the validation module is otherwise atomic-capable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
