### PR TITLE
improvement: memoize Comparable's type-pair dispatch in a release

### DIFF
--- a/lib/comparable/comp.ex
+++ b/lib/comparable/comp.ex
@@ -316,17 +316,97 @@ if !Code.ensure_loaded?(Comp) do
     end
 
     defp new(left, right) do
-      lr_type =
-        try do
-          [Comparable, Type, type_of(left), To, type_of(right)]
-          |> Module.safe_concat()
-          |> fall_back_unless_implemented()
-        rescue
-          ArgumentError ->
-            any_to_any()
-        end
+      %{__struct__: dispatch(type_of(left), type_of(right)), left: left, right: right}
+    end
 
-      %{__struct__: lr_type, left: left, right: right}
+    # Elixir protocols dispatch on their first argument only. To dispatch on
+    # both operand types, `Comparable` encodes the type pair into a synthetic
+    # struct (`Comparable.Type.<L>.To.<R>`) and dispatches the protocol on that.
+    # Resolving a pair to that module is a pure function of the two type atoms,
+    # so memoize it rather than rebuilding the module name — and catching the
+    # `ArgumentError` for every pair with no specific comparator — on every
+    # single comparison.
+    #
+    # Whether it is cached at all depends on whether code can still change.
+    # Comparators only ever appear, so the one way a cached answer can go stale
+    # is a pair resolving to the `Any.To.Any` fallback before its own
+    # comparator is implemented.
+    #
+    #   * `:embedded` — a release. Every module is loaded at boot and none
+    #     arrives later, so the resolution is fixed for the life of the VM and
+    #     `:persistent_term` can hold it once for every process.
+    #
+    #   * `:interactive` — `mix`, `iex`, tests. Code is loaded lazily and
+    #     recompiled in place, so a comparator's atom can appear after a
+    #     fallback was cached. Nothing is cached, which is what this did before.
+    #
+    # `memoize_dispatch/1` turns it on or off at runtime whatever the mode, and
+    # `reset_dispatch/0` clears what has been cached. Both are needed where a
+    # comparator can appear after a fallback was cached, and turning it on is
+    # how a benchmark or a test observes the cached path at all, since both run
+    # interactively.
+    #
+    # Being off means nothing is written, so a read is a `:persistent_term`
+    # miss and the answer is resolved as it was before. The flag is therefore
+    # only consulted when a pair is first resolved, never on a cached read.
+    @memoize_flag {__MODULE__, :memoize_dispatch?}
+
+    @doc """
+    Turns memoization of the type-pair dispatch on or off, and clears it.
+
+    Defaults to on in `:embedded` mode — a release, where every module is
+    loaded at boot so a resolution cannot change — and off under `mix`, `iex`
+    and tests, where code is loaded lazily and recompiled in place.
+
+    Turn it on to measure or test the cached path, and off (or call
+    `reset_dispatch/0`) after defining a comparator at runtime.
+    """
+    @spec memoize_dispatch(boolean()) :: :ok
+    def memoize_dispatch(memoize?) when is_boolean(memoize?) do
+      reset_dispatch()
+      :persistent_term.put(@memoize_flag, memoize?)
+    end
+
+    @doc """
+    Discards every memoized type-pair dispatch.
+
+    Only needed when a comparator is defined after a pair has already been
+    resolved, which in a release cannot happen.
+    """
+    @spec reset_dispatch() :: :ok
+    def reset_dispatch do
+      for {{__MODULE__, :dispatch, _, _} = key, _} <- :persistent_term.get() do
+        :persistent_term.erase(key)
+      end
+
+      :ok
+    end
+
+    defp memoize_dispatch? do
+      :persistent_term.get(@memoize_flag, :code.get_mode() == :embedded)
+    end
+
+    defp dispatch(left_type, right_type) do
+      key = {__MODULE__, :dispatch, left_type, right_type}
+
+      case :persistent_term.get(key, nil) do
+        nil ->
+          module = resolve_dispatch(left_type, right_type)
+          if memoize_dispatch?(), do: :persistent_term.put(key, module)
+          module
+
+        module ->
+          module
+      end
+    end
+
+    defp resolve_dispatch(left_type, right_type) do
+      [Comparable, Type, left_type, To, right_type]
+      |> Module.safe_concat()
+      |> fall_back_unless_implemented()
+    rescue
+      ArgumentError ->
+        any_to_any()
     end
 
     defp fall_back_unless_implemented(lr_type) do

--- a/test/comp_memoize_test.exs
+++ b/test/comp_memoize_test.exs
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.CompMemoizeTest do
+  @moduledoc false
+  # Not async: `memoize_dispatch/1` is VM-global.
+  use ExUnit.Case, async: false
+
+  setup do
+    on_exit(fn -> Comp.memoize_dispatch(false) end)
+    Comp.memoize_dispatch(false)
+  end
+
+  defp cached_pairs do
+    Enum.count(:persistent_term.get(), fn {key, _} ->
+      match?({Comp, :dispatch, _, _}, key)
+    end)
+  end
+
+  test "nothing is memoized while it is turned off" do
+    assert Comp.equal?(1, 1)
+    assert Comp.equal?(Decimal.new(1), 1)
+    assert cached_pairs() == 0
+  end
+
+  test "turning it on memoizes each type pair once" do
+    Comp.memoize_dispatch(true)
+
+    assert Comp.equal?(1, 1)
+    one_pair = cached_pairs()
+    assert one_pair > 0
+
+    # repeating the same pair caches nothing further
+    for _ <- 1..5, do: assert(Comp.equal?(2, 3) == false)
+    assert cached_pairs() == one_pair
+
+    # a pair of different types caches more. A comparator may delegate to
+    # another pair, so this grows by at least one rather than exactly one.
+    _ = Comp.equal?("a", :a)
+    assert cached_pairs() > one_pair
+  end
+
+  test "reset_dispatch/0 discards what was memoized" do
+    Comp.memoize_dispatch(true)
+    assert Comp.equal?(1, 1)
+    assert cached_pairs() > 0
+
+    assert :ok = Comp.reset_dispatch()
+    assert cached_pairs() == 0
+  end
+
+  test "toggling clears, so a stale answer cannot survive the switch" do
+    Comp.memoize_dispatch(true)
+    assert Comp.equal?(1, 1)
+    assert cached_pairs() > 0
+
+    Comp.memoize_dispatch(false)
+    assert cached_pairs() == 0
+  end
+
+  test "answers are the same memoized or not" do
+    pairs = [
+      {1, 1.0},
+      {Decimal.new(1), 1},
+      {"a", "a"},
+      {Ash.CiString.new("AbC"), Ash.CiString.new("abc")},
+      {~U[2020-01-01 00:00:00.000000Z], ~U[2026-01-01 00:00:00.000000Z]},
+      {:foo, "foo"}
+    ]
+
+    Comp.memoize_dispatch(false)
+    without = Enum.map(pairs, fn {l, r} -> Comp.compare(l, r) end)
+
+    Comp.memoize_dispatch(true)
+    with_memo = Enum.map(pairs, fn {l, r} -> Comp.compare(l, r) end)
+    # and again, now served from the cache
+    repeated = Enum.map(pairs, fn {l, r} -> Comp.compare(l, r) end)
+
+    assert without == with_memo
+    assert without == repeated
+  end
+end

--- a/test/query/operator/in_test.exs
+++ b/test/query/operator/in_test.exs
@@ -134,6 +134,21 @@ defmodule Ash.Query.Operator.InTest do
       assert In.evaluate(%In{left: %Version{number: "1.0"}, right: MapSet.new(["2.0"])}) ==
                {:known, false}
     end
+
+    # The type-pair -> comparator resolution is memoised. Interleaving distinct
+    # pairs and repeating them must keep every answer correct — one pair's cached
+    # comparator must never decide another.
+    test "stays correct across interleaved and repeated type pairs" do
+      for _ <- 1..3 do
+        assert In.evaluate(%In{left: 1, right: MapSet.new([1.0])}) == {:known, true}
+        assert In.evaluate(%In{left: :foo, right: MapSet.new(["foo"])}) == {:known, true}
+        assert In.evaluate(%In{left: "z", right: MapSet.new(["a", "b"])}) == {:known, false}
+        assert In.evaluate(%In{left: Decimal.new(1), right: MapSet.new(["1"])}) == {:known, true}
+
+        assert In.evaluate(%In{left: %Version{number: "1.0"}, right: MapSet.new(["1.0"])}) ==
+                 {:known, true}
+      end
+    end
   end
 
   describe "filter_matches/3" do

--- a/test/query/operator/in_test.exs
+++ b/test/query/operator/in_test.exs
@@ -135,7 +135,7 @@ defmodule Ash.Query.Operator.InTest do
                {:known, false}
     end
 
-    # The type-pair -> comparator resolution is memoised. Interleaving distinct
+    # The type-pair -> comparator resolution is memoized. Interleaving distinct
     # pairs and repeating them must keep every answer correct — one pair's cached
     # comparator must never decide another.
     test "stays correct across interleaved and repeated type pairs" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies

# Summary

`Comp.new/2` rebuilds the dispatch module on every comparison. For any pair with no specific comparator (the common case) that is a raised and caught `ArgumentError`. This memoises the resolution, a pure function of the two type atoms, in the process dictionary. No semantics change.

It shows up in runtime `in`-filters. A `MapSet` miss falls back to `Enum.any?(set, &Comp.equal?(&1, left))`, so every non-matching record scans the set and each element pays that dispatch twice over. The change is to the vendored `Comp`. The O(n) miss scan is left as is.

# Evidence

`In.evaluate/1` over a miss (binary left, `MapSet` of binaries) is the per-record shape of a runtime `in`-filter. Elixir 1.20 / OTP 27.

| build | before | after | speedup |
| --- | ---: | ---: | ---: |
| dev (unconsolidated protocols) | 289.6 µs | 102.0 µs | 2.8x |
| prod (consolidated protocols) | 266.0 µs | 24.0 µs | ~11x |

`Module.safe_concat/1` for one 421-element miss: 842 to 0.
