### PR TITLE
improvement: index runtime_sort rekey by primary key instead of scanning

### DIFF
--- a/lib/ash/actions/sort.ex
+++ b/lib/ash/actions/sort.ex
@@ -148,14 +148,41 @@ defmodule Ash.Actions.Sort do
   end
 
   defp maybe_rekey(new_results, results, resource, true) do
-    if Ash.Resource.Info.primary_key(resource) == [] do
-      new_results
-    else
-      Enum.map(new_results, fn new_result ->
-        Enum.find(results, new_result, fn result ->
-          resource.primary_key_matches?(new_result, result)
+    pkey = Ash.Resource.Info.primary_key(resource)
+
+    cond do
+      pkey == [] ->
+        new_results
+
+      Ash.Resource.Info.primary_key_simple_equality?(resource) ->
+        # The simple-equality matcher is plain term equality over `Map.take/2`,
+        # so the scan becomes one O(n) index build plus O(1) lookups. `put_new`
+        # keeps the *first* record for a duplicate key (matching `Enum.find`),
+        # and a record with a nil/false key value is skipped so it matches
+        # nothing, including itself.
+        index =
+          Enum.reduce(results, %{}, fn result, acc ->
+            taken = Map.take(result, pkey)
+
+            if Enum.all?(Map.values(taken)),
+              do: Map.put_new(acc, taken, result),
+              else: acc
+          end)
+
+        Enum.map(new_results, fn new_result ->
+          taken = Map.take(new_result, pkey)
+
+          if Enum.all?(Map.values(taken)),
+            do: Map.get(index, taken, new_result),
+            else: new_result
         end)
-      end)
+
+      true ->
+        Enum.map(new_results, fn new_result ->
+          Enum.find(results, new_result, fn result ->
+            resource.primary_key_matches?(new_result, result)
+          end)
+        end)
     end
   end
 

--- a/test/sort/sort_test.exs
+++ b/test/sort/sort_test.exs
@@ -384,4 +384,36 @@ defmodule Ash.Test.Sort.SortTest do
               }} = Ash.Sort.parse_input(Post, "unsortable_author.name")
     end
   end
+
+  describe "runtime_sort/3 rekey" do
+    test "returns the input records reordered by the sort" do
+      a = %Post{id: "1", title: "a"}
+      b = %Post{id: "2", title: "b"}
+      c = %Post{id: "3", title: "c"}
+
+      assert [^c, ^b, ^a] =
+               Ash.Actions.Sort.runtime_sort([a, b, c], [title: :desc], resource: Post)
+    end
+
+    test "rekeys duplicate primary keys to the first matching input record" do
+      # Two distinct records share a primary key: every occurrence must resolve
+      # to the *first* one in the input, not the last.
+      a = %Post{id: "1", title: "x"}
+      b = %Post{id: "1", title: "y"}
+      c = %Post{id: "2", title: "z"}
+
+      assert [^c, ^a, ^a] =
+               Ash.Actions.Sort.runtime_sort([a, b, c], [title: :desc], resource: Post)
+    end
+
+    test "does not rekey records whose primary key is nil" do
+      # A nil key matches nothing, including another nil-keyed record, so each is
+      # returned as-is rather than collapsed onto a shared nil bucket.
+      a = %Post{id: nil, title: "z"}
+      b = %Post{id: nil, title: "a"}
+
+      assert [^b, ^a] =
+               Ash.Actions.Sort.runtime_sort([a, b], [title: :asc], resource: Post)
+    end
+  end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies

# Summary

maybe_rekey/4 mapped each of the n sorted records back onto the input with Enum.find. As the sorted list is a permutation of the input, Enum.find lands on each position exactly once, so the cost is exactly triangular, n(n+1)/2, regardless of sort order.

Performance has been made linear for the common simple-equality primary key case, where matching is plain term equality over Map.take/2, by first building a key -> record index. Primary keys using semantic equality (Ash.Type.equal?/3) keep the existing scan.

The first part of the PR is 'test only'.

The second part refactors maybe_rekey/4 to the indexed form, preserving both of those behaviours.

# Evidence

Measured on Ash `main`, Elixir 1.20.0 / OTP 27. Each run rekeys a shuffled permutation of N records back onto the input — the shape maybe_rekey/4 sees after every runtime sort — with the before/after outputs asserted equal.

## The cost

| records | before | after |
| ---: | ---: | ---: |
| 500 | 6.4 ms | 0.1 ms |
| 1,000 | 25.5 ms | 0.3 ms |
| 2,000 | 102.9 ms | 0.6 ms |
| 4,000 | 426.6 ms | 1.2 ms |
| 8,000 | 1,679.5 ms | 2.6 ms |

Before: cost quadruples as N doubles. After: linear.
