### PR TITLE
fix: compare a Decimal to a float instead of raising

### DIFF
--- a/lib/ash/type/decimal.ex
+++ b/lib/ash/type/decimal.ex
@@ -416,7 +416,7 @@ defcomparable left :: Decimal, right :: Decimal do
 end
 
 defcomparable left :: Decimal, right :: Float do
-  Decimal.compare(Ash.Type.Decimal.new(left), right)
+  Decimal.compare(left, Decimal.from_float(right))
 end
 
 defcomparable left :: Decimal, right :: BitString do

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -101,6 +101,29 @@ defmodule Ash.Test.Type.DecimalTest do
     assert Ash.Type.Decimal.equal?(Decimal.new("1.0"), Decimal.new("1.00"))
   end
 
+  describe "comparability" do
+    test "a decimal compares equal to an integer, string and float of the same value" do
+      assert Comp.equal?(Decimal.new(1), 1)
+      assert Comp.equal?(Decimal.new(1), "1")
+      assert Comp.equal?(Decimal.new(1), 1.0)
+    end
+
+    test "a decimal compares equal to a float in either operand order" do
+      assert Comp.equal?(Decimal.new(1), 1.0)
+      assert Comp.equal?(1.0, Decimal.new(1))
+    end
+
+    test "a decimal orders against a float" do
+      assert Comp.greater_than?(Decimal.new("1.5"), 1.0)
+      assert Comp.less_than?(Decimal.new("0.5"), 1.0)
+      assert Comp.less_than?(1.0, Decimal.new("1.5"))
+    end
+
+    test "a decimal compares equal to a fractional float" do
+      assert Comp.equal?(Decimal.from_float(1.5), 1.5)
+    end
+  end
+
   test "pass with valid precision constraint" do
     valid_attrs = @valid_attrs |> Map.put(:precise_amount, 1.23)
 


### PR DESCRIPTION
fixes #2804 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

The `Decimal :: Float` comparable converted `left`, already a `Decimal`, leaving the float to reach `Decimal.compare/2` raw - which raises. It now converts the float with `Decimal.from_float/1`, like the integer and string clauses convert their operand.

There are two commits, the first adds the test cases, the second carries the single line fix.
