### PR TITLE
fix(ci): add contents: read to the credo job

### DIFF
--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -536,6 +536,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     permissions:
+      # actions/checkout needs this. A job-level `permissions:` block replaces the
+      # workflow default rather than adding to it, so omitting `contents` leaves
+      # the job with none — which fails checkout on a private repository.
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -536,9 +536,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     permissions:
-      # actions/checkout needs this. A job-level `permissions:` block replaces the
-      # workflow default rather than adding to it, so omitting `contents` leaves
-      # the job with none — which fails checkout on a private repository.
+      # A job-level block replaces the workflow default; checkout needs this.
       contents: read
       security-events: write
     steps:


### PR DESCRIPTION
The `credo` job declares its own permissions:

```yaml
  credo:
    permissions:
      security-events: write
```

A job-level `permissions:` block replaces the workflow default rather than extending it, so the job runs with no `contents` permission. `actions/checkout` then fails:

```
fatal: repository 'https://github.com/<org>/<repo>/' not found
The process '/usr/bin/git' failed with exit code 128
```

Checkout of a public repository succeeds without `contents`, so this only affects private repos calling `ash-ci.yml`. `mix credo --strict` passes on `team-alembic/ash_authentication` (public) and fails at checkout on a private repo on the same workflow.

`credo` is the only ungated job that overrides `permissions`. `deploy-docs` also overrides, but is gated on `publish-docs` and a repository-owner check.