### PR TITLE
fix: order ETS min/max aggregates with Comp instead of Erlang term order

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1043,19 +1043,19 @@ defmodule Ash.DataLayer.Ets do
                   Enum.sum(items)
                 end
 
+              # `Comp` is what `Ash.Actions.Sort.runtime_sort/3` orders with, so
+              # comparing with it here keeps `min`/`max` consistent with how this
+              # data layer sorts the very same field. `Enum.max/1` would fall
+              # back to Erlang term order, which compares a struct's fields in
+              # alphabetical key order — for a `DateTime` that means `:day`
+              # decides and `:year` is never reached. No field ordering would be
+              # right anyway: `DateTime.compare/2` applies the UTC offsets, so
+              # two rows with different wall clocks can be the same instant.
               :max ->
-                if is_struct(first_item, Decimal) do
-                  Enum.reduce(items, &Decimal.max(&1, &2))
-                else
-                  Enum.max(items)
-                end
+                Enum.max(items, Comp)
 
               :min ->
-                if is_struct(first_item, Decimal) do
-                  Enum.reduce(items, &Decimal.min(&1, &2))
-                else
-                  Enum.min(items)
-                end
+                Enum.min(items, Comp)
             end
         end
     end

--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -52,6 +52,10 @@ defmodule Ash.Test.Actions.AggregateTest do
         public?(true)
       end
 
+      attribute :thing4, :utc_datetime_usec do
+        public?(true)
+      end
+
       create_timestamp :created_at
     end
 
@@ -287,6 +291,34 @@ defmodule Ash.Test.Actions.AggregateTest do
       |> Ash.create!(authorize?: false)
 
       assert %{count: 2} = Ash.aggregate!(Post, {:count, :count}, authorize?: false)
+    end
+
+    test "a datetime field sorts and firsts by chronology" do
+      # Erlang term order compares a struct's fields in alphabetical key order,
+      # so for a DateTime :day (31 vs 1) decides before :year is ever reached.
+      # These two instants therefore order one way by term order and the
+      # opposite way by chronology.
+      early = ~U[2020-12-31 23:00:00.000000Z]
+      late = ~U[2026-01-01 00:00:00.000000Z]
+
+      for at <- [early, late] do
+        Comment
+        |> Ash.Changeset.for_create(:create, %{public: true, thing: "chrono", thing4: at})
+        |> Ash.create!(authorize?: false)
+      end
+
+      mine = Ash.Query.filter(Comment, thing == "chrono")
+
+      assert [^late, ^early] =
+               mine
+               |> Ash.Query.sort(thing4: :desc)
+               |> Ash.read!(authorize?: false)
+               |> Enum.map(& &1.thing4)
+
+      assert %{first: ^late} =
+               mine
+               |> Ash.Query.sort(thing4: :desc)
+               |> Ash.aggregate!({:first, :first, field: :thing4}, authorize?: false)
     end
 
     test "honors tenant" do

--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -239,6 +239,16 @@ defmodule Ash.Test.Actions.AggregateTest do
         authorize? false
       end
 
+      min :min_of_thing4, :comments, :thing4 do
+        public? true
+        authorize? false
+      end
+
+      max :max_of_thing4, :comments, :thing4 do
+        public? true
+        authorize? false
+      end
+
       sum :sum_of_doubled_thing3, :comments, :doubled_thing3 do
         public? true
         authorize? false
@@ -319,6 +329,25 @@ defmodule Ash.Test.Actions.AggregateTest do
                mine
                |> Ash.Query.sort(thing4: :desc)
                |> Ash.aggregate!({:first, :first, field: :thing4}, authorize?: false)
+    end
+
+    test "min and max of a datetime field agree with that ordering" do
+      early = ~U[2020-12-31 23:00:00.000000Z]
+      late = ~U[2026-01-01 00:00:00.000000Z]
+
+      for at <- [early, late] do
+        Comment
+        |> Ash.Changeset.for_create(:create, %{public: true, thing: "extremes", thing4: at})
+        |> Ash.create!(authorize?: false)
+      end
+
+      mine = Ash.Query.filter(Comment, thing == "extremes")
+
+      assert %{max: ^late} =
+               Ash.aggregate!(mine, {:max, :max, field: :thing4}, authorize?: false)
+
+      assert %{min: ^early} =
+               Ash.aggregate!(mine, {:min, :min, field: :thing4}, authorize?: false)
     end
 
     test "honors tenant" do
@@ -603,6 +632,25 @@ defmodule Ash.Test.Actions.AggregateTest do
                Ash.Actions.Read.add_calc_context(aggregate, nil, true, nil, nil, Domain, Post,
                  parent_stack: []
                )
+    end
+
+    test "min and max aggregates over a relationship order a datetime chronologically" do
+      early = ~U[2020-12-31 23:00:00.000000Z]
+      late = ~U[2026-01-01 00:00:00.000000Z]
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "title", public: true})
+        |> Ash.create!(authorize?: false)
+
+      for at <- [early, late] do
+        Comment
+        |> Ash.Changeset.for_create(:create, %{post_id: post.id, public: true, thing4: at})
+        |> Ash.create!(authorize?: false)
+      end
+
+      assert Ash.load!(post, :min_of_thing4, authorize?: false).min_of_thing4 == early
+      assert Ash.load!(post, :max_of_thing4, authorize?: false).max_of_thing4 == late
     end
 
     test "aggregations on decimal fields succeed" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2823.

`min` and `max` in `Ash.DataLayer.Ets` compared with `Enum.min/1` and `Enum.max/1`, which fall
back to Erlang term order. For struct-valued types that is wrong, and for two values the answers
are not merely inaccurate but **swapped**. The `max` of a datetime field returned the earliest record.

`Decimal` was already special-cased, which is why it worked.
Measured before and after, with two values per type chosen so term order and the type's own order
disagree:

| attribute type | before | after |
| --- | --- | --- |
| `:utc_datetime_usec` | inverted | correct |
| `:naive_datetime` | inverted | correct |
| `:date` | inverted | correct |
| `:time_usec` | inverted | correct |
| `:duration` | inverted | correct |
| `:ci_string` | inverted | correct |
| `:decimal` | correct — special-cased | correct |
| `:integer` (control) | correct | correct |

AshPostgres answers these correctly, so the two in-tree data layers disagreed. Repro in the
issue.

# Cause

`aggregate_value/6` in `lib/ash/data_layer/ets/ets.ex`:

```elixir
:max ->
  if is_struct(first_item, Decimal) do
    Enum.reduce(items, &Decimal.max(&1, &2))
  else
    Enum.max(items)          # ← Erlang term order
  end
```

Erlang orders maps by size, then keys, then values **in key order** — and the keys are atoms,
which sort lexicographically. So a struct's fields are compared in alphabetical name order:

```elixir
~U[2020-01-01 00:00:00Z] |> Map.keys() |> Enum.sort()
#=> [:__struct__, :calendar, :day, :hour, :microsecond, :minute, :month,
#=>  :second, :std_offset, :time_zone, :utc_offset, :year, :zone_abbr]
```

`:day` decides and `:year` is never reached, so `2020-12-31` sorts above `2026-01-01`. The same
shape explains `time_usec`: `:microsecond` outranks `:minute` and `:second`.

Reordering fields would not be a fix either.  For `DateTime`, `Comp` does not read struct fields at all — it
delegates to the stdlib comparator:

```elixir
defcomparable left :: DateTime, right :: DateTime do
  DateTime.compare(left, right)
end
```

and `DateTime.compare/2` applies `utc_offset`/`std_offset`, so it is instant-based. Two rows with
different wall-clock fields in different zones are the same instant and compare `:eq`, which no
ordering of the stored fields can reproduce.

This is the one place in the file that does not use `Comp`. `distinct_and_sort/6` routes to
`Ash.Actions.Sort.runtime_sort/3`, which compares with `Comp`, so *sorting* the same field in the
same read already gives the chronological answer. Comparing with `Comp` here makes `min`/`max`
agree with it:

```elixir
:max -> Enum.max(items, Comp)
:min -> Enum.min(items, Comp)
```

`Comp` is vendored at `lib/comparable/`, so this adds no dependency. It handles `Decimal`, so the
special case goes with it, and `nil`s are already rejected before this point.

Both routes into `aggregate_value/6` are covered by the tests: `run_aggregate_query/3` (a direct
`Ash.aggregate!`) and `do_add_aggregates/4` (a declared aggregate over a relationship). Both fail
without the change.

# Commits

1. `test:` pin that a datetime field sorts and `first`s chronologically. These pass as is. That is
   the contrast which gives `min`/`max` their expected answer, and nothing pinned it.
2. `fix:` compare with `Comp`, plus the `min`/`max` cases for both routes.