### PR TITLE
fix: don't raise when an operator on two literals yields a struct

### DIFF
--- a/lib/ash/filter/filter.ex
+++ b/lib/ash/filter/filter.ex
@@ -4086,10 +4086,13 @@ defmodule Ash.Filter do
     end
   end
 
-  defp maybe_operator_expression(operator, context) when is_struct(operator) do
+  # Over two literals the operator is evaluated on construction, so the result arrives here.
+  defp maybe_operator_expression(
+         %{__operator__?: true, left: left, right: right} = operator,
+         context
+       ) do
     case Ash.Query.Operator.operator_expression(operator) do
       {:ok, expr_module} ->
-        %{left: left, right: right} = operator
         arguments = [left, right]
         resource = context[:resource]
 

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -162,6 +162,36 @@ defmodule Ash.Test.ExprTest do
     end
   end
 
+  describe "operators over two literals" do
+    test "a result that is not a struct" do
+      assert eval!(expr(^1 + ^2)) == 3
+    end
+
+    test "a decimal result" do
+      assert eval!(expr(^Decimal.new(1) + ^Decimal.new(2))) == Decimal.new(3)
+    end
+
+    test "a datetime result" do
+      now = DateTime.utc_now()
+      duration = Duration.new!(day: 7)
+
+      assert eval!(expr(^now + ^duration)) == DateTime.shift(now, duration)
+    end
+
+    test "a date result" do
+      today = Date.utc_today()
+      duration = Duration.new!(day: 7)
+
+      assert eval!(expr(^today + ^duration)) == Date.shift(today, duration)
+    end
+
+    test "a duration result" do
+      duration = Duration.new!(day: 7)
+
+      assert eval!(expr(^duration + ^duration)) == Duration.add(duration, duration)
+    end
+  end
+
   describe "rem expressions" do
     test "evaluates" do
       expr = expr(rem(1, 2) == 0)


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2846 

Added tests and fixed guard.

When both operands are literals the operator is evaluated on construction, so what reaches `maybe_operator_expression/2` is the result. `is_struct/1` can't tell that from an operator, so a struct result reached `find_overload/1`, which matches only `%mod{left: _, right: _}`.

Tightening the guard routes those to the existing `:unknown` fallback — the same path `^1 + ^2` already takes.

