### PR TITLE
fix(ci): pass `--all` to `mix igniter.upgrade` so the job stops failing

### DIFF
--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -657,7 +657,7 @@ jobs:
           OBAN_PRO_LICENSE_KEY: ${{ secrets.OBAN_PRO_LICENSE_KEY }}
       - uses: team-alembic/staple-actions/actions/mix-task@325af91762b51931c459503300c22c057251b3cf # main
         with:
-          task: igniter.upgrade --git-ci --yes
+          task: igniter.upgrade --git-ci --yes --all
         if: github.event.pull_request.user.login == 'dependabot[bot]'
       - name: Commit Changes
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0


### PR DESCRIPTION
The shared `mix igniter.upgrade` job fails on every dependabot PR across the
ecosystem:

```
##[group]Run mix igniter.upgrade --git-ci --yes
Must specify at least one package to upgrade or use --all to upgrade all packages.
##[error]Process completed with exit code 1.
```

The job passes neither package names nor `--all`, so `mix igniter.upgrade`
rejects the invocation before doing any work. Confirmed identical in `ash`,
`ash_postgres`, `ash_phoenix`, `ash_graphql` and `ash_ai` — anything using this
workflow.

It broke in ff418c2fe ("ci: setup action properly for igniter.upgrade"), which
converted the step from a `run:` to the `staple-actions/mix-task` action and
dropped the argument along the way:

```diff
-        run: mix igniter.upgrade ${{steps.dependabot-metadata.outputs.dependency-names}} --git-ci
+          task: igniter.upgrade --git-ci
```

Nothing surfaced it because the step only runs for dependabot PRs. On tag pushes
it's skipped, and `build-release`/`hex_publish` gate on `!failure()`, which
treats skipped as fine — so releases were never blocked and the failure just sat
on dependabot PRs as a red X.

`--all` is the right argument rather than restoring `dependency-names`: under
`--git-ci` the upgrade set is derived entirely from diffing `HEAD~1:mix.lock`
against the loaded deps, and the dependency fetch is skipped, so `--all` only
satisfies the argument check. It doesn't widen what gets upgraded or touch
`mix.lock`.

Verified end-to-end in a scratch project with a simulated dependabot lock bump:
`--git-ci --yes` exits 1 with the error above, `--git-ci --yes --all` exits 0 and
reports `jason 1.4.4 => 1.4.5` with `mix.lock` unmodified.

Igniter shouldn't have demanded the argument in the first place, since it never
reads it on the `--git-ci` path — ash-project/igniter#397 fixes that end. This
change is worth landing regardless: it's a one-liner, it works against released
igniter, and it unblocks dependabot PRs now instead of after an igniter release.
