### PR TITLE
fix: report the primary key in the combination fieldset

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -4600,7 +4600,8 @@ defmodule Ash.Query do
                  combination_of_queries?: true,
                  combination_fieldset:
                    Enum.uniq(
-                     (combination.select || default_select) ++ Map.keys(combination.calculations)
+                     selected_fields(ash_query.resource, combination.select || default_select) ++
+                       Map.keys(combination.calculations)
                    )
                }}
             end
@@ -4613,6 +4614,16 @@ defmodule Ash.Query do
         {:ok, opts[:initial_query] || Ash.DataLayer.resource_to_query(ash_query.resource, domain),
          %{}}
     end
+  end
+
+  # The fieldset must describe what each combination query selects, and `select/3`
+  # decides that — it always adds the primary key and any always-selected
+  # attributes to whatever was asked for.
+  defp selected_fields(resource, select) do
+    resource
+    |> new()
+    |> select(select, replace?: true)
+    |> Map.fetch!(:select)
   end
 
   defp combination_queries(query) do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -185,6 +185,25 @@ defmodule Ash.Test.QueryTest do
                |> Ash.read!()
     end
 
+    test "a union of parts that select only a shared field still returns both records" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+      Ash.create!(User, %{name: "fred", email: "b@bar.com"})
+
+      assert [_, _] =
+               User
+               |> Ash.Query.combination_of([
+                 Ash.Query.Combination.base(
+                   filter: expr(email == "a@bar.com"),
+                   select: [:name]
+                 ),
+                 Ash.Query.Combination.union(
+                   filter: expr(email == "b@bar.com"),
+                   select: [:name]
+                 )
+               ])
+               |> Ash.read!()
+    end
+
     test "a combination calculation naming no resource field stays in :calculations" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -204,6 +204,22 @@ defmodule Ash.Test.QueryTest do
                |> Ash.read!()
     end
 
+    test "the combination fieldset reports the primary key even when the parts do not select it" do
+      {:ok, query} =
+        User
+        |> Ash.Query.combination_of([
+          Ash.Query.Combination.base(filter: expr(name == "fred"), select: [:name]),
+          Ash.Query.Combination.union(filter: expr(name == "alice"), select: [:name])
+        ])
+        |> Ash.Query.data_layer_query()
+
+      fieldset = query.context[:data_layer][:combination_fieldset]
+
+      for field <- Ash.Resource.Info.primary_key(User) do
+        assert field in fieldset
+      end
+    end
+
     test "a combination calculation naming no resource field stays in :calculations" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Closes #2835

# Summary

Reworked based on guidance from review of #2835

Now the primary key is always selected, so the fix is to make the combination fieldset say so. 

# Cause

`select/3` already adds the primary key and the always-selected attributes to every select
(`lib/ash/query/query.ex:1702-1705`), and each combination part is built through it. But the
fieldset was built from the raw `select:` on the combination, not from the query `select/3`
produced, so it under-reported what the parts select. For a part with `select: [:region]`:

| | |
| --- | --- |
| raw `combination.select` | `[:region]` |
| what `select/3` makes of it | `[:id, :region]` |
| `combination_fieldset` | `[:region]` |

# The change

Derive the fieldset through `select/3`, so it cannot disagree with the queries that function
builds. Always-selected attributes are now reported too, for the same reason.

Nothing in a data layer changes. `Ash.DataLayer.Ets` keys its dedupe off the built query's select
rather than the fieldset, which is why it kept records distinct already.

# Commits
1. `test:` pin that a union of narrowly selected parts keeps records distinct Passes as is.
2. `fix:` derive the fieldset through `select/3`, and assert the primary key is in it.