### PR TITLE
feat: add all/1 builtin validation as the complement to any/1

### DIFF
--- a/lib/ash/resource/validation/all.ex
+++ b/lib/ash/resource/validation/all.ex
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Resource.Validation.All do
+  @moduledoc false
+
+  @opt_schema [
+    validations: [
+      type: {:list, Ash.Resource.Validation.validation_type()},
+      required: true,
+      doc: "The list of validations, all of which must pass"
+    ]
+  ]
+
+  use Ash.Resource.Validation
+  alias Ash.Error.Changes.InvalidAttribute
+  alias Ash.Error.Changes.InvalidChanges
+  require Ash.Expr
+
+  opt_schema = @opt_schema
+
+  defmodule Opts do
+    @moduledoc false
+    use Spark.Options.Validator, schema: opt_schema
+  end
+
+  @impl true
+  def init(opts) do
+    with {:ok, opts} <- Opts.validate(opts),
+         opts <- Opts.to_options(opts),
+         validations <- opts[:validations] do
+      validated_validations =
+        Enum.map(validations, fn validation_spec ->
+          {validation, validation_opts} =
+            case validation_spec do
+              {validation, validation_opts} -> {validation, validation_opts}
+              validation -> {validation, []}
+            end
+
+          case Code.ensure_compiled(validation) do
+            {:module, ^validation} ->
+              if function_exported?(validation, :describe, 1) do
+                {:ok, validation_opts} = Ash.Resource.Validation.init(validation, validation_opts)
+                {validation, validation_opts}
+              else
+                raise ArgumentError,
+                      "#{inspect(validation)} must implement `describe/1` function to be used in #{__MODULE__}"
+              end
+
+            _ ->
+              raise ArgumentError, "#{inspect(validation)} is not a valid module"
+          end
+        end)
+
+      opts = Keyword.put(opts, :validations, validated_validations)
+      {:ok, opts}
+    else
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def supports(opts) do
+    validations = opts[:validations]
+
+    case validations do
+      [] ->
+        []
+
+      [{first_validation, first_opts} | rest] ->
+        first_supports = first_validation.supports(first_opts)
+
+        Enum.reduce(rest, first_supports, fn {validation, validation_opts}, acc ->
+          validation_supports = validation.supports(validation_opts)
+          Enum.filter(acc, &(&1 in validation_supports))
+        end)
+    end
+  end
+
+  @impl true
+  def validate(subject, opts, context) do
+    validations = opts[:validations]
+
+    results =
+      Enum.map(validations, fn {validation, validation_opts} ->
+        Ash.Resource.Validation.validate(validation, subject, validation_opts, context)
+      end)
+
+    case Enum.all?(results, &(&1 == :ok)) do
+      true ->
+        :ok
+
+      false ->
+        {:error,
+         opts
+         |> describe()
+         |> InvalidAttribute.exception()}
+    end
+  end
+
+  @impl true
+  def atomic(changeset, opts, context) do
+    validations = opts[:validations]
+
+    {message, vars} =
+      if context.message do
+        {context.message, []}
+      else
+        desc = describe(opts)
+        {desc[:message], desc[:vars] || []}
+      end
+
+    atomic_results =
+      Enum.map(validations, fn {validation, validation_opts} ->
+        Ash.Resource.Validation.atomic(validation, changeset, validation_opts, context)
+      end)
+      |> List.flatten()
+
+    case Enum.find(atomic_results, &short_circuits?/1) do
+      nil ->
+        atomic_results
+        |> Enum.reject(&(&1 == :ok))
+        |> Enum.reduce({[], false}, fn
+          {:atomic, new_fields, new_condition, _error_expr}, {fields, condition} ->
+            {Enum.uniq(fields ++ new_fields), Ash.Expr.expr(^new_condition or ^condition)}
+        end)
+        |> case do
+          {_fields, false} ->
+            :ok
+
+          {fields, condition} ->
+            {:atomic, fields, condition,
+             Ash.Expr.expr(
+               error(^InvalidChanges, %{fields: ^fields, message: ^message, vars: ^Map.new(vars)})
+             )}
+        end
+
+      response ->
+        response
+    end
+  end
+
+  defp short_circuits?({:error, _}), do: true
+  defp short_circuits?({:not_atomic, _reason}), do: true
+  defp short_circuits?(_), do: false
+
+  @impl true
+  def describe(opts) do
+    validations = opts[:validations]
+
+    validation_messages =
+      Enum.map(validations, fn {validation, validation_opts} ->
+        case Ash.Resource.Validation.describe(validation, validation_opts) do
+          message when is_binary(message) -> message
+          options -> options[:message]
+        end
+      end)
+
+    message = "must pass all of: #{Enum.join(validation_messages, ", ")}"
+    [message: message, vars: []]
+  end
+end

--- a/lib/ash/resource/validation/builtins.ex
+++ b/lib/ash/resource/validation/builtins.ex
@@ -110,6 +110,27 @@ defmodule Ash.Resource.Validation.Builtins do
   end
 
   @doc """
+  Validates that all of the provided validations pass
+
+  Primarily useful when composed with other validations, like `any/1` or `negate/1`.
+  At the top level, listing multiple `validate` statements already requires all of them to pass.
+
+  ## Examples
+
+      validate any([
+                 all([
+                   one_of(:status, [:valid]),
+                   match(:title, "^[a-z]+$")
+                 ]),
+                 attribute_equals(:priority, 1)
+               ])
+  """
+  @spec all(validations :: list(Validation.ref())) :: Validation.ref()
+  def all(validations) do
+    {Validation.All, validations: validations}
+  end
+
+  @doc """
   Validates that the action name matches the provided action name or names. Primarily meant for use in `where`.
 
   ## Examples

--- a/test/resource/validation/all_test.exs
+++ b/test/resource/validation/all_test.exs
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.Validation.AllTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ash.Resource.Validation.All
+
+  alias Ash.Test.Domain, as: Domain
+
+  defmodule Post do
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+
+      update :update_with_all_validation do
+        validate all([
+                   one_of(:status, [:valid]),
+                   match(:title, "^[a-z]+$")
+                 ])
+      end
+
+      update :update_with_any_all_validation do
+        validate any([
+                   all([
+                     one_of(:status, [:valid]),
+                     match(:title, "^[a-z]+$")
+                   ]),
+                   attribute_equals(:priority, 1)
+                 ])
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :status, :atom do
+        public?(true)
+      end
+
+      attribute :priority, :integer do
+        public?(true)
+      end
+
+      attribute :title, :string do
+        public?(true)
+      end
+    end
+  end
+
+  defmodule PassingValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(_, _, _), do: :ok
+
+    @impl true
+    def describe(_opts), do: [message: "Passing validation", vars: []]
+  end
+
+  defmodule FailingValidation do
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(_, _, _), do: {:error, :some_error}
+
+    @impl true
+    def describe(_opts), do: [message: "Failing validation", vars: []]
+  end
+
+  defmodule CustomValidationNoDescribe do
+    use Ash.Resource.Validation
+
+    @impl true
+    def validate(_, _, _), do: {:error, :some_error}
+  end
+
+  describe "All validation" do
+    test "passes when all inner validations pass" do
+      {:ok, opts} =
+        All.init(
+          validations: [
+            PassingValidation,
+            PassingValidation
+          ]
+        )
+
+      changeset = Post |> Ash.Changeset.for_create(:create, %{status: :valid})
+
+      assert :ok = All.validate(changeset, opts, %{})
+    end
+
+    test "fails when one inner validation fails" do
+      {:ok, opts} =
+        All.init(
+          validations: [
+            PassingValidation,
+            FailingValidation,
+            PassingValidation
+          ]
+        )
+
+      changeset = Post |> Ash.Changeset.for_create(:create, %{status: :valid})
+
+      assert {:error, %Ash.Error.Changes.InvalidAttribute{}} =
+               All.validate(changeset, opts, %{})
+    end
+
+    test "fails when all inner validations fail" do
+      {:ok, opts} =
+        All.init(
+          validations: [
+            FailingValidation,
+            FailingValidation
+          ]
+        )
+
+      changeset = Post |> Ash.Changeset.for_create(:create, %{status: :valid})
+
+      assert {:error, %Ash.Error.Changes.InvalidAttribute{}} =
+               All.validate(changeset, opts, %{})
+    end
+
+    test "works with builtin validations" do
+      {:ok, opts} =
+        All.init(
+          validations: [
+            Ash.Resource.Validation.Builtins.one_of(:status, [:valid]),
+            Ash.Resource.Validation.Builtins.match(:title, "^[a-z]+$")
+          ]
+        )
+
+      changeset = Post |> Ash.Changeset.for_create(:create, %{status: :valid, title: "lowercase"})
+
+      assert :ok = All.validate(changeset, opts, %{})
+    end
+
+    test "fails with builtin validations when one does not match" do
+      {:ok, opts} =
+        All.init(
+          validations: [
+            Ash.Resource.Validation.Builtins.one_of(:status, [:valid]),
+            Ash.Resource.Validation.Builtins.match(:title, "^[a-z]+$")
+          ]
+        )
+
+      changeset = Post |> Ash.Changeset.for_create(:create, %{status: :valid, title: "UPPERCASE"})
+
+      assert {:error, %Ash.Error.Changes.InvalidAttribute{}} =
+               All.validate(changeset, opts, %{})
+    end
+
+    test "returns error on init if validation does not export `describe/1`" do
+      assert_raise ArgumentError, ~r/must implement `describe\/1`/, fn ->
+        All.init(validations: [CustomValidationNoDescribe])
+      end
+    end
+
+    test "describe returns appropriate message" do
+      {:ok, opts} =
+        All.init(
+          validations: [
+            PassingValidation,
+            FailingValidation
+          ]
+        )
+
+      description = All.describe(opts)
+
+      assert description[:message] =~ "must pass all of:"
+      assert description[:message] =~ "Passing validation"
+      assert description[:message] =~ "Failing validation"
+      assert description[:vars] == []
+    end
+
+    test "works atomically with update actions when all validations pass" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{status: :invalid, title: "UPPERCASE"})
+        |> Ash.create!()
+
+      updated_post =
+        post
+        |> Ash.Changeset.for_update(:update_with_all_validation, %{
+          status: :valid,
+          title: "lowercase"
+        })
+        |> Ash.update!()
+
+      assert updated_post.status == :valid
+      assert updated_post.title == "lowercase"
+    end
+
+    test "fails atomically with update actions when one validation fails" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{status: :valid, title: "lowercase"})
+        |> Ash.create!()
+
+      assert_raise Ash.Error.Invalid, fn ->
+        post
+        |> Ash.Changeset.for_update(:update_with_all_validation, %{
+          status: :valid,
+          title: "UPPERCASE"
+        })
+        |> Ash.update!()
+      end
+    end
+
+    test "fails atomically with update actions when the other validation fails" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{status: :valid, title: "lowercase"})
+        |> Ash.create!()
+
+      assert_raise Ash.Error.Invalid, fn ->
+        post
+        |> Ash.Changeset.for_update(:update_with_all_validation, %{
+          status: :invalid,
+          title: "lowercase"
+        })
+        |> Ash.update!()
+      end
+    end
+
+    test "composes with any, passing when the all branch passes" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{status: :invalid, title: "UPPERCASE"})
+        |> Ash.create!()
+
+      updated_post =
+        post
+        |> Ash.Changeset.for_update(:update_with_any_all_validation, %{
+          status: :valid,
+          title: "lowercase",
+          priority: 2
+        })
+        |> Ash.update!()
+
+      assert updated_post.status == :valid
+    end
+
+    test "composes with any, passing when the other branch passes" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{status: :invalid, title: "UPPERCASE"})
+        |> Ash.create!()
+
+      updated_post =
+        post
+        |> Ash.Changeset.for_update(:update_with_any_all_validation, %{
+          status: :invalid,
+          title: "UPPERCASE",
+          priority: 1
+        })
+        |> Ash.update!()
+
+      assert updated_post.priority == 1
+    end
+
+    test "composes with any, failing when the all branch only partially passes" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{status: :invalid, title: "UPPERCASE"})
+        |> Ash.create!()
+
+      assert_raise Ash.Error.Invalid, fn ->
+        post
+        |> Ash.Changeset.for_update(:update_with_any_all_validation, %{
+          status: :valid,
+          title: "UPPERCASE",
+          priority: 2
+        })
+        |> Ash.update!()
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Ash.Resource.Validation.All` and the corresponding `all/1` builtin, which passes only when every provided validation passes.

```elixir
validate all([
  present(:foo),
  absent(:bar)
])
```

## Why

Together with `any/1` (OR) and `negate/1` (NOT), this completes the validation combinators. It enables compositions like `any([all([...]), ...])` that were previously inexpressible, since AND only existed at the DSL level via multiple `validate` statements or `where` clauses.

## Implementation

Implemented as the dual of `Ash.Resource.Validation.Any`:

- `validate/3` fails with a combined `"must pass all of: ..."` error when any constituent fails.
- `atomic/3` combines the constituent error conditions with `or` (where `Any` combines with `and`), drops `:ok` constituents, and short-circuits on static `{:error, ...}` results.
- Returns `{:not_atomic, ...}` if any constituent cannot be run atomically.
