### PR TITLE
fix: resolve bulk index from changeset in after_batch filter

### DIFF
--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -3363,7 +3363,8 @@ defmodule Ash.Actions.Update.Bulk do
           {matches, non_matches} =
             results
             |> Enum.split_with(fn
-              {:ok, result, _changeset} ->
+              {:ok, result, changeset} ->
+                result = Ash.Actions.Helpers.Bulk.put_metadata(result, changeset)
                 result.__metadata__[metadata_key] in List.wrap(changes[index])
             end)
 

--- a/test/actions/bulk/bulk_create_test.exs
+++ b/test/actions/bulk/bulk_create_test.exs
@@ -2251,6 +2251,92 @@ defmodule Ash.Test.Actions.BulkCreateTest do
     end
   end
 
+  describe "data layer that stamps only :bulk_action_ref" do
+    # Mirrors AshPostgres: since #2411 a data layer identifies returned records with
+    # `:bulk_action_ref`, and is not required to stamp the legacy `:bulk_create_index`.
+    # Core re-stamps the index later, in `process_results`.
+    defmodule RefOnlyDataLayer do
+      use Spark.Dsl.Extension, sections: []
+
+      @behaviour Ash.DataLayer
+
+      @impl true
+      def can?(_, :create), do: true
+      def can?(_, :bulk_create), do: true
+      def can?(_, :read), do: true
+      def can?(_, _), do: false
+
+      @impl true
+      def resource_to_query(_resource, _domain), do: %{}
+
+      @impl true
+      def run_query(_query, _resource), do: {:ok, []}
+
+      @impl true
+      def create(_resource, changeset) do
+        {:ok, struct(changeset.resource, changeset.attributes)}
+      end
+
+      @impl true
+      def bulk_create(resource, changesets, _opts) do
+        records =
+          Enum.map(changesets, fn changeset ->
+            resource
+            |> struct(changeset.attributes)
+            |> Ash.Resource.put_metadata(:bulk_action_ref, changeset.context.bulk_create.ref)
+          end)
+
+        {:ok, records}
+      end
+    end
+
+    defmodule RefOnlyPost do
+      use Ash.Resource, data_layer: RefOnlyDataLayer, domain: Ash.Test.Domain
+
+      attributes do
+        uuid_primary_key :id
+        attribute :title, :string, allow_nil?: false, public?: true
+      end
+
+      actions do
+        default_accept :*
+        defaults [:create]
+
+        create :create_only_when_valid do
+          change AddAfterToTitle, only_when_valid?: true
+        end
+
+        create :create_where_title_is_keep do
+          change AddAfterToTitle, where: [attribute_equals(:title, "keep")]
+        end
+      end
+    end
+
+    test "after_batch receives every record for an only_when_valid? change" do
+      assert %Ash.BulkResult{records: [%{title: "title1_after"}, %{title: "title2_after"}]} =
+               Ash.bulk_create!(
+                 [%{title: "title1"}, %{title: "title2"}],
+                 RefOnlyPost,
+                 :create_only_when_valid,
+                 return_records?: true,
+                 sorted?: true,
+                 authorize?: false
+               )
+    end
+
+    test "after_batch receives exactly the records a where clause matches" do
+      assert %Ash.BulkResult{records: [%{title: "keep_after"}, %{title: "skip"}]} =
+               Ash.bulk_create!(
+                 [%{title: "keep"}, %{title: "skip"}],
+                 RefOnlyPost,
+                 :create_where_title_is_keep,
+                 return_records?: true,
+                 sorted?: true,
+                 authorize?: false
+               )
+    end
+  end
+
   describe "data layer partial_success" do
     defmodule PartialSuccessDataLayer do
       use Spark.Dsl.Extension, sections: []


### PR DESCRIPTION
If you have a change with batch_change/3 and after_batch/3 on it, and you register it with only_when_valid?: true (or a where), then after_batch/3 gets called with an empty list on Ash.bulk_create/4.

batch_change/3 gets everything fine. It's only after_batch that comes up empty.

Nothing errors either, so if that hook was writing an audit log or kicking off events, you just don't get them and never find out.

The filter deciding which records go to after_batch looks at:


result.__metadata__[:bulk_create_index]
AshPostgres doesn't put that on records. It puts :bulk_action_ref, which is what #2411 made the right thing to set.

So that lookup is nil for every record, and nothing matches.

The changeset is already sitting there in the filter unused, and it has the index on it. So I just took it from there.


The regression test adds a data layer that stamps :bulk_action_ref and not :bulk_create_index — exactly what AshPostgres does — and asserts after_batch still gets its records, and gets only the ones a where matches.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
