### PR TITLE
fix: accept a Duration in from_now/1

### DIFF
--- a/documentation/topics/reference/expressions.md
+++ b/documentation/topics/reference/expressions.md
@@ -121,10 +121,10 @@ For elixir-backed data layers, they will be a function or an MFA that will be ca
 
 - `now/0` | Evaluates to the current time when the expression is evaluated
 - `today/0` | Evaluates to the current date when the expression is evaluated
-- `ago/2` | i.e `deleted_at > ago(7, :day)`. The available time intervals are documented in `Ash.Type.DurationName`
-- `from_now/2` | Same as `ago` but adds instead of subtracting
-- `datetime_add/3` | add an interval to a datetime, i.e `datetime_add(^datetime, 10, :hour)`
-- `date_add/3` | add an interval to a date, i.e `date_add(^date, 3, :day)`
+- `ago/1-2` | i.e `deleted_at > ago(7, :day)`, or a `Duration`: `deleted_at > ago(^Duration.new!(day: 7))`. The available time intervals are documented in `Ash.Type.DurationName`
+- `from_now/1-2` | Same as `ago` but adds instead of subtracting
+- `datetime_add/2-3` | add an interval to a datetime, i.e `datetime_add(^datetime, 10, :hour)`, or a `Duration`: `datetime_add(^datetime, ^Duration.new!(hour: 10))`
+- `date_add/2-3` | add an interval to a date, i.e `date_add(^date, 3, :day)`, or a `Duration`: `date_add(^date, ^Duration.new!(day: 3))`
 - `start_of_day/1-2` | Converts a date or a datetime to the correspond start of its day (at 00:00 time).
 
 ## Primitives

--- a/lib/ash/query/function/from_now.ex
+++ b/lib/ash/query/function/from_now.ex
@@ -15,7 +15,7 @@ defmodule Ash.Query.Function.FromNow do
 
   use Ash.Query.Function, name: :from_now, eager_evaluate?: false
 
-  def args, do: [[:integer, :duration_name]]
+  def args, do: [[:integer, :duration_name], [:duration]]
 
   def returns, do: [:utc_datetime]
 

--- a/test/query/function/from_now_test.exs
+++ b/test/query/function/from_now_test.exs
@@ -5,6 +5,8 @@
 defmodule Ash.Query.Function.FromNowTest do
   use ExUnit.Case, async: true
 
+  require Ash.Expr
+
   alias Ash.Query.Function.FromNow
 
   describe "from now query function" do
@@ -19,6 +21,17 @@ defmodule Ash.Query.Function.FromNowTest do
 
       assert {:known, %DateTime{} = datetime} =
                FromNow.evaluate(%{arguments: [Duration.new!(year: 1)]})
+
+      assert datetime.year == today.year + 1
+    end
+
+    # `evaluate/1` is reached only if `args/0` declares the form, so calling it
+    # directly does not show whether the function is callable in an expression.
+    test "a duration is callable as an expression" do
+      today = Date.utc_today()
+
+      assert {:ok, %DateTime{} = datetime} =
+               Ash.Expr.eval(Ash.Expr.expr(from_now(^Duration.new!(year: 1))))
 
       assert datetime.year == today.year + 1
     end


### PR DESCRIPTION
Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2843 

`from_now`'s Function'`args/0` gains the `Duration` form, matching `ago`

`ago`, `date_add` and `datetime_add` all declare their Duration form. This brings `from_now` into line.

Added a test that goes through the expression path.

Documented missing Duration forms in the expressions guide.