### PR TITLE
fix: dispatch on whether a comparator is implemented

### DIFF
--- a/lib/comparable/comp.ex
+++ b/lib/comparable/comp.ex
@@ -320,13 +320,22 @@ if !Code.ensure_loaded?(Comp) do
         try do
           [Comparable, Type, type_of(left), To, type_of(right)]
           |> Module.safe_concat()
+          |> fall_back_unless_implemented()
         rescue
           ArgumentError ->
-            [Comparable, Type, Any, To, Any]
-            |> Module.safe_concat()
+            any_to_any()
         end
 
       %{__struct__: lr_type, left: left, right: right}
+    end
+
+    defp fall_back_unless_implemented(lr_type) do
+      if Comparable.impl_for(%{__struct__: lr_type}), do: lr_type, else: any_to_any()
+    end
+
+    defp any_to_any do
+      [Comparable, Type, Any, To, Any]
+      |> Module.safe_concat()
     end
   end
 end

--- a/test/comparable/comp_test.exs
+++ b/test/comparable/comp_test.exs
@@ -2,16 +2,22 @@
 #
 # SPDX-License-Identifier: MIT
 
+defmodule CompTest.Uncomparable do
+  @moduledoc false
+  defstruct [:value]
+end
+
 defmodule CompTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
+  alias CompTest.Uncomparable
+
   describe "dispatch" do
+    # Every pair here answers differently under generic term order, which is
+    # case-sensitive, orders a struct before a binary, and orders `Decimal` by
+    # its fields rather than its value.
     test "a pair with its own comparator reaches that comparator" do
-      # Both of these are answered by a `defcomparable` for the pair, and both
-      # would answer differently under the generic fallback: Erlang term order
-      # is case-sensitive and orders any struct after any binary, and orders
-      # `Decimal` structs by their fields rather than by their value.
       assert Comp.compare(Ash.CiString.new("Hello"), "hello") == :eq
       assert Comp.compare("hello", Ash.CiString.new("Hello")) == :eq
       assert Comp.compare(Decimal.new("1.0"), 1) == :eq
@@ -20,6 +26,14 @@ defmodule CompTest do
 
     test "a pair with no comparator falls back to generic term order" do
       assert Comp.compare(Ash.CiString.new("a"), Decimal.new(1)) == :lt
+    end
+
+    test "a pair falls back whether or not its module name has been named elsewhere" do
+      assert Comp.compare(%Uncomparable{value: 1}, %Uncomparable{value: 2}) == :lt
+
+      Module.concat([Comparable, Type, Uncomparable, To, Uncomparable])
+
+      assert Comp.compare(%Uncomparable{value: 1}, %Uncomparable{value: 2}) == :lt
     end
   end
 end

--- a/test/comparable/comp_test.exs
+++ b/test/comparable/comp_test.exs
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule CompTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  describe "dispatch" do
+    test "a pair with its own comparator reaches that comparator" do
+      # Both of these are answered by a `defcomparable` for the pair, and both
+      # would answer differently under the generic fallback: Erlang term order
+      # is case-sensitive and orders any struct after any binary, and orders
+      # `Decimal` structs by their fields rather than by their value.
+      assert Comp.compare(Ash.CiString.new("Hello"), "hello") == :eq
+      assert Comp.compare("hello", Ash.CiString.new("Hello")) == :eq
+      assert Comp.compare(Decimal.new("1.0"), 1) == :eq
+      assert Comp.compare(Decimal.new("1.0"), Decimal.new("1")) == :eq
+    end
+
+    test "a pair with no comparator falls back to generic term order" do
+      assert Comp.compare(Ash.CiString.new("a"), Decimal.new(1)) == :lt
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2839 