### PR TITLE
fix: reset the combinations accumulator after an intersect in ETS

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1244,7 +1244,7 @@ defmodule Ash.DataLayer.Ets do
                   matcher.(result, temp_results_acc)
                 end)
 
-              {:cont, {:ok, records, grouper.(records, acc)}}
+              {:cont, {:ok, records, grouper.(records, base)}}
 
             :except ->
               temp_results_acc = grouper.(results, base)

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -235,6 +235,25 @@ defmodule Ash.Test.QueryTest do
       assert ["a@bar.com", "j@bar.com"] = result |> Enum.map(& &1.email) |> Enum.sort()
     end
 
+    test "a union following an intersect sees only the records the intersect left" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+      Ash.create!(User, %{name: "fred", email: "b@baz.com"})
+      Ash.create!(User, %{name: "john", email: "j@bar.com"})
+
+      result =
+        User
+        |> Ash.Query.combination_of([
+          Ash.Query.Combination.base([]),
+          Ash.Query.Combination.intersect(filter: expr(name == "fred")),
+          Ash.Query.Combination.union(filter: expr(contains(email, "bar.com")))
+        ])
+        |> Ash.read!()
+
+      # the intersect leaves the two freds, and the union adds back the john it removed
+      assert ["a@bar.com", "b@baz.com", "j@bar.com"] =
+               result |> Enum.map(& &1.email) |> Enum.sort()
+    end
+
     test "combinations with multiple union_all" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
       Ash.create!(User, %{name: "alice", email: "a@baz.com"})

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -217,6 +217,24 @@ defmodule Ash.Test.QueryTest do
       assert hd(result).email == "a@bar.com"
     end
 
+    test "a union following an except sees only the records the except left" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+      Ash.create!(User, %{name: "fred", email: "b@baz.com"})
+      Ash.create!(User, %{name: "john", email: "j@bar.com"})
+
+      result =
+        User
+        |> Ash.Query.combination_of([
+          Ash.Query.Combination.base([]),
+          Ash.Query.Combination.except(filter: expr(name == "fred")),
+          Ash.Query.Combination.union(filter: expr(contains(email, "bar.com")))
+        ])
+        |> Ash.read!()
+
+      # the except leaves john, and the union adds back the fred the except removed
+      assert ["a@bar.com", "j@bar.com"] = result |> Enum.map(& &1.email) |> Enum.sort()
+    end
+
     test "combinations with multiple union_all" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
       Ash.create!(User, %{name: "alice", email: "a@baz.com"})


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2821.

In `Ash.DataLayer.Ets`, a `union` following an `intersect` dropped records it should
have returned, so ETS and AshPostgres disagreed on the same combination query:

| middle part | ETS | AshPostgres |
| --- | --- | --- |
| `intersect` | `["alpha", "beta"]` | `["alpha", "beta", "gamma"]` |
| `except` | `["alpha", "gamma"]` | `["alpha", "gamma"]` |

This PR fixes combination query accumulation in ETS to return the Postgres answer for `intersect`. `except` already agreed.

# Cause

`get_records/4` folds over the combination parts, carrying an accumulator of the
records seen so far that later parts match against:

```elixir
:intersect ->
  {:cont, {:ok, records, grouper.(records, acc)}}    # merged into acc

:except ->
  {:cont, {:ok, results, grouper.(results, base)}}   # rebuilt from base
```

When `intersect` merged `records` they were already a subset of `acc`, so that
`grouper` called a no-op and the accumulator kept everything, including the records
the intersect just removed. The following `union` then saw them as duplicates and
dropped them. `except` rebuilds from `base` and keeps only the survivors.

Rebuilding from `base` in `intersect` too is the whole fix. It matches how both
operations are documented, in terms of "the previous combinations", now accumulated.

The bug was subtle, it could only be observed if the combination query had more than two parts which is why existing tests passed.

# Commits

1. `test:` a three-part `base / except / union` case, which passes as-is and pins the
   accumulator behaviour that nothing previously observed.
2. `fix:` the one-line change, plus the matching `intersect` case.

Full suite green (3755 tests).

