### PR TITLE
fix: decide an ETS aggregate is empty after rejecting nil values

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1027,22 +1027,25 @@ defmodule Ash.DataLayer.Ets do
         end
 
       kind when kind in [:sum, :max, :min] ->
-        records
-        |> Enum.map(&field_value(&1, field))
-        |> case do
+        values = Stream.map(records, &field_value(&1, field))
+
+        items =
+          if uniq? do
+            values |> Stream.uniq() |> Stream.reject(&is_nil/1)
+          else
+            values |> Stream.reject(&is_nil/1)
+          end
+
+        # Whether there is anything to aggregate has to be decided after the
+        # `nil`s are rejected, not before. Records that all hold `nil` leave
+        # nothing to fold, exactly as no records at all do, and both should
+        # give the aggregate's default rather than one giving `Enum.sum([])`
+        # and the other raising out of `Enum.max/2`.
+        case Enum.take(items, 1) do
           [] ->
             nil
 
-          items ->
-            items =
-              if uniq? do
-                items |> Stream.uniq() |> Stream.reject(&is_nil/1)
-              else
-                items |> Stream.reject(&is_nil/1)
-              end
-
-            first_item = List.first(Enum.to_list(Stream.take(items, 1)))
-
+          [first_item] ->
             case kind do
               :sum ->
                 if is_struct(first_item, Decimal) do

--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -303,6 +303,20 @@ defmodule Ash.Test.Actions.AggregateTest do
       assert %{count: 2} = Ash.aggregate!(Post, {:count, :count}, authorize?: false)
     end
 
+    test "min, max and sum over no records at all return the default" do
+      mine = Ash.Query.filter(Comment, thing == "no-such-comment")
+
+      for kind <- [:min, :max, :sum] do
+        assert %{v: nil} =
+                 Ash.aggregate!(mine, {:v, kind, field: :thing3}, authorize?: false)
+
+        assert %{v: :none} =
+                 Ash.aggregate!(mine, {:v, kind, field: :thing3, default: :none},
+                   authorize?: false
+                 )
+      end
+    end
+
     test "a datetime field sorts and firsts by chronology" do
       # Erlang term order compares a struct's fields in alphabetical key order,
       # so for a DateTime :day (31 vs 1) decides before :year is ever reached.

--- a/test/actions/aggregate_test.exs
+++ b/test/actions/aggregate_test.exs
@@ -317,6 +317,26 @@ defmodule Ash.Test.Actions.AggregateTest do
       end
     end
 
+    test "min, max and sum over records whose values are all nil return the default" do
+      for _ <- 1..2 do
+        Comment
+        |> Ash.Changeset.for_create(:create, %{public: true, thing: "all-nil", thing3: nil})
+        |> Ash.create!(authorize?: false)
+      end
+
+      mine = Ash.Query.filter(Comment, thing == "all-nil")
+
+      for kind <- [:min, :max, :sum] do
+        assert %{v: nil} =
+                 Ash.aggregate!(mine, {:v, kind, field: :thing3}, authorize?: false)
+
+        assert %{v: :none} =
+                 Ash.aggregate!(mine, {:v, kind, field: :thing3, default: :none},
+                   authorize?: false
+                 )
+      end
+    end
+
     test "a datetime field sorts and firsts by chronology" do
       # Erlang term order compares a struct's fields in alphabetical key order,
       # so for a DateTime :day (31 vs 1) decides before :year is ever reached.


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2831. Fixes #2832.

Two reported symptoms, one cause, so they are fixed together rather than in two passes over the
same expression.

When at least one record matched but every matched value was `nil`:

| aggregate | before | after |
| --- | --- | --- |
| `min` | `** (Enum.EmptyError)` | `nil` |
| `max` | `** (Enum.EmptyError)` | `nil` |
| `sum` | `0` | `nil` |

With no records matched at all, all three already answered `nil`, so Ets disagreed with itself
depending on where the emptiness came from. `AshPostgres` answers `nil` in both cases. 

# Cause

`aggregate_value/6` in `lib/ash/data_layer/ets/ets.ex` asked whether there was anything to
aggregate *before* rejecting `nil` values:

```elixir
records
|> Enum.map(&field_value(&1, field))
|> case do
  [] ->
    nil                                        # guards "no records"

  items ->
    items = items |> Stream.reject(&is_nil/1)  # can empty it again, unguarded
    ...
    :max -> Enum.max(items, Comp)              # Enum.EmptyError
    :sum -> Enum.sum(items)                    # 0
```

Records that all hold `nil` map to `[nil, nil]`, which is not `[]`, so they pass the guard . Rejection then empties the stream underneath the fold.

Both outcomes also bypass the aggregate's `default:`, which is only consulted at the end of the
function and is reached neither by a raise nor by a returned `0`.

The fix rejects the `nil`s first and decides emptiness on what is left, which is the question the
guard was asking:

```elixir
items = ... |> Stream.reject(&is_nil/1)

case Enum.take(items, 1) do
  [] -> nil
  [first_item] -> ...
end
```

`Enum.take(items, 1)` keeps the stream lazy and supplies `first_item` in the same pass, as the
previous code already did.

`avg`, `count`, `first` and `list` were unaffected.

# A behaviour change worth calling out

`sum` over a field where every matched value is `nil` now answers `nil` rather than `0`. Anyone
relying on the `0` would see `nil`. It is what this same aggregate already returns when no records
match, and what `AshPostgres` returns for the same query, but it is a change for ETS datalayer users.

# Commits

1. `test:` pin what `min`, `max` and `sum` return when no records match at all, with and without
   an explicit `default: Passes as is.
2. `fix:` decide emptiness after rejecting `nil`s, and assert the all-`nil` case now matches.