### PR TITLE
improvement: express a duration in the largest units it is permitted …

### DIFF
--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -11,7 +11,7 @@ defmodule Ash.Type.Duration do
     units: [
       type: {:or, [{:in, [:year_month, :day_time]}, {:list, {:in, @duration_units}}]},
       doc: """
-      The units the value may be expressed in. A duration is always re-expressed in the largest of these units that will hold it, on the way in and on the way out, so `[:week, :hour]` turns `1 week 1 day 5 hours` into `1 week 29 hours`. A value being written that no combination of the permitted units expresses exactly is rejected — including anything that would have to cross the year/month to week/day boundary, which no conversion can. A value being *read* is truncated to what the permitted units can say instead of being refused, so a store holding `1 day 5 hours 3 minutes` in a `[:day]` attribute reads back as `1 day`: lossy, but readable and writable again. Either an explicit list of units, or a shorthand for one side of that boundary: `:year_month` (`[:year, :month]`) or `:day_time` (`[:week, :day, :hour, :minute, :second, :microsecond]`). Confining an attribute to a single side keeps its values comparable (see `Ash.Type.Duration.compare/2`). With no constraint every unit is permitted, so the same normalization applies and nothing is ever lost.
+      The units the value may be expressed in. A duration is always re-expressed in the largest of these units that will hold it, on the way in and on the way out, so `[:week, :hour]` turns `1 week 1 day 5 hours` into `1 week 29 hours`. A value that no combination of the permitted units expresses exactly is rejected — including anything that would have to cross the year/month to week/day boundary, which no conversion can. This applies on the way out as well as in: a stored duration the permitted units cannot express is refused rather than quietly rewritten. Either an explicit list of units, or a shorthand for one side of that boundary: `:year_month` (`[:year, :month]`) or `:day_time` (`[:week, :day, :hour, :minute, :second, :microsecond]`). Confining an attribute to a single side keeps its values comparable (see `Ash.Type.Duration.compare/2`). With no constraint every unit is permitted, so the same normalization applies and nothing is ever lost.
       """
     ]
   ]
@@ -75,7 +75,7 @@ defmodule Ash.Type.Duration do
 
   def apply_constraints(%Duration{} = value, constraints) do
     allowed = permitted_units(constraints[:units])
-    normalized = normalize_units(value, allowed, :reject)
+    normalized = normalize_units(value, allowed)
 
     case disallowed_units(normalized, allowed) do
       [] ->
@@ -125,15 +125,17 @@ defmodule Ash.Type.Duration do
   @impl true
   def cast_stored(nil, _), do: {:ok, nil}
 
+  # A stored value gets the same treatment as one being written: a duration the
+  # permitted units cannot express is refused, not quietly rewritten into one they can.
   def cast_stored(value, constraints) when is_binary(value) do
     with {:ok, duration} <- cast_input(value, constraints) do
-      {:ok, normalize_units(duration, permitted_units(constraints[:units]), :truncate)}
+      apply_constraints(duration, constraints)
     end
   end
 
   def cast_stored(value, constraints) do
     with {:ok, duration} <- Ecto.Type.load(:duration, value) do
-      {:ok, normalize_units(duration, permitted_units(constraints[:units]), :truncate)}
+      apply_constraints(duration, constraints)
     end
   end
 
@@ -159,28 +161,25 @@ defmodule Ash.Type.Duration do
   @days_per_month 30
   @months_per_year 12
 
-  # One canonical form on both sides of storage, whatever units a data layer kept it
-  # in. A write (`:reject`) must not lose part of what was asked for; a read
-  # (`:truncate`) must answer with something the attribute can hold.
-  defp normalize_units(%Duration{} = duration, allowed, on_remainder) do
+  # One canonical form on both sides of storage, whatever units a data layer kept it in.
+  defp normalize_units(%Duration{} = duration, allowed) do
     duration
-    |> redistribute(@year_month_units, allowed, on_remainder, &total_months/1, &from_months/4)
+    |> redistribute(@year_month_units, allowed, &total_months/1, &from_months/3)
     |> redistribute(
       @day_time_units,
       allowed,
-      on_remainder,
       &total_microseconds_in_bucket/1,
-      &from_microseconds/4
+      &from_microseconds/3
     )
   end
 
   # Within a bucket only — months and microseconds are not interconvertible. A bucket
-  # with no permitted unit has nowhere to put its value, so it goes the way of any
-  # other remainder: refused on a write, dropped on a read.
-  defp redistribute(duration, bucket, allowed, on_remainder, total, build) do
+  # with no permitted unit has nowhere to put its value, so it is left for
+  # `apply_constraints/2` to report, like any other remainder.
+  defp redistribute(duration, bucket, allowed, total, build) do
     targets = Enum.filter(bucket, &(&1 in allowed))
 
-    case build.(total.(duration), targets, duration, on_remainder) do
+    case build.(total.(duration), targets, duration) do
       {:ok, normalized} -> normalized
       :inexact -> duration
     end
@@ -202,8 +201,8 @@ defmodule Ash.Type.Duration do
     (minutes * @seconds_per_minute + second) * @usec_per_second + microsecond
   end
 
-  defp from_months(total, targets, duration, on_remainder) do
-    with {:ok, assigned} <- assign(total, targets, &months_per_unit/1, on_remainder) do
+  defp from_months(total, targets, duration) do
+    with {:ok, assigned} <- assign(total, targets, &months_per_unit/1) do
       {:ok, struct!(duration, Map.merge(%{year: 0, month: 0}, assigned))}
     end
   end
@@ -211,10 +210,9 @@ defmodule Ash.Type.Duration do
   defp from_microseconds(
          total,
          targets,
-         %Duration{microsecond: {_, precision}} = duration,
-         on_remainder
+         %Duration{microsecond: {_, precision}} = duration
        ) do
-    with {:ok, assigned} <- assign(total, targets, &microseconds_per_unit/1, on_remainder) do
+    with {:ok, assigned} <- assign(total, targets, &microseconds_per_unit/1) do
       zeroed = %{week: 0, day: 0, hour: 0, minute: 0, second: 0}
 
       assigned =
@@ -228,7 +226,7 @@ defmodule Ash.Type.Duration do
   end
 
   # Largest permitted unit first, so the smallest permitted one carries the rest.
-  defp assign(total, targets, size, on_remainder) do
+  defp assign(total, targets, size) do
     {assigned, remainder} =
       targets
       |> Enum.sort_by(size, :desc)
@@ -237,7 +235,7 @@ defmodule Ash.Type.Duration do
         {{unit, div(left, per)}, rem(left, per)}
       end)
 
-    if remainder == 0 or on_remainder == :truncate do
+    if remainder == 0 do
       {:ok, Map.new(assigned)}
     else
       :inexact

--- a/lib/ash/type/duration.ex
+++ b/lib/ash/type/duration.ex
@@ -11,7 +11,7 @@ defmodule Ash.Type.Duration do
     units: [
       type: {:or, [{:in, [:year_month, :day_time]}, {:list, {:in, @duration_units}}]},
       doc: """
-      The units permitted to be non-zero; any unit outside the set must be zero, otherwise casting fails. Either an explicit list of units, or a shorthand for one side of the comparability boundary: `:year_month` (`[:year, :month]`) or `:day_time` (`[:week, :day, :hour, :minute, :second, :microsecond]`). Confining an attribute to a single side keeps its values comparable (see `Ash.Type.Duration.compare/2`).
+      The units the value may be expressed in. A duration is always re-expressed in the largest of these units that will hold it, on the way in and on the way out, so `[:week, :hour]` turns `1 week 1 day 5 hours` into `1 week 29 hours`. A value being written that no combination of the permitted units expresses exactly is rejected — including anything that would have to cross the year/month to week/day boundary, which no conversion can. A value being *read* is truncated to what the permitted units can say instead of being refused, so a store holding `1 day 5 hours 3 minutes` in a `[:day]` attribute reads back as `1 day`: lossy, but readable and writable again. Either an explicit list of units, or a shorthand for one side of that boundary: `:year_month` (`[:year, :month]`) or `:day_time` (`[:week, :day, :hour, :minute, :second, :microsecond]`). Confining an attribute to a single side keeps its values comparable (see `Ash.Type.Duration.compare/2`). With no constraint every unit is permitted, so the same normalization applies and nothing is ever lost.
       """
     ]
   ]
@@ -74,33 +74,35 @@ defmodule Ash.Type.Duration do
   def apply_constraints(nil, _), do: {:ok, nil}
 
   def apply_constraints(%Duration{} = value, constraints) do
-    case constraints[:units] do
-      nil ->
-        {:ok, value}
+    allowed = permitted_units(constraints[:units])
+    normalized = normalize_units(value, allowed, :reject)
 
-      units ->
-        allowed = expand_units(units)
+    case disallowed_units(normalized, allowed) do
+      [] ->
+        {:ok, normalized}
 
-        case Enum.reject(@duration_units, &(&1 in allowed or unit_zero?(value, &1))) do
-          [] ->
-            {:ok, value}
-
-          disallowed ->
-            {:error,
-             [
-               [
-                 message: "must only use the units %{units}",
-                 units: Enum.map_join(allowed, ", ", &to_string/1),
-                 disallowed: Enum.map_join(disallowed, ", ", &to_string/1)
-               ]
-             ]}
-        end
+      disallowed ->
+        {:error,
+         [
+           [
+             message: "must only use the units %{units}",
+             units: Enum.map_join(allowed, ", ", &to_string/1),
+             disallowed: Enum.map_join(disallowed, ", ", &to_string/1)
+           ]
+         ]}
     end
   end
+
+  # No `units` constraint permits every unit.
+  defp permitted_units(nil), do: @duration_units
+  defp permitted_units(units), do: expand_units(units)
 
   defp expand_units(:year_month), do: @year_month_units
   defp expand_units(:day_time), do: @day_time_units
   defp expand_units(units) when is_list(units), do: units
+
+  defp disallowed_units(%Duration{} = value, allowed),
+    do: Enum.reject(@duration_units, &(&1 in allowed or unit_zero?(value, &1)))
 
   defp unit_zero?(%Duration{microsecond: {value, _precision}}, :microsecond), do: value == 0
   defp unit_zero?(%Duration{} = duration, unit), do: Map.fetch!(duration, unit) == 0
@@ -124,11 +126,15 @@ defmodule Ash.Type.Duration do
   def cast_stored(nil, _), do: {:ok, nil}
 
   def cast_stored(value, constraints) when is_binary(value) do
-    cast_input(value, constraints)
+    with {:ok, duration} <- cast_input(value, constraints) do
+      {:ok, normalize_units(duration, permitted_units(constraints[:units]), :truncate)}
+    end
   end
 
-  def cast_stored(value, _) do
-    Ecto.Type.load(:duration, value)
+  def cast_stored(value, constraints) do
+    with {:ok, duration} <- Ecto.Type.load(:duration, value) do
+      {:ok, normalize_units(duration, permitted_units(constraints[:units]), :truncate)}
+    end
   end
 
   @impl true
@@ -152,6 +158,101 @@ defmodule Ash.Type.Duration do
   @days_per_week 7
   @days_per_month 30
   @months_per_year 12
+
+  # One canonical form on both sides of storage, whatever units a data layer kept it
+  # in. A write (`:reject`) must not lose part of what was asked for; a read
+  # (`:truncate`) must answer with something the attribute can hold.
+  defp normalize_units(%Duration{} = duration, allowed, on_remainder) do
+    duration
+    |> redistribute(@year_month_units, allowed, on_remainder, &total_months/1, &from_months/4)
+    |> redistribute(
+      @day_time_units,
+      allowed,
+      on_remainder,
+      &total_microseconds_in_bucket/1,
+      &from_microseconds/4
+    )
+  end
+
+  # Within a bucket only — months and microseconds are not interconvertible. A bucket
+  # with no permitted unit has nowhere to put its value, so it goes the way of any
+  # other remainder: refused on a write, dropped on a read.
+  defp redistribute(duration, bucket, allowed, on_remainder, total, build) do
+    targets = Enum.filter(bucket, &(&1 in allowed))
+
+    case build.(total.(duration), targets, duration, on_remainder) do
+      {:ok, normalized} -> normalized
+      :inexact -> duration
+    end
+  end
+
+  defp total_months(%Duration{year: year, month: month}),
+    do: year * @months_per_year + month
+
+  defp total_microseconds_in_bucket(%Duration{
+         week: week,
+         day: day,
+         hour: hour,
+         minute: minute,
+         second: second,
+         microsecond: {microsecond, _precision}
+       }) do
+    hours = (week * @days_per_week + day) * @hours_per_day + hour
+    minutes = hours * @minutes_per_hour + minute
+    (minutes * @seconds_per_minute + second) * @usec_per_second + microsecond
+  end
+
+  defp from_months(total, targets, duration, on_remainder) do
+    with {:ok, assigned} <- assign(total, targets, &months_per_unit/1, on_remainder) do
+      {:ok, struct!(duration, Map.merge(%{year: 0, month: 0}, assigned))}
+    end
+  end
+
+  defp from_microseconds(
+         total,
+         targets,
+         %Duration{microsecond: {_, precision}} = duration,
+         on_remainder
+       ) do
+    with {:ok, assigned} <- assign(total, targets, &microseconds_per_unit/1, on_remainder) do
+      zeroed = %{week: 0, day: 0, hour: 0, minute: 0, second: 0}
+
+      assigned =
+        case Map.pop(assigned, :microsecond) do
+          {nil, rest} -> Map.put(rest, :microsecond, {0, precision})
+          {value, rest} -> Map.put(rest, :microsecond, {value, precision})
+        end
+
+      {:ok, struct!(duration, Map.merge(zeroed, assigned))}
+    end
+  end
+
+  # Largest permitted unit first, so the smallest permitted one carries the rest.
+  defp assign(total, targets, size, on_remainder) do
+    {assigned, remainder} =
+      targets
+      |> Enum.sort_by(size, :desc)
+      |> Enum.map_reduce(total, fn unit, left ->
+        per = size.(unit)
+        {{unit, div(left, per)}, rem(left, per)}
+      end)
+
+    if remainder == 0 or on_remainder == :truncate do
+      {:ok, Map.new(assigned)}
+    else
+      :inexact
+    end
+  end
+
+  defp months_per_unit(:year), do: @months_per_year
+  defp months_per_unit(:month), do: 1
+
+  defp microseconds_per_unit(:week), do: @days_per_week * microseconds_per_unit(:day)
+  defp microseconds_per_unit(:day), do: @hours_per_day * microseconds_per_unit(:hour)
+  defp microseconds_per_unit(:hour), do: @minutes_per_hour * microseconds_per_unit(:minute)
+  defp microseconds_per_unit(:minute), do: @seconds_per_minute * @usec_per_second
+  defp microseconds_per_unit(:second), do: @usec_per_second
+  defp microseconds_per_unit(:microsecond), do: 1
 
   @doc """
   Compares two durations as a total order, matching how the AshPostgres data

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -537,6 +537,156 @@ defmodule Ash.Test.Type.DurationTest do
     end
   end
 
+  describe "normalization preserves what a duration means" do
+    # Elixir's own shift is the oracle here rather than compare/2: if normalizing
+    # changed a magnitude, the two would land on different instants.
+    test "a normalized duration shifts a datetime to the same instant" do
+      anchors = [~U[2024-01-01 00:00:00Z], ~U[2024-02-29 00:00:00Z], ~U[2025-03-01 00:00:00Z]]
+
+      inputs = [
+        Duration.new!(hour: 36),
+        Duration.new!(minute: 90),
+        Duration.new!(day: 365),
+        Duration.new!(month: 18),
+        Duration.new!(year: 1),
+        Duration.new!(year: 1, day: 5),
+        Duration.new!(week: 1, day: 1, hour: 5),
+        Duration.new!(second: 129_600),
+        Duration.new!(day: -10),
+        Duration.new!(month: -18),
+        Duration.new!(day: 1, hour: -5),
+        Duration.new!(year: 1, day: -5)
+      ]
+
+      for input <- inputs, anchor <- anchors do
+        assert {:ok, normalized} = Ash.Type.Duration.cast_stored(input, [])
+
+        assert DateTime.shift(anchor, input) == DateTime.shift(anchor, normalized),
+               "#{inspect(input)} normalized to #{inspect(normalized)}, " <>
+                 "which shifts #{anchor} differently"
+      end
+    end
+
+    test "a year still lands a year later, across a leap day" do
+      assert {:ok, normalized} = Ash.Type.Duration.cast_stored(Duration.new!(year: 1), [])
+
+      assert Date.shift(~D[2024-02-29], normalized) ==
+               Date.shift(~D[2024-02-29], Duration.new!(year: 1))
+
+      assert Date.shift(~D[2024-02-29], normalized) == ~D[2025-02-28]
+    end
+
+    test "365 days is not a year, before or after normalizing" do
+      assert {:ok, normalized} = Ash.Type.Duration.cast_stored(Duration.new!(day: 365), [])
+
+      # 2024 is a leap year, so 365 days from its start is a day short of a year
+      assert Date.shift(~D[2024-01-01], normalized) == ~D[2024-12-31]
+
+      refute Date.shift(~D[2024-01-01], normalized) ==
+               Date.shift(~D[2024-01-01], Duration.new!(year: 1))
+    end
+  end
+
+  describe "negative durations" do
+    test "a negative duration normalizes with a consistent sign" do
+      assert {:ok, Duration.new!(week: -1, day: -3)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: -10), [])
+
+      assert {:ok, Duration.new!(year: -1, month: -6)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(month: -18), [])
+    end
+
+    test "mixed signs within a side collapse to one representation" do
+      # a day less five hours is nineteen hours
+      assert {:ok, Duration.new!(hour: 19)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 1, hour: -5), [])
+
+      assert {:ok, Duration.new!(week: -1, day: -4)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(week: -2, day: 3), [])
+    end
+
+    test "the net sign wins, even against the largest unit" do
+      # a week less ten days is three days short, not a week and a bit
+      assert {:ok, Duration.new!(day: -3)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(week: 1, day: -10), [])
+
+      assert {:ok, Duration.new!(hour: 6)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: -1, hour: 30), [])
+
+      assert {:ok, Duration.new!(month: -6)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1, month: -18), [])
+    end
+
+    test "the two sides keep their own signs, independently" do
+      assert {:ok, Duration.new!(year: 1, day: -5)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1, day: -5), [])
+
+      # one side positive, the other negative, each normalized on its own
+      assert {:ok, Duration.new!(year: 1, week: -57, day: -1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1, day: -400), [])
+    end
+
+    test "a duration that nets to zero normalizes to zero" do
+      assert {:ok, zero} = Ash.Type.Duration.cast_stored(Duration.new!(day: 1, hour: -24), [])
+      assert Ash.Type.Duration.compare(zero, Duration.new!([])) == :eq
+    end
+
+    test "a negative microsecond borrows from seconds" do
+      assert {:ok, %Duration{second: -1, microsecond: {-500_000, 6}}} =
+               Ash.Type.Duration.cast_stored(Duration.new!(microsecond: {-1_500_000, 6}), [])
+    end
+  end
+
+  describe "the year/month to week/day divide" do
+    test "a year is never expressed in days, whatever units are permitted" do
+      assert {:ok, Duration.new!(year: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1), [])
+
+      assert {:ok, Duration.new!(year: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1), units: :year_month)
+    end
+
+    test "days are never expressed in years, whatever units are permitted" do
+      # 365 days is 52 weeks and a day, not a year — the divide holds even though
+      # :year is permitted here
+      assert {:ok, Duration.new!(week: 52, day: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 365), [])
+    end
+
+    test "the two sides normalize independently, keeping both" do
+      assert {:ok, Duration.new!(year: 1, day: 5)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1, day: 5), [])
+    end
+
+    test "a read across the divide loses the side it cannot speak for" do
+      # [:day] can say nothing about years, so a stored year has nowhere to go
+      assert {:ok, Duration.new!([])} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1), units: [:day])
+    end
+
+    test "a write across the divide is refused rather than lost" do
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(year: 1), units: [:day])
+    end
+
+    test "within a side, a remainder truncates on read and refuses on write" do
+      assert {:ok, Duration.new!(week: 52)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 365), units: [:week])
+
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(day: 365), units: [:week])
+    end
+
+    test "comparison still crosses the divide, by the documented convention" do
+      # compare/2 is unchanged: it converts a month to 30 days so durations stay
+      # totally ordered. Normalization makes no such conversion.
+      assert Ash.Type.Duration.compare(Duration.new!(year: 1), Duration.new!(day: 360)) == :eq
+
+      assert {:ok, Duration.new!(year: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(year: 1), [])
+    end
+  end
+
   describe "atomic updates" do
     defmodule AtomicSpan do
       @moduledoc false

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -328,68 +328,39 @@ defmodule Ash.Test.Type.DurationTest do
                )
     end
 
-    test "a read is tolerant and lossy where a write is strict" do
-      # 10_801 seconds is not a whole number of hours
-      inexact = Duration.new!(second: 10_801)
+    test "a stored value the permitted units cannot express is refused, not rewritten" do
+      # 10801 seconds is not a whole number of hours
+      assert {:error, _} =
+               Ash.Type.Duration.cast_stored(Duration.new!(second: 10_801), units: [:hour])
 
-      # a write must not silently lose the odd second
-      assert {:error, _} = Ash.Type.Duration.apply_constraints(inexact, units: [:hour])
-
-      # a read must still answer with something the attribute can hold
-      assert {:ok, Duration.new!(hour: 3)} ==
-               Ash.Type.Duration.cast_stored(inexact, units: [:hour])
-    end
-
-    test "a lossy read keeps what it can say and drops what it cannot" do
       # under [:day] the 5h 3min has nowhere to go
-      assert {:ok, Duration.new!(day: 1)} ==
+      assert {:error, _} =
                Ash.Type.Duration.cast_stored(Duration.new!(day: 1, hour: 5, minute: 3),
                  units: [:day]
                )
-
-      # and what comes back is writable, which is the point
-      assert {:ok, _} =
-               Ash.Type.Duration.apply_constraints(Duration.new!(day: 1), units: [:day])
     end
 
-    test "a lossy read drops a bucket the permitted units cannot speak for at all" do
+    test "a read refuses a bucket the permitted units cannot speak for at all" do
       # [:week] can say nothing about months
-      assert {:ok, Duration.new!([])} ==
+      assert {:error, _} =
                Ash.Type.Duration.cast_stored(Duration.new!(month: 18), units: [:week])
-
-      # and nothing smaller than the smallest permitted unit survives either
-      assert {:ok, Duration.new!([])} ==
-               Ash.Type.Duration.cast_stored(Duration.new!(second: 129_600), units: [:week])
     end
 
-    test "every read is writable, however coarse the permitted units" do
+    test "a read applies the constraint exactly as a write does" do
       for {units, stored} <- [
+            {[:hour], Duration.new!(second: 10_801)},
             {[:week], Duration.new!(month: 18)},
             {[:week], Duration.new!(second: 129_600)},
             {[:year], Duration.new!(month: 6)},
-            {[:hour], Duration.new!(second: 10_801)},
             {[:day], Duration.new!(day: 1, hour: 5, minute: 3)}
           ] do
-        assert {:ok, loaded} = Ash.Type.Duration.cast_stored(stored, units: units)
+        write = Ash.Type.Duration.apply_constraints(stored, units: units)
+        read = Ash.Type.Duration.cast_stored(stored, units: units)
 
-        assert {:ok, ^loaded} = Ash.Type.Duration.apply_constraints(loaded, units: units),
-               "#{inspect(stored)} under #{inspect(units)} read back as #{inspect(loaded)}, " <>
-                 "which the attribute rejects"
+        assert match?({:error, _}, write) and match?({:error, _}, read),
+               "#{inspect(stored)} under #{inspect(units)}: " <>
+                 "write #{inspect(write)}, read #{inspect(read)}"
       end
-    end
-
-    test "a write still refuses what a read would drop" do
-      # a read must answer; a write must not lose data
-      assert {:error, _} =
-               Ash.Type.Duration.apply_constraints(Duration.new!(month: 18), units: [:week])
-
-      assert {:error, _} =
-               Ash.Type.Duration.apply_constraints(Duration.new!(second: 129_600), units: [:week])
-    end
-
-    test "a lossy read truncates towards zero, so it never overstates a duration" do
-      assert {:ok, Duration.new!(hour: -3)} ==
-               Ash.Type.Duration.cast_stored(Duration.new!(second: -10_801), units: [:hour])
     end
 
     test "a read never loses anything when every unit is permitted" do
@@ -408,9 +379,9 @@ defmodule Ash.Test.Type.DurationTest do
                )
     end
 
-    test "a lossy read only loses in the bucket that cannot express its value" do
-      # the year/month side is exact and survives
-      assert {:ok, Duration.new!(year: 1, hour: 3)} ==
+    test "one inexpressible side refuses the whole value on read" do
+      # the year/month side is exact, but the day/time side is not, so the read fails
+      assert {:error, _} =
                Ash.Type.Duration.cast_stored(Duration.new!(month: 12, second: 10_801),
                  units: [:year, :hour]
                )
@@ -658,9 +629,9 @@ defmodule Ash.Test.Type.DurationTest do
                Ash.Type.Duration.cast_stored(Duration.new!(year: 1, day: 5), [])
     end
 
-    test "a read across the divide loses the side it cannot speak for" do
+    test "a read across the divide is refused, like a write" do
       # [:day] can say nothing about years, so a stored year has nowhere to go
-      assert {:ok, Duration.new!([])} ==
+      assert {:error, _} =
                Ash.Type.Duration.cast_stored(Duration.new!(year: 1), units: [:day])
     end
 
@@ -669,8 +640,9 @@ defmodule Ash.Test.Type.DurationTest do
                Ash.Type.Duration.apply_constraints(Duration.new!(year: 1), units: [:day])
     end
 
-    test "within a side, a remainder truncates on read and refuses on write" do
-      assert {:ok, Duration.new!(week: 52)} ==
+    test "within a side, a remainder is refused on both paths" do
+      # 365 days is 52 weeks and a day; [:week] cannot say the odd day
+      assert {:error, _} =
                Ash.Type.Duration.cast_stored(Duration.new!(day: 365), units: [:week])
 
       assert {:error, _} =

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -118,6 +118,7 @@ defmodule Ash.Test.Type.DurationTest do
 
     attributes do
       attribute :duration, :duration, public?: true
+      attribute :hours_only, :duration, public?: true, constraints: [units: [:hour]]
     end
   end
 
@@ -161,6 +162,41 @@ defmodule Ash.Test.Type.DurationTest do
         |> Ash.create!()
 
       assert holder.embedded.duration == nil
+    end
+
+    # ISO 8601 round trips faithfully, so this is for consistency, not repair.
+    test "an embedded duration is normalized, and a read agrees with the write" do
+      holder =
+        Holder
+        |> Ash.Changeset.for_create(:create, %{embedded: %{duration: Duration.new!(hour: 36)}})
+        |> Ash.create!()
+
+      assert holder.embedded.duration == Duration.new!(day: 1, hour: 12)
+
+      assert [%{embedded: %{duration: read_back}}] = Ash.read!(Holder)
+      assert read_back == holder.embedded.duration
+    end
+
+    test "an embedded duration honours its units constraint" do
+      # converted, because 2 days is exactly 48 hours
+      holder =
+        Holder
+        |> Ash.Changeset.for_create(:create, %{embedded: %{hours_only: Duration.new!(day: 2)}})
+        |> Ash.create!()
+
+      assert holder.embedded.hours_only == Duration.new!(hour: 48)
+
+      assert [%{embedded: %{hours_only: read_back}}] = Ash.read!(Holder)
+      assert read_back == holder.embedded.hours_only
+    end
+
+    test "an embedded duration is rejected when the permitted units cannot express it" do
+      assert {:error, _} =
+               Holder
+               |> Ash.Changeset.for_create(:create, %{
+                 embedded: %{hours_only: Duration.new!(minute: 90)}
+               })
+               |> Ash.create()
     end
   end
 
@@ -262,6 +298,300 @@ defmodule Ash.Test.Type.DurationTest do
                |> Ash.create()
 
       assert post.duration_calendar_free == Duration.new!(day: 3, hour: 12)
+    end
+  end
+
+  describe "normalizing stored durations into the permitted units" do
+    # A store keeps only what it can: Postgres returns `week: 1` as `day: 7`.
+    test "re-expresses a stored value in the permitted unit" do
+      assert {:ok, Duration.new!(week: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 7), units: [:week])
+
+      assert {:ok, Duration.new!(hour: 3)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(second: 10_800), units: [:hour])
+    end
+
+    test "what is read back can be written again" do
+      constraints = [units: [:hour]]
+
+      assert {:ok, loaded} =
+               Ash.Type.Duration.cast_stored(Duration.new!(second: 10_800), constraints)
+
+      # the invariant the defect broke
+      assert {:ok, ^loaded} = Ash.Type.Duration.apply_constraints(loaded, constraints)
+    end
+
+    test "fills the largest permitted unit first" do
+      assert {:ok, Duration.new!(day: 1, hour: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(second: 90_000),
+                 units: [:day, :hour]
+               )
+    end
+
+    test "a read is tolerant and lossy where a write is strict" do
+      # 10_801 seconds is not a whole number of hours
+      inexact = Duration.new!(second: 10_801)
+
+      # a write must not silently lose the odd second
+      assert {:error, _} = Ash.Type.Duration.apply_constraints(inexact, units: [:hour])
+
+      # a read must still answer with something the attribute can hold
+      assert {:ok, Duration.new!(hour: 3)} ==
+               Ash.Type.Duration.cast_stored(inexact, units: [:hour])
+    end
+
+    test "a lossy read keeps what it can say and drops what it cannot" do
+      # under [:day] the 5h 3min has nowhere to go
+      assert {:ok, Duration.new!(day: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 1, hour: 5, minute: 3),
+                 units: [:day]
+               )
+
+      # and what comes back is writable, which is the point
+      assert {:ok, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(day: 1), units: [:day])
+    end
+
+    test "a lossy read drops a bucket the permitted units cannot speak for at all" do
+      # [:week] can say nothing about months
+      assert {:ok, Duration.new!([])} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(month: 18), units: [:week])
+
+      # and nothing smaller than the smallest permitted unit survives either
+      assert {:ok, Duration.new!([])} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(second: 129_600), units: [:week])
+    end
+
+    test "every read is writable, however coarse the permitted units" do
+      for {units, stored} <- [
+            {[:week], Duration.new!(month: 18)},
+            {[:week], Duration.new!(second: 129_600)},
+            {[:year], Duration.new!(month: 6)},
+            {[:hour], Duration.new!(second: 10_801)},
+            {[:day], Duration.new!(day: 1, hour: 5, minute: 3)}
+          ] do
+        assert {:ok, loaded} = Ash.Type.Duration.cast_stored(stored, units: units)
+
+        assert {:ok, ^loaded} = Ash.Type.Duration.apply_constraints(loaded, units: units),
+               "#{inspect(stored)} under #{inspect(units)} read back as #{inspect(loaded)}, " <>
+                 "which the attribute rejects"
+      end
+    end
+
+    test "a write still refuses what a read would drop" do
+      # a read must answer; a write must not lose data
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(month: 18), units: [:week])
+
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(second: 129_600), units: [:week])
+    end
+
+    test "a lossy read truncates towards zero, so it never overstates a duration" do
+      assert {:ok, Duration.new!(hour: -3)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(second: -10_801), units: [:hour])
+    end
+
+    test "a read never loses anything when every unit is permitted" do
+      # microsecond is the floor, so there is never a remainder
+      odd = Duration.new!(day: 1, hour: 5, minute: 3, microsecond: {7, 6})
+
+      assert {:ok, %Duration{week: 0, day: 1, hour: 5, minute: 3, microsecond: {7, 6}}} =
+               Ash.Type.Duration.cast_stored(odd, [])
+    end
+
+    test "normalizes the year/month and day/time buckets independently" do
+      # months and microseconds are not interconvertible
+      assert {:ok, Duration.new!(year: 1, week: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(month: 12, day: 7),
+                 units: [:year, :week]
+               )
+    end
+
+    test "a lossy read only loses in the bucket that cannot express its value" do
+      # the year/month side is exact and survives
+      assert {:ok, Duration.new!(year: 1, hour: 3)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(month: 12, second: 10_801),
+                 units: [:year, :hour]
+               )
+    end
+
+    test "a write reports only the bucket it cannot express" do
+      assert {:error, [[message: _, units: _, disallowed: disallowed]]} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(month: 12, second: 10_801),
+                 units: [:year, :hour]
+               )
+
+      assert disallowed =~ "second"
+      refute disallowed =~ "month"
+    end
+
+    test "with no units constraint, all units are permitted and still filled greedily" do
+      assert {:ok, Duration.new!(week: 1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 7), [])
+
+      assert {:ok, Duration.new!(year: 1, month: 6)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(month: 18), [])
+    end
+
+    test "normalizes on the way in as well, so a write and a read agree" do
+      # apply_constraints is the write side; cast_stored is the read side
+      assert {:ok, normalized} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(hour: 36), units: :day_time)
+
+      assert normalized == Duration.new!(day: 1, hour: 12)
+      assert {:ok, ^normalized} = Ash.Type.Duration.cast_stored(normalized, units: :day_time)
+    end
+
+    test "accepts a unit outside the permitted set when it converts exactly" do
+      # `day` cannot be said here, but 1 day is exactly 24 hours
+      assert {:ok, Duration.new!(hour: 24)} ==
+               Ash.Type.Duration.apply_constraints(Duration.new!(day: 1), units: [:week, :hour])
+    end
+
+    test "still rejects across the bucket divide, which no conversion can cross" do
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(month: 1), units: :day_time)
+
+      assert {:error, _} =
+               Ash.Type.Duration.apply_constraints(Duration.new!(day: 1), units: :year_month)
+    end
+
+    test "keeps the microsecond precision it was stored with" do
+      assert {:ok, %Duration{hour: 3, microsecond: {0, 6}}} =
+               Ash.Type.Duration.cast_stored(
+                 %Duration{second: 10_800, microsecond: {0, 6}},
+                 units: [:hour]
+               )
+    end
+
+    test "normalizes a negative duration without changing its sign" do
+      assert {:ok, Duration.new!(week: -1)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: -7), units: [:week])
+    end
+
+    test "normalizes a value stored as an ISO 8601 string" do
+      assert {:ok, Duration.new!(week: 1)} ==
+               Ash.Type.Duration.cast_stored("P7D", units: [:week])
+    end
+
+    test "nil is unaffected" do
+      assert {:ok, nil} = Ash.Type.Duration.cast_stored(nil, units: [:week])
+    end
+
+    test "spills a unit it cannot say into the next one it can" do
+      # :day is missing, so a stored day is carried by hours
+      assert {:ok, Duration.new!(week: 1, hour: 29)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(week: 1, day: 1, hour: 5),
+                 units: [:week, :hour]
+               )
+
+      assert {:ok, Duration.new!(week: 1, hour: 72)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 10), units: [:week, :hour])
+    end
+
+    test "fills greedily even when every unit used is already permitted" do
+      # the permitted set says what may be said, not what shape a value keeps
+      assert {:ok, Duration.new!(week: 1, day: 3)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(day: 10), units: :day_time)
+
+      assert {:ok, Duration.new!(year: 1, month: 6)} ==
+               Ash.Type.Duration.cast_stored(Duration.new!(month: 18), units: :year_month)
+    end
+
+    test "what a create returns is what a subsequent read returns" do
+      written = Duration.new!(day: 3, hour: 12)
+
+      assert {:ok, post} =
+               Post
+               |> Ash.Changeset.for_create(:create, %{
+                 duration_b: @minute30,
+                 duration_calendar_free: written
+               })
+               |> Ash.create()
+
+      assert post.duration_calendar_free == written
+
+      assert {:ok, reread} = Ash.get(Post, post.id)
+      assert reread.duration_calendar_free == post.duration_calendar_free
+    end
+
+    test "what an update returns is what a subsequent read returns" do
+      assert {:ok, post} =
+               Post
+               |> Ash.Changeset.for_create(:create, %{duration_b: @minute30})
+               |> Ash.create()
+
+      assert {:ok, post} =
+               post
+               |> Ash.Changeset.for_update(:update, %{
+                 duration_calendar_free: Duration.new!(hour: 36)
+               })
+               |> Ash.update()
+
+      # normalized on the way in
+      assert post.duration_calendar_free == Duration.new!(day: 1, hour: 12)
+
+      assert {:ok, reread} = Ash.get(Post, post.id)
+      assert reread.duration_calendar_free == post.duration_calendar_free
+    end
+  end
+
+  describe "atomic updates" do
+    defmodule AtomicSpan do
+      @moduledoc false
+      use Ash.Resource, domain: Domain, data_layer: Ash.DataLayer.Ets
+
+      ets do
+        private?(true)
+      end
+
+      attributes do
+        uuid_primary_key :id
+        attribute :free, :duration, public?: true
+        attribute :hours_only, :duration, public?: true, constraints: [units: [:hour]]
+      end
+
+      actions do
+        default_accept :*
+        defaults [:read, :create]
+
+        update :atomically do
+          accept [:free]
+          require_atomic? true
+        end
+
+        update :non_atomically do
+          accept [:hours_only]
+          require_atomic? false
+        end
+      end
+    end
+
+    test "an atomic update returns the canonical form, as a read does" do
+      # an atomic update skips apply_constraints/2, but the record returns via cast_stored/2
+      assert {:ok, span} = Ash.create(AtomicSpan, %{free: Duration.new!(hour: 1)})
+
+      assert {:ok, updated} =
+               span
+               |> Ash.Changeset.for_update(:atomically, %{free: Duration.new!(hour: 36)})
+               |> Ash.update()
+
+      assert updated.free == Duration.new!(day: 1, hour: 12)
+
+      assert {:ok, reread} = Ash.get(AtomicSpan, span.id)
+      assert reread.free == updated.free
+    end
+
+    test "a non-atomic write normalizes into the permitted units" do
+      assert {:ok, span} = Ash.create(AtomicSpan, %{hours_only: Duration.new!(hour: 3)})
+
+      assert {:ok, updated} =
+               span
+               |> Ash.Changeset.for_update(:non_atomically, %{hours_only: Duration.new!(day: 2)})
+               |> Ash.update()
+
+      assert updated.hours_only == Duration.new!(hour: 48)
     end
   end
 


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Fixes #2850

Added tests, and normalisation on both sides of storage.

A duration is now expressed in the largest units it is permitted to use. No `units` constraint permits every unit, so there is one rule rather than two paths.

`apply_constraints/2` normalises before validating, so it returns a modified value, this is done so a return matches a later round-trip read.

`cast_stored/2` truncates towards zero where the permitted units cannot express what the store holds, because a read has to answer with something the attribute can hold; a write still refuses, because it must not lose part of what was asked for.

`may_support_atomic_update?/1` is deliberately unchanged as an atomic update skips apply_constraints/2, so nothing normalises on the way in however as every route back out of the store goes through cast_stored/2 what's returned is canonical either way. Measured on both Ets and Postgres.
