### PR TITLE
feat: add mfa constraint to Ash.Type.Function for portable persistence

### DIFF
--- a/lib/ash/type/function.ex
+++ b/lib/ash/type/function.ex
@@ -4,6 +4,15 @@
 
 defmodule Ash.Type.Function do
   @constraints [
+    mfa: [
+      type: :boolean,
+      default: false,
+      doc: """
+      Restricts the value to external captures (`&Module.function/arity`), refusing \
+      anonymous functions and closures. Only external captures can be stored: a closure \
+      captures its environment, which cannot be rehydrated in another VM.
+      """
+    ],
     arity: [
       type: :pos_integer,
       doc: "Enforces a specific arity on the provided function"
@@ -12,11 +21,15 @@ defmodule Ash.Type.Function do
   @moduledoc """
   Represents a function.
 
-  If the type would be dumped to a native format, `:erlang.term_to_binary(term, [:safe])` is used.
+  By default a function is dumped to a native format with
+  `:erlang.term_to_binary(term, [:safe])`, and this is *NOT SAFE* to use with
+  external input (see https://erlang.org/doc/man/erlang.html#binary_to_term-2).
 
-  Please keep in mind, this is *NOT SAFE* to use with external input.
-
-  More information available here: https://erlang.org/doc/man/erlang.html#binary_to_term-2
+  With the `mfa` constraint the value is restricted to external captures
+  (`&Module.function/arity`) and stored as a portable capture string such as
+  `"&Elixir.MyApp.callback/2"`, late-bound back to the function on read. This
+  decouples the stored reference from the compiled implementation, so it survives
+  across VMs and releases where a serialized closure would not.
 
   ### Constraints
 
@@ -33,14 +46,32 @@ defmodule Ash.Type.Function do
   def constraints, do: @constraints
 
   @impl true
+  def apply_constraints(nil, _), do: {:ok, nil}
+
   def apply_constraints(term, constraints) do
-    if constraints[:arity] && not is_function(term, constraints[:arity]) do
-      {:error,
-       message: error_message("Expected a function of arity %{arity}"), arity: constraints[:arity]}
-    else
-      {:ok, term}
+    cond do
+      constraints[:mfa] && not external?(term) ->
+        {:error,
+         message:
+           error_message(
+             "anonymous functions and closures cannot be stored; use a &Module.function/arity capture"
+           )}
+
+      constraints[:arity] && not is_function(term, constraints[:arity]) ->
+        {:error,
+         message: error_message("Expected a function of arity %{arity}"),
+         arity: constraints[:arity]}
+
+      true ->
+        {:ok, term}
     end
   end
+
+  defp external?(term) when is_function(term) do
+    Function.info(term, :type) == {:type, :external}
+  end
+
+  defp external?(_), do: false
 
   @impl true
   def matches_type?(v, _constraints) do

--- a/lib/ash/type/function.ex
+++ b/lib/ash/type/function.ex
@@ -40,7 +40,13 @@ defmodule Ash.Type.Function do
   import Ash.Gettext
 
   @impl true
-  def storage_type(_), do: :binary
+  def storage_type(constraints) do
+    if constraints[:mfa] do
+      :string
+    else
+      :binary
+    end
+  end
 
   @impl true
   def constraints, do: @constraints
@@ -88,13 +94,21 @@ defmodule Ash.Type.Function do
   @impl true
   def cast_stored(nil, _), do: {:ok, nil}
 
+  # A stored value is read by shape, not by constraint: a capture string is
+  # parsed and late-bound, anything else is loaded as a legacy `term_to_binary`
+  # blob. This is what makes adding `mfa: true` to an attribute with existing
+  # rows safe — old binary rows still load, new rows read as capture strings.
+  def cast_stored("&" <> _ = value, _constraints) do
+    parse_mfa_string(value)
+  end
+
   # sobelow_skip ["Misc.BinToTerm"]
-  def cast_stored(value, _) do
+  def cast_stored(value, _constraints) do
     case Ecto.Type.load(:binary, value) do
       {:ok, val} ->
         case :erlang.binary_to_term(val, [:safe]) do
           function when is_function(function) ->
-            function
+            {:ok, function}
 
           _ ->
             :error
@@ -109,10 +123,61 @@ defmodule Ash.Type.Function do
   end
 
   @impl true
-
   def dump_to_native(nil, _), do: {:ok, nil}
 
-  def dump_to_native(value, _) do
-    Ecto.Type.dump(:binary, :erlang.term_to_binary(value))
+  def dump_to_native(value, constraints) do
+    if constraints[:mfa] do
+      case mfa_string(value) do
+        {:ok, string} -> Ecto.Type.dump(:string, string)
+        :error -> :error
+      end
+    else
+      Ecto.Type.dump(:binary, :erlang.term_to_binary(value))
+    end
+  end
+
+  defp mfa_string(fun) when is_function(fun) do
+    case Function.info(fun, :type) do
+      {:type, :external} ->
+        info = Function.info(fun)
+
+        {:ok,
+         "&" <>
+           Atom.to_string(info[:module]) <>
+           "." <> Atom.to_string(info[:name]) <> "/" <> Integer.to_string(info[:arity])}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp mfa_string(_), do: :error
+
+  defp parse_mfa_string("&" <> rest) do
+    with [mod_fun, arity_str] <- String.split(rest, "/", parts: 2),
+         {arity, ""} <- Integer.parse(arity_str),
+         {:ok, module, name} <- split_module_function(mod_fun),
+         fun when is_function(fun) <- Function.capture(module, name, arity) do
+      {:ok, fun}
+    else
+      _ -> :error
+    end
+  rescue
+    # `String.to_existing_atom/1` and `Function.capture/3` raise for an unknown
+    # module, function or arity — an unresolvable capture string is not a match.
+    _ -> :error
+  end
+
+  defp split_module_function(mod_fun) do
+    case String.split(mod_fun, ".") do
+      [_only] ->
+        :error
+
+      parts ->
+        {module_parts, [function]} = Enum.split(parts, -1)
+
+        {:ok, String.to_existing_atom(Enum.join(module_parts, ".")),
+         String.to_existing_atom(function)}
+    end
   end
 end

--- a/test/type/function_test.exs
+++ b/test/type/function_test.exs
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Type.FunctionTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defp cast_and_apply(value, constraints) do
+    with {:ok, value} <- Ash.Type.Function.cast_input(value, constraints) do
+      Ash.Type.Function.apply_constraints(value, constraints)
+    end
+  end
+
+  describe "without the mfa constraint" do
+    test "accepts an anonymous function" do
+      fun = fn x -> x end
+      assert {:ok, ^fun} = cast_and_apply(fun, [])
+    end
+
+    test "accepts an external capture" do
+      fun = &Enum.map/2
+      assert {:ok, ^fun} = cast_and_apply(fun, [])
+    end
+
+    test "rejects a non-function" do
+      assert :error = cast_and_apply("not a function", [])
+    end
+  end
+
+  describe "with mfa: true" do
+    test "accepts an external capture" do
+      fun = &Enum.map/2
+      assert {:ok, ^fun} = cast_and_apply(fun, mfa: true)
+    end
+
+    test "accepts an external capture of an Erlang function" do
+      fun = &:erlang.map_size/1
+      assert {:ok, ^fun} = cast_and_apply(fun, mfa: true)
+    end
+
+    test "refuses an anonymous function" do
+      assert {:error, opts} = cast_and_apply(fn x -> x end, mfa: true)
+      assert opts[:message] =~ "capture"
+    end
+
+    test "refuses a closure that captures its environment" do
+      env = 1
+      assert {:error, _} = cast_and_apply(fn x -> x + env end, mfa: true)
+    end
+
+    test "refuses a partial application, which is a closure" do
+      assert {:error, _} = cast_and_apply(&Enum.map(&1, fn x -> x end), mfa: true)
+    end
+
+    test "the cast value stays a directly callable function" do
+      assert {:ok, fun} = cast_and_apply(&Enum.map/2, mfa: true)
+      assert fun.([1, 2], &(&1 * 2)) == [2, 4]
+    end
+  end
+
+  describe "mfa combined with arity" do
+    test "accepts an external capture of the declared arity" do
+      assert {:ok, _} = cast_and_apply(&Enum.map/2, mfa: true, arity: 2)
+    end
+
+    test "refuses an external capture of the wrong arity" do
+      assert {:error, opts} = cast_and_apply(&Enum.map/2, mfa: true, arity: 1)
+      assert opts[:arity] == 1
+    end
+  end
+end

--- a/test/type/function_test.exs
+++ b/test/type/function_test.exs
@@ -162,6 +162,32 @@ defmodule Ash.Test.Type.FunctionTest do
     end
   end
 
+  describe "reconstructing a capture whose module is not loaded" do
+    test "reconstructs from the atom alone, but invocation needs the code at call time" do
+      defmodule TransientHandler do
+        @moduledoc false
+        def handle(x), do: x
+      end
+
+      {:ok, stored} = Ash.Type.Function.dump_to_native(&TransientHandler.handle/1, mfa: true)
+
+      # Remove the module: a reading VM that does not currently hold this code.
+      :code.purge(TransientHandler)
+      :code.delete(TransientHandler)
+      refute Code.ensure_loaded?(TransientHandler)
+
+      # Reconstruction still succeeds — it needs the module *atom*, not the loaded
+      # code. This is what lets a record be read on a node where the function's
+      # implementation is absent.
+      assert {:ok, fun} = Ash.Type.Function.cast_stored(stored, mfa: true)
+      assert is_function(fun, 1)
+
+      # The capture is late-bound, so with the code absent invocation raises
+      # rather than silently misbehaving — the caveat the constraint documents.
+      assert_raise UndefinedFunctionError, fn -> fun.(1) end
+    end
+  end
+
   describe "through a resource with constraints: [mfa: true]" do
     test "stores an external capture and reads it back callable" do
       assert {:ok, created} =

--- a/test/type/function_test.exs
+++ b/test/type/function_test.exs
@@ -6,6 +6,25 @@ defmodule Ash.Test.Type.FunctionTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  defmodule Handler do
+    @moduledoc false
+    use Ash.Resource, data_layer: Ash.DataLayer.Ets, domain: Ash.Test.Domain
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:create, :read]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :callback, :function, constraints: [mfa: true, arity: 2], public?: true
+    end
+  end
+
   defp cast_and_apply(value, constraints) do
     with {:ok, value} <- Ash.Type.Function.cast_input(value, constraints) do
       Ash.Type.Function.apply_constraints(value, constraints)
@@ -67,6 +86,99 @@ defmodule Ash.Test.Type.FunctionTest do
     test "refuses an external capture of the wrong arity" do
       assert {:error, opts} = cast_and_apply(&Enum.map/2, mfa: true, arity: 1)
       assert opts[:arity] == 1
+    end
+  end
+
+  describe "storage_type/1" do
+    test "is :binary without the constraint" do
+      assert Ash.Type.Function.storage_type([]) == :binary
+      assert Ash.Type.Function.storage_type(mfa: false) == :binary
+    end
+
+    test "is :string with mfa: true" do
+      assert Ash.Type.Function.storage_type(mfa: true) == :string
+    end
+  end
+
+  describe "persistence with mfa: true" do
+    test "dumps an external capture to its capture string" do
+      assert {:ok, "&Elixir.Enum.map/2"} =
+               Ash.Type.Function.dump_to_native(&Enum.map/2, mfa: true)
+    end
+
+    test "dumps an external capture of an Erlang function" do
+      assert {:ok, "&erlang.map_size/1"} =
+               Ash.Type.Function.dump_to_native(&:erlang.map_size/1, mfa: true)
+    end
+
+    test "loads a capture string back into the same function" do
+      assert {:ok, "&Elixir.Enum.map/2" = stored} =
+               Ash.Type.Function.dump_to_native(&Enum.map/2, mfa: true)
+
+      assert {:ok, fun} = Ash.Type.Function.cast_stored(stored, mfa: true)
+      assert fun == (&Enum.map/2)
+      assert fun.([1, 2], &(&1 * 2)) == [2, 4]
+    end
+
+    test "a capture string naming an unknown module does not load" do
+      # `String.to_existing_atom/1` guards against materialising arbitrary atoms
+      # from stored strings, so an unknown module or function is refused outright.
+      assert :error =
+               Ash.Type.Function.cast_stored("&Elixir.DefinitelyNotARealModule.nope/1", mfa: true)
+    end
+
+    test "a malformed capture string does not load" do
+      assert :error = Ash.Type.Function.cast_stored("&not a capture", mfa: true)
+      assert :error = Ash.Type.Function.cast_stored("&Elixir.Enum.map", mfa: true)
+    end
+
+    test "captures are late-bound: a known module/function loads, arity resolved at call" do
+      # Consistent with storing a reference rather than the implementation, the
+      # arity is not checked against exports at load time — the capture binds and
+      # would raise only if invoked. Module and function must still be known atoms.
+      assert {:ok, fun} = Ash.Type.Function.cast_stored("&Elixir.Enum.map/99", mfa: true)
+      assert is_function(fun, 99)
+    end
+  end
+
+  describe "persistence without the constraint" do
+    test "round-trips a function through the binary form" do
+      assert {:ok, dumped} = Ash.Type.Function.dump_to_native(&Enum.map/2, [])
+      assert is_binary(dumped)
+      assert {:ok, fun} = Ash.Type.Function.cast_stored(dumped, [])
+      assert fun == (&Enum.map/2)
+    end
+  end
+
+  describe "reading a legacy binary row after mfa: true is added" do
+    test "an old term_to_binary row still loads under the constraint" do
+      # A row written before the constraint existed: binary, not a capture string.
+      {:ok, legacy} = Ash.Type.Function.dump_to_native(&Enum.map/2, [])
+
+      # cast_stored reads by shape, so it still loads even though the attribute
+      # now declares mfa: true.
+      assert {:ok, fun} = Ash.Type.Function.cast_stored(legacy, mfa: true)
+      assert fun == (&Enum.map/2)
+    end
+  end
+
+  describe "through a resource with constraints: [mfa: true]" do
+    test "stores an external capture and reads it back callable" do
+      assert {:ok, created} =
+               Handler
+               |> Ash.Changeset.for_create(:create, %{callback: &Enum.map/2})
+               |> Ash.create()
+
+      assert {:ok, [read]} = Ash.read(Handler)
+      assert read.id == created.id
+      assert read.callback.([1, 2], &(&1 * 10)) == [10, 20]
+    end
+
+    test "refuses a closure at create" do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Handler
+               |> Ash.Changeset.for_create(:create, %{callback: fn a, b -> {a, b} end})
+               |> Ash.create()
     end
   end
 end


### PR DESCRIPTION
closes #2806

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [*] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [*] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

This PR adds a `mfa: true` constraint to 'Ash.Type.Function' for portable persistence.
There are three commits in this PR:
- the `mfa` constraint refusing closures at cast (validation only, storage untouched)
- constrained functions are persisted as portable capture strings instead of VM-fragile binaries
- tests documenting late binding

This PR provides a persistence option for `Ash.Type.Function` that is safer than the default binary form. The default dumps via `:erlang.binary_to_term/2` - a deserialization surface the moduledoc flags as "NOT SAFE to use with external input".

The `mfa: true` form needs no binary deserialization: the stored value is a readable capture string, parsed with `String.to_existing_atom/1` (never minting atoms) and resolved with `Function.capture/3`.

That said it does need care: the referenced `Module.function/arity` may not be present in the reading runtime. Reconstruction needs only the module atom, so the record still loads; invocation is late-bound and raises `UndefinedFunctionError` if the code is genuinely absent. That trade-off is documented and tested.

The constraint is opt-in and defaults off, so existing `:function` attributes are unchanged - same `:binary` storage, closures still accepted.

