### PR TITLE
fix: sort a ranked union in ETS, not only a ranked union_all

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -397,7 +397,15 @@ defmodule Ash.DataLayer.Ets do
         _resource,
         parent \\ nil
       ) do
-    maybe_not_distinct? = Enum.any?(combination_of, &(elem(&1, 0) == :union_all))
+    # A fold can return the same primary key twice in two ways: `union_all`
+    # keeps every row, and a `union` between parts carrying different
+    # combination calculations keeps both copies, because the equality basis
+    # is the combination fieldset. `runtime_sort/3` needs to know, or it
+    # batches the sort-key load and cannot tell the copies apart.
+    maybe_not_distinct? =
+      Enum.any?(combination_of, fn {type, combination} ->
+        type == :union_all or not Enum.empty?(combination.calculations)
+      end)
 
     with {:ok, records} when records != [] <-
            get_records(resource, combination_of, parent, tenant),

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -304,6 +304,7 @@ defmodule Ash.Test.QueryTest do
       end
 
       assert [3, 2, 1] = ranked.(:union_all)
+      assert [3, 2, 1] = ranked.(:union)
     end
 
     test "combination with offset" do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -274,6 +274,38 @@ defmodule Ash.Test.QueryTest do
       assert Enum.any?(result, &(&1.name == "john"))
     end
 
+    test "a ranked union_all sorts by its combination calculation" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+
+      # One record, reached by three parts that each rank it differently.
+      ranked = fn type ->
+        User
+        |> Ash.Query.combination_of([
+          Ash.Query.Combination.base(
+            filter: expr(name == "fred"),
+            calculations: %{sort_order: calc(1, type: :integer)}
+          ),
+          apply(Ash.Query.Combination, type, [
+            [
+              filter: expr(name == "fred"),
+              calculations: %{sort_order: calc(2, type: :integer)}
+            ]
+          ]),
+          apply(Ash.Query.Combination, type, [
+            [
+              filter: expr(name == "fred"),
+              calculations: %{sort_order: calc(3, type: :integer)}
+            ]
+          ])
+        ])
+        |> Ash.Query.sort([{calc(^combinations(:sort_order)), :desc}])
+        |> Ash.read!()
+        |> Enum.map(& &1.calculations[:sort_order])
+      end
+
+      assert [3, 2, 1] = ranked.(:union_all)
+    end
+
     test "combination with offset" do
       # Create users with ascending email for predictable sort order
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2827 .

Sorting by a combination calculation did nothing when the parts were joined with `union`. The
same query with `union_all` sorted correctly. One record, reached by three parts ranking it
1/2/3, sorted descending:

```
union_all -> [3, 2, 1]     correct
union     -> [1, 2, 3]     unsorted
```

That is the ranked shape the combinations guide documents. Repro in the issue.

# Cause

`run_query/3` in `lib/ash/data_layer/ets/ets.ex` tells `Ash.Actions.Sort.runtime_sort/3` whether
the fold can return the same primary key twice:

```elixir
maybe_not_distinct? = Enum.any?(combination_of, &(elem(&1, 0) == :union_all))
```

`runtime_sort/3` uses `maybe_not_distinct?` when choosing how to load the sort key — batched, or one record at a time. The batched branch cannot resolve two records sharing a primary key into two records, so the key
is mis-assigned and the sort silently does nothing.

The condition is too narrow. `union_all` is not the only way to get a repeated primary key: for a
`union` the equality basis is the combination fieldset, so parts carrying different combination
calculations keep both copies.

Now widening to any part carrying combination calculations:

```elixir
maybe_not_distinct? =
  Enum.any?(combination_of, fn {type, combination} ->
    type == :union_all or not Enum.empty?(combination.calculations)
  end)
```

`Ash.Query.Combination`'s `calculations` defaults to `%{}`, so the emptiness test has to be
`Enum.empty?/1`. Comparing against `[]` is `true` for `%{}`, which would set the flag for every
combination query and put them all on the unbatched path.

# Commits

1. `test:` pin the ranked three-part shape from the guide, asserted for `union_all` - passes  as-is.
2. `fix:` widen the condition, and assert the same result for `union`.