### PR TITLE
feat: add units constraint to Ash.Type.Duration

### DIFF
--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -3,12 +3,32 @@
 # SPDX-License-Identifier: MIT
 
 defmodule Ash.Type.Duration do
+  @year_month_units [:year, :month]
+  @day_time_units [:week, :day, :hour, :minute, :second, :microsecond]
+  @duration_units @year_month_units ++ @day_time_units
+
+  @constraints [
+    units: [
+      type: {:or, [{:in, [:year_month, :day_time]}, {:list, {:in, @duration_units}}]},
+      doc: """
+      The units permitted to be non-zero; any unit outside the set must be zero, otherwise casting fails. Either an explicit list of units, or a shorthand for one side of the comparability boundary: `:year_month` (`[:year, :month]`) or `:day_time` (`[:week, :day, :hour, :minute, :second, :microsecond]`). Confining an attribute to a single side keeps its values comparable (see `Ash.Type.Duration.compare/2`).
+      """
+    ]
+  ]
+
   @moduledoc """
   Represents a Duration
 
   A builtin type that can be referenced via `:duration`
+
+  ### Constraints
+
+  #{Spark.Options.docs(@constraints)}
   """
   use Ash.Type
+
+  @impl true
+  def constraints, do: @constraints
 
   @impl true
   def storage_type(_), do: :duration
@@ -51,6 +71,41 @@ defmodule Ash.Type.Duration do
   end
 
   @impl true
+  def apply_constraints(nil, _), do: {:ok, nil}
+
+  def apply_constraints(%Duration{} = value, constraints) do
+    case constraints[:units] do
+      nil ->
+        {:ok, value}
+
+      units ->
+        allowed = expand_units(units)
+
+        case Enum.reject(@duration_units, &(&1 in allowed or unit_zero?(value, &1))) do
+          [] ->
+            {:ok, value}
+
+          disallowed ->
+            {:error,
+             [
+               [
+                 message: "must only use the units %{units}",
+                 units: Enum.map_join(allowed, ", ", &to_string/1),
+                 disallowed: Enum.map_join(disallowed, ", ", &to_string/1)
+               ]
+             ]}
+        end
+    end
+  end
+
+  defp expand_units(:year_month), do: @year_month_units
+  defp expand_units(:day_time), do: @day_time_units
+  defp expand_units(units) when is_list(units), do: units
+
+  defp unit_zero?(%Duration{microsecond: {value, _precision}}, :microsecond), do: value == 0
+  defp unit_zero?(%Duration{} = duration, unit), do: Map.fetch!(duration, unit) == 0
+
+  @impl true
   def matches_type?(%{__struct__: Duration}, _), do: true
   def matches_type?(_, _), do: false
 
@@ -58,6 +113,12 @@ defmodule Ash.Type.Duration do
   def cast_atomic(new_value, _constraints) do
     {:atomic, new_value}
   end
+
+  # A `units` whitelist is a property of the decoded `Duration` struct's fields,
+  # which cannot be checked within an atomic expression. Fall back to the
+  # non-atomic path so `apply_constraints/2` enforces it.
+  @impl true
+  def may_support_atomic_update?(constraints), do: is_nil(constraints[:units])
 
   @impl true
   def cast_stored(nil, _), do: {:ok, nil}

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -51,6 +51,11 @@ defmodule Ash.Test.Type.DurationTest do
 
       attribute :duration_d, :duration, allow_nil?: true, public?: true
 
+      attribute :duration_calendar_free, :duration,
+        allow_nil?: true,
+        public?: true,
+        constraints: [units: :day_time]
+
       attribute :date, :date, allow_nil?: true, public?: true
 
       attribute :datetime, :datetime, allow_nil?: true, public?: true
@@ -99,6 +104,107 @@ defmodule Ash.Test.Type.DurationTest do
       calculate :utc_datetime_usec_minus_duration_c,
                 :utc_datetime_usec,
                 expr(utc_datetime_usec - duration_c)
+    end
+  end
+
+  describe "units constraint" do
+    @calendar_free [:week, :day, :hour, :minute, :second, :microsecond]
+
+    test "with no constraint, any unit is permitted" do
+      assert {:ok, _} = Ash.Type.Duration.apply_constraints(Duration.new!(year: 1, month: 2), [])
+    end
+
+    test "accepts durations that use only whitelisted units" do
+      assert {:ok, _} =
+               Ash.Type.Duration.apply_constraints(
+                 Duration.new!(day: 3, hour: 4, minute: 30),
+                 units: @calendar_free
+               )
+
+      assert {:ok, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(week: 2), units: @calendar_free)
+    end
+
+    test "rejects durations that use a non-whitelisted unit" do
+      assert {:error, [[message: message, units: _, disallowed: disallowed]]} =
+               Ash.Type.Duration.apply_constraints(
+                 Duration.new!(month: 1, day: 3),
+                 units: @calendar_free
+               )
+
+      assert message =~ "must only use the units"
+      assert disallowed =~ "month"
+    end
+
+    test "the :day_time shorthand accepts day/time units and rejects year/month" do
+      assert {:ok, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(day: 3, hour: 4),
+                 units: :day_time
+               )
+
+      assert {:error, [[message: _, units: units, disallowed: disallowed]]} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(month: 1), units: :day_time)
+
+      # the reported permitted units are the expanded list, not the shorthand atom
+      assert units =~ "week"
+      assert disallowed =~ "month"
+    end
+
+    test "the :year_month shorthand accepts year/month units and rejects day/time" do
+      assert {:ok, _} =
+               Ash.Type.Duration.apply_constraints(
+                 Duration.new!(year: 2, month: 6),
+                 units: :year_month
+               )
+
+      assert {:error, [[message: _, units: units, disallowed: disallowed]]} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(day: 1), units: :year_month)
+
+      assert units =~ "year"
+      assert disallowed =~ "day"
+    end
+
+    test "treats the microsecond precision tuple as zero/non-zero on its value only" do
+      assert {:ok, _} =
+               Ash.Type.Duration.apply_constraints(
+                 Duration.new!(second: 5, microsecond: {0, 6}),
+                 units: [:second]
+               )
+
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(
+                 Duration.new!(second: 5, microsecond: {1, 6}),
+                 units: [:second]
+               )
+    end
+
+    test "nil passes regardless of constraint" do
+      assert {:ok, nil} = Ash.Type.Duration.apply_constraints(nil, units: [:day])
+    end
+
+    test "does not support atomic updates when a units constraint is set" do
+      refute Ash.Type.Duration.may_support_atomic_update?(units: @calendar_free)
+      assert Ash.Type.Duration.may_support_atomic_update?([])
+    end
+
+    test "is enforced when casting through a resource attribute" do
+      assert {:error, _} =
+               Post
+               |> Ash.Changeset.for_create(:create, %{
+                 duration_b: @minute30,
+                 duration_calendar_free: @month5
+               })
+               |> Ash.create()
+
+      assert {:ok, post} =
+               Post
+               |> Ash.Changeset.for_create(:create, %{
+                 duration_b: @minute30,
+                 duration_calendar_free: Duration.new!(day: 3, hour: 12)
+               })
+               |> Ash.create()
+
+      assert post.duration_calendar_free == Duration.new!(day: 3, hour: 12)
     end
   end
 

--- a/test/type/new_type_test.exs
+++ b/test/type/new_type_test.exs
@@ -213,8 +213,11 @@ defmodule Ash.Test.Type.NewTypeTest do
   end
 
   describe "BoundedDuration (duration with min/max)" do
-    test "exposes custom constraints on a type that natively has none" do
-      assert Ash.Type.Duration.constraints() == []
+    test "exposes custom constraints not present on the base type" do
+      base_keys = Ash.Type.Duration.constraints() |> Keyword.keys()
+      refute :min in base_keys
+      refute :max in base_keys
+
       keys = BoundedDuration.constraints() |> Keyword.keys()
       assert :min in keys
       assert :max in keys


### PR DESCRIPTION
closes #2810

Duration attributes accepted any duration, with no way to declare which units a value may use. Add a `units` constraint — a whitelist of the Duration fields permitted to be non-zero; any unit outside the list must be zero, otherwise casting fails.

# Contributor checklist

- [* ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [*] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

This PR adds units constraint to `Ash.Type.Duration`

`units` accepts an explicit list, or a shorthand for one side of the comparability boundary - `:day_time` (week/day/hour/minute/second/ microsecond) or `:year_month` (year/month):

    attribute :timeout, :duration, constraints: [units: :day_time]
    attribute :term,    :duration, constraints: [units: :year_month]
    attribute :offset,  :duration, constraints: [units: [:hour, :minute]]

This is cast-time validation - data hygiene, keeping unintended units out of storage. Confining an attribute to a single side of the boundary also keeps its values comparable (see `Ash.Type.Duration.compare/2`).

A units whitelist is a property of the decoded `Duration` struct's fields and cannot be checked inside an atomic expression, so `may_support_atomic_update?/1` returns false when the constraint is set, routing the value through the non-atomic path where it is enforced.

While this PR is related to issue #2808 and its PR #2809 it does not *require* them.