### PR TITLE
fix: resolve a combinations reference in the outer filter

### DIFF
--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -540,7 +540,31 @@ defmodule Ash.Query do
   def combination_of(query, combinations) do
     query = new(query)
 
-    %{query | combination_of: query.combination_of ++ List.wrap(combinations)}
+    query = %{query | combination_of: query.combination_of ++ List.wrap(combinations)}
+
+    # A `^combinations(...)` reference can only be hydrated once the
+    # combinations are known, so a filter built before this call still carries
+    # the bare field name. Hydrate it now that they are known — otherwise the
+    # reference stays unresolvable and every record is filtered out.
+    case query.filter do
+      nil ->
+        query
+
+      filter ->
+        case Ash.Filter.hydrate_refs(filter, combination_hydration_context(query)) do
+          {:ok, hydrated} -> %{query | filter: hydrated}
+          {:error, error} -> add_error(query, :filter, error)
+        end
+    end
+  end
+
+  @doc false
+  def combination_hydration_context(query) do
+    %{
+      resource: query.resource,
+      public?: false,
+      first_combination: Enum.at(query.combination_of, 0)
+    }
   end
 
   @doc """
@@ -3971,7 +3995,8 @@ defmodule Ash.Query do
                  filter,
                  %{
                    resource: query.resource,
-                   public?: false
+                   public?: false,
+                   first_combination: Enum.at(query.combination_of, 0)
                  }
                  |> with_parent_stack(opts)
                  |> with_conflicting_upsert_values(opts)
@@ -4027,7 +4052,8 @@ defmodule Ash.Query do
                  filter,
                  %{
                    resource: query.resource,
-                   public?: false
+                   public?: false,
+                   first_combination: Enum.at(query.combination_of, 0)
                  }
                  |> with_parent_stack(opts)
                  |> with_conflicting_upsert_values(opts)

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -215,6 +215,29 @@ defmodule Ash.Test.QueryTest do
       refute Map.has_key?(calculations, :name)
     end
 
+    test "a combination calculation can be sorted on from the outer query" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+      Ash.create!(User, %{name: "alice", email: "a@baz.com"})
+
+      ranked = [
+        Ash.Query.Combination.base(
+          filter: expr(name == "fred"),
+          calculations: %{sort_order: calc(1, type: :integer)}
+        ),
+        Ash.Query.Combination.union(
+          filter: expr(name == "alice"),
+          calculations: %{sort_order: calc(2, type: :integer)}
+        )
+      ]
+
+      assert [2, 1] =
+               User
+               |> Ash.Query.combination_of(ranked)
+               |> Ash.Query.sort([{calc(^combinations(:sort_order)), :desc}])
+               |> Ash.read!()
+               |> Enum.map(& &1.calculations[:sort_order])
+    end
+
     test "it handles combinations with intersect" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
       Ash.create!(User, %{name: "john", email: "j@bar.com"})

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -238,6 +238,47 @@ defmodule Ash.Test.QueryTest do
                |> Enum.map(& &1.calculations[:sort_order])
     end
 
+    test "a combination calculation can be filtered on from the outer query" do
+      Ash.create!(User, %{name: "fred", email: "a@bar.com"})
+      Ash.create!(User, %{name: "alice", email: "a@baz.com"})
+
+      ranked = [
+        Ash.Query.Combination.base(
+          filter: expr(name == "fred"),
+          calculations: %{sort_order: calc(1, type: :integer)}
+        ),
+        Ash.Query.Combination.union(
+          filter: expr(name == "alice"),
+          calculations: %{sort_order: calc(2, type: :integer)}
+        )
+      ]
+
+      # a predicate that excludes nothing must not exclude everything
+      assert [1, 2] =
+               User
+               |> Ash.Query.combination_of(ranked)
+               |> Ash.Query.filter(^combinations(:sort_order) > 0)
+               |> Ash.read!()
+               |> Enum.map(& &1.calculations[:sort_order])
+               |> Enum.sort()
+
+      # and one that discriminates must discriminate
+      assert [%User{name: "alice"}] =
+               User
+               |> Ash.Query.combination_of(ranked)
+               |> Ash.Query.filter(^combinations(:sort_order) == 2)
+               |> Ash.read!()
+
+      # the reference resolves whichever order the query is built in
+      assert [1, 2] =
+               User
+               |> Ash.Query.filter(^combinations(:sort_order) > 0)
+               |> Ash.Query.combination_of(ranked)
+               |> Ash.read!()
+               |> Enum.map(& &1.calculations[:sort_order])
+               |> Enum.sort()
+    end
+
     test "it handles combinations with intersect" do
       Ash.create!(User, %{name: "fred", email: "a@bar.com"})
       Ash.create!(User, %{name: "john", email: "j@bar.com"})


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2837.

`^combinations(:field)` resolved in an outer sort but matched nothing in an outer filter:

```
unfiltered                             [{"alpha", 1}, {"gamma", 2}]
filter combinations(:sort_order) > 0   []      every record qualifies
filter combinations(:sort_order) == 2  []      gamma expected
sort   combinations(:sort_order) desc  [{"gamma", 2}, {"alpha", 1}]
```

# Cause

`Ash.Filter.do_hydrate_refs/2` turns the bare field name into an `Ash.Query.CombinationAttr`, but
only when the context carries `first_combination`:

```elixir
def do_hydrate_refs(%Ref{combinations?: true, attribute: attribute} = ref,
      %{resource: resource, first_combination: first_combination})
    when is_atom(attribute) and not is_nil(first_combination) do
  # → %CombinationAttr{}
end

def do_hydrate_refs(%Ref{combinations?: true} = ref, _) do
  {:ok, ref}          # ← falls through, attribute still an atom
end
```

Both clauses of `Ash.Filter.Runtime.resolve_ref/5` that handle combination references require the
hydrated struct, so an unhydrated one resolves to `:unknown` and every record is dropped. The sort
path supplies `first_combination`; the filter path did not.

# The change

Supply it in both `do_filter/3` clauses.

That covers a filter added *after* the combinations. One added *before* them cannot be hydrated
when it is built  since there is nothing to resolve it agains, so we must rehydrate existing filter using `combination_of/2` . Both cases are fixed and both are covered by tests; fixing
only the first would have left the other silently returning nothing.

Sorting is untouched as it already supplied the context, and the `test:` commit pins it.

Note this is in `lib/ash/query/query.ex` rather than a data layer, so it applies to any data layer
that resolves combination references at runtime, such as ETS.

# Commits

1. `test:` pin that a combination calculation is usable from the outer query, via the sort path
   that already works. Passes as-is.
2. `fix:` supply `first_combination` when hydrating the filter, rehydrate on `combination_of/2`,
   and assert both orders plus a discriminating predicate.