### PR TITLE
fix: wrap the embedded duration dump in an ok tuple

### DIFF
--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -135,7 +135,7 @@ defmodule Ash.Type.Duration do
   def dump_to_embedded(nil, _), do: {:ok, nil}
 
   def dump_to_embedded(value, _) do
-    Duration.to_iso8601(value)
+    {:ok, Duration.to_iso8601(value)}
   end
 
   @impl true

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -107,6 +107,63 @@ defmodule Ash.Test.Type.DurationTest do
     end
   end
 
+  defmodule Embedded do
+    @moduledoc false
+    use Ash.Resource, data_layer: :embedded
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    attributes do
+      attribute :duration, :duration, public?: true
+    end
+  end
+
+  defmodule Holder do
+    @moduledoc false
+    use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    actions do
+      default_accept :*
+      defaults [:read, :destroy, create: :*, update: :*]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :embedded, Embedded, public?: true
+    end
+  end
+
+  describe "embedded resources" do
+    test "a duration is written and read back" do
+      duration = Duration.new!(week: 1)
+
+      holder =
+        Holder
+        |> Ash.Changeset.for_create(:create, %{embedded: %{duration: duration}})
+        |> Ash.create!()
+
+      assert holder.embedded.duration == duration
+
+      assert [%{embedded: %{duration: ^duration}}] = Ash.read!(Holder)
+    end
+
+    test "a nil duration is written and read back" do
+      holder =
+        Holder
+        |> Ash.Changeset.for_create(:create, %{embedded: %{duration: nil}})
+        |> Ash.create!()
+
+      assert holder.embedded.duration == nil
+    end
+  end
+
   describe "units constraint" do
     @calendar_free [:week, :day, :hour, :minute, :second, :microsecond]
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2848 

The roundtrip for embedded duration uses ISO8601 so roundtrips without loss, however it was missing the {:ok, ..} wrapper.