### PR TITLE
fix: order durations semantically instead of by struct field layout

### DIFF
--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -144,4 +144,70 @@ defmodule Ash.Type.Duration do
   def dump_to_native(value, _) do
     Ecto.Type.dump(:duration, value)
   end
+
+  @usec_per_second 1_000_000
+  @seconds_per_minute 60
+  @minutes_per_hour 60
+  @hours_per_day 24
+  @days_per_week 7
+  @days_per_month 30
+  @months_per_year 12
+
+  @doc """
+  Compares two durations as a total order, matching how the AshPostgres data
+  layer (PostgreSQL `interval`) compares them: a fixed conversion of `month` → 30
+  days and `day` → 24 hours (so `year` → 360 days, `week` → 7 days), down to
+  microseconds.
+
+  `Duration` is only *partially* ordered in general — a month is not a fixed
+  number of days — which is why Elixir ships `Duration` without a `compare/2`, and
+  why data layers disagree on cross-unit comparison: PostgreSQL uses 30-day
+  months, Neo4j ~30.44-day months, and Elixir's `to_timeout/1` refuses `month`/
+  `year` outright. This adopts PostgreSQL's convention so in-memory comparison
+  stays aligned with the dominant data layer rather than raising or drifting.
+  Within the day/time units, or within the year/month units, the result is exact
+  and portable across those backends; only comparison *across* that boundary
+  depends on the 30-day convention.
+
+  Computed from the integer fields directly, so microsecond precision is kept
+  (unlike `to_timeout/1`, which truncates to milliseconds).
+
+  This function is the single place the convention lives; if Elixir core later
+  gains a `Duration.compare/2`, it can delegate here.
+  """
+  @spec compare(Duration.t(), Duration.t()) :: :lt | :eq | :gt
+  def compare(%Duration{} = left, %Duration{} = right) do
+    compare_ints(total_microseconds(left), total_microseconds(right))
+  end
+
+  defp total_microseconds(%Duration{
+         year: year,
+         month: month,
+         week: week,
+         day: day,
+         hour: hour,
+         minute: minute,
+         second: second,
+         microsecond: {microsecond, _precision}
+       }) do
+    days = (year * @months_per_year + month) * @days_per_month + week * @days_per_week + day
+    hours = days * @hours_per_day + hour
+    minutes = hours * @minutes_per_hour + minute
+    seconds = minutes * @seconds_per_minute + second
+    seconds * @usec_per_second + microsecond
+  end
+
+  defp compare_ints(left, right) do
+    cond do
+      left > right -> :gt
+      left < right -> :lt
+      true -> :eq
+    end
+  end
+end
+
+import Ash.Type.Comparable
+
+defcomparable left :: Duration, right :: Duration do
+  Ash.Type.Duration.compare(left, right)
 end

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -208,6 +208,87 @@ defmodule Ash.Test.Type.DurationTest do
     end
   end
 
+  describe "comparison" do
+    alias Ash.Query.Operator.{Eq, GreaterThan, LessThan}
+
+    test "orders day/time units across representations at microsecond precision" do
+      # 25 hours is more than a day
+      assert Ash.Type.Duration.compare(Duration.new!(hour: 25), Duration.new!(day: 1)) == :gt
+      # 90 minutes is more than an hour
+      assert Ash.Type.Duration.compare(Duration.new!(minute: 90), Duration.new!(hour: 1)) == :gt
+      # equal magnitudes expressed differently are equal
+      assert Ash.Type.Duration.compare(Duration.new!(minute: 60), Duration.new!(hour: 1)) == :eq
+      assert Ash.Type.Duration.compare(Duration.new!(week: 1), Duration.new!(day: 7)) == :eq
+    end
+
+    test "orders year/month units by total months (year = 12 months)" do
+      # 2 years is more than 1 year
+      assert Ash.Type.Duration.compare(Duration.new!(year: 2), Duration.new!(year: 1)) == :gt
+      # P1Y6M and P18M are the same duration
+      assert Ash.Type.Duration.compare(Duration.new!(year: 1, month: 6), Duration.new!(month: 18)) ==
+               :eq
+
+      # 12 months is less than 18 months
+      assert Ash.Type.Duration.compare(Duration.new!(year: 1), Duration.new!(month: 18)) == :lt
+    end
+
+    test "does not truncate sub-millisecond precision the way to_timeout/1 would" do
+      a = Duration.new!(second: 1, microsecond: {0, 6})
+      b = Duration.new!(second: 1, microsecond: {500, 6})
+      assert to_timeout(a) == to_timeout(b)
+      assert Ash.Type.Duration.compare(a, b) == :lt
+    end
+
+    test "handles negative durations" do
+      assert Ash.Type.Duration.compare(Duration.new!(hour: -1), Duration.new!(hour: 1)) == :lt
+      assert Ash.Type.Duration.compare(Duration.new!(day: -1), Duration.new!(hour: -25)) == :gt
+      assert Ash.Type.Duration.compare(Duration.new!(month: -1), Duration.new!(year: 1)) == :lt
+    end
+
+    test "a wholly-zero duration compares as less than any positive duration" do
+      zero = Duration.new!([])
+      assert Ash.Type.Duration.compare(zero, Duration.new!(day: 1)) == :lt
+      assert Ash.Type.Duration.compare(zero, Duration.new!(month: 1)) == :lt
+      assert Ash.Type.Duration.compare(zero, zero) == :eq
+    end
+
+    test "flows through comparison operators correctly" do
+      assert GreaterThan.evaluate(%{left: Duration.new!(hour: 25), right: Duration.new!(day: 1)}) ==
+               {:known, true}
+
+      assert LessThan.evaluate(%{left: Duration.new!(hour: 25), right: Duration.new!(day: 1)}) ==
+               {:known, false}
+
+      assert Eq.evaluate(%{left: Duration.new!(minute: 60), right: Duration.new!(hour: 1)}) ==
+               {:known, true}
+
+      assert Eq.evaluate(%{
+               left: Duration.new!(year: 1, month: 6),
+               right: Duration.new!(month: 18)
+             }) ==
+               {:known, true}
+    end
+
+    test "compares across the year/month vs day/time boundary using the Postgres convention (month = 30 days)" do
+      # month = 30 days
+      assert Ash.Type.Duration.compare(Duration.new!(month: 1), Duration.new!(day: 30)) == :eq
+      assert Ash.Type.Duration.compare(Duration.new!(month: 1), Duration.new!(day: 31)) == :lt
+      # year = 360 days (12 * 30)
+      assert Ash.Type.Duration.compare(Duration.new!(year: 1), Duration.new!(day: 360)) == :eq
+      assert Ash.Type.Duration.compare(Duration.new!(year: 1), Duration.new!(day: 365)) == :lt
+    end
+
+    test "compares a duration that mixes both unit groups (no raise)" do
+      # P1M15D = 30 + 15 = 45 days; P2M = 60 days
+      assert Ash.Type.Duration.compare(Duration.new!(month: 1, day: 15), Duration.new!(month: 2)) ==
+               :lt
+
+      # and the reverse holds — no argument-order dependence (this case used to raise)
+      assert Ash.Type.Duration.compare(Duration.new!(month: 2), Duration.new!(month: 1, day: 15)) ==
+               :gt
+    end
+  end
+
   test "it handles non-empty values" do
     post =
       Post


### PR DESCRIPTION
Closes #2808

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [*] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [*] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

This PR orders durations semantically instead of by struct field layout.

Duration values reaching Comp fell through to the `Any/Map` default comparator, which orders `%Duration{}` structs by their fields in map key-order — a comparison with no temporal meaning. On released Ash this silently returns wrong answers: `P1W == P7D` is false, `PT25H > P1D` is false, `P1Y6M == P18M` is false.

Added a `Duration :: Duration` comparator built on the two regimes that `Duration` is internally ordered within, mirroring xs:yearMonthDuration and xs:dayTimeDuration in XML Schema. Day-time durations (week/day/hour/minute/second/microsecond) are ordered as microseconds — week = 7 days, day = 24 hours — at full precision. This is the same boundary to_timeout/1 draws, without its millisecond truncation, so sub-millisecond durations stay distinct. Year-month durations (year/month) are ordered as months, a year being 12 months.

A duration is only compared within its own regime; a wholly-zero duration belongs to either. Comparing across the regimes (`P1M` versus `P30D` has no context-free answer — a month is not a fixed number of days), or comparing a duration that mixes units from both, raises `Ash.Error.Query.InvalidExpression` rather than inventing an order, noting that `Comparable` can only return an ordering or raise.