### PR TITLE
fix(ci): reference the unused-deps input by its declared name

### DIFF
--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -590,7 +590,7 @@ jobs:
   unused-deps:
     name: mix deps.unlock --check-unused
     runs-on: ubuntu-latest
-    if: ${{inputs.unused_deps}}
+    if: ${{inputs.unused-deps}}
     needs:
       - build-test
     steps:


### PR DESCRIPTION
The `unused-deps` input is declared with a hyphen, but the job is gated on `inputs.unused_deps`:

```yaml
      unused-deps:            # declared
        type: boolean
        default: true
...
  unused-deps:
    if: ${{inputs.unused_deps}}   # referenced
```

`inputs.unused_deps` is not a property of the `inputs` context, so the expression evaluates to empty, and the job is skipped on every run.

### It has never run

The typo was present in 2f2015eb, the commit that added the feature on 2026-03-25, so `mix deps.unlock --check-unused` has not executed once in the ~4 months since — for this repository or any downstream one calling `ash-ci.yml`.

Visible on a recent `main` run ([30698561054](https://github.com/ash-project/ash/actions/runs/30698561054)):

```
skipped  ash-ci (Picosat)   / mix deps.unlock --check-unused
skipped  ash-ci (SimpleSat) / mix deps.unlock --check-unused
```

despite the input defaulting to `true`.

It went unnoticed because the failure mode is a *skipped* job rather than a failing one — it still appears in the checks list, greyed out and non-blocking, so it looks present.

### The fix

One identifier. Hyphenated names work fine with dot notation in this file — `inputs.changelog-lint`, `inputs.community-files`, `inputs.publish-docs` and `inputs.spark-formatter` all do it, and `Changelog Lint` reports success in the same run — so matching the declared name is all that is needed.

Found while setting up CI for `ash_localize` on top of this workflow.