### PR TITLE
fix: compare the combination fieldset by name so shadowing calcs are applied

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1110,17 +1110,19 @@ defmodule Ash.DataLayer.Ets do
         & &1.name
       )
 
+    # `field_set` holds field structs while these are names, so the two have to
+    # be compared by name. A combination calculation whose name shadows a field
+    # of the resource is promoted onto the record itself below; anything else
+    # stays in `:calculations`.
+    field_set_names = Enum.map(field_set, & &1.name)
+
     fields_to_rewrite =
       resource
       |> Ash.Resource.Info.fields([:attributes, :calculations, :aggregates])
       |> Enum.map(& &1.name)
+      |> Enum.filter(&(&1 in field_set_names))
 
-    rewrite? = not Enum.empty?(field_set -- fields_to_rewrite)
-
-    fields_to_rewrite =
-      if rewrite? do
-        Enum.filter(fields_to_rewrite, &(&1 in field_set))
-      end
+    rewrite? = not Enum.empty?(fields_to_rewrite)
 
     {simple_equality, non_simple_equality} =
       Enum.split_with(field_set, fn %{type: type} ->

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -199,6 +199,22 @@ defmodule Ash.Test.QueryTest do
                |> Ash.read!()
     end
 
+    test "a combination calculation shadowing a resource field is promoted onto the record" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+
+      assert [%User{name: "from-combination", calculations: calculations}] =
+               User
+               |> Ash.Query.combination_of([
+                 Ash.Query.Combination.base(
+                   filter: expr(name == "fred"),
+                   calculations: %{name: calc("from-combination", type: :string)}
+                 )
+               ])
+               |> Ash.read!()
+
+      refute Map.has_key?(calculations, :name)
+    end
+
     test "it handles combinations with intersect" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
       Ash.create!(User, %{name: "john", email: "j@bar.com"})

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -185,6 +185,20 @@ defmodule Ash.Test.QueryTest do
                |> Ash.read!()
     end
 
+    test "a combination calculation naming no resource field stays in :calculations" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+
+      assert [%User{calculations: %{sort_order: 1}}] =
+               User
+               |> Ash.Query.combination_of([
+                 Ash.Query.Combination.base(
+                   filter: expr(name == "fred"),
+                   calculations: %{sort_order: calc(1, type: :integer)}
+                 )
+               ])
+               |> Ash.read!()
+    end
+
     test "it handles combinations with intersect" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
       Ash.create!(User, %{name: "john", email: "j@bar.com"})


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2829

A combination calculation whose name matches a field of the resource was computed but not applied
to the record:

```
combination calculates :name -> "from-combination"

record.name          -> "stored"
record.calculations  -> %{name: "from-combination"}
```

A calculation naming no field of the resource is unaffected and still belongs in
`:calculations` — that half was already correct. Repro in the issue.

# Cause

`get_records/4` in `lib/ash/data_layer/ets/ets.ex` works out which combination calculations to
move onto the record by intersecting the combination fieldset with the resource's own fields:

```elixir
rewrite? = not Enum.empty?(field_set -- fields_to_rewrite)

fields_to_rewrite =
  if rewrite? do
    Enum.filter(fields_to_rewrite, &(&1 in field_set))
  end
```

`field_set` holds field structs: `%Ash.Resource.Attribute{}`, `%Ash.Query.Calculation{}`.
`fields_to_rewrite` holds names. 

Comparing them across types means the subtraction removes nothing, so `rewrite?` is always `true`, and the membership test never matches, so the list is always `[]`. The guarded body then splits each record's calculations on `[]`:

```elixir
{merge, remain} = Map.split(record.calculations, fields_to_rewrite)
```

which moves nothing, leaving the calculated value in `:calculations` and the stored value on the
record.

Comparing by name makes the step do what its body implies. `rewrite?` is now usually `false`, so
the per-record mapping is skipped entirely rather than run as a no-op.

# Commits

1. `test:` pin that a calculation naming no field of the resource stays in `:calculations`. Pass as is.
2. `fix:` compare by name, and assert a shadowing calculation reaches the record.
