### PR TITLE
fix: declare the duration overloads of the plus and minus operators

### DIFF
--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -9,7 +9,43 @@ defmodule Ash.Query.Operator.Basic do
     plus: [
       symbol: :+,
       no_nils: true,
-      evaluate_types: :numbers
+      evaluate_types: :numbers,
+      types: [
+        [:same, :any],
+        [:duration, :duration],
+        [:date, :duration],
+        [:duration, :date],
+        [:datetime, :duration],
+        [:duration, :datetime],
+        [:utc_datetime, :duration],
+        [:duration, :utc_datetime],
+        [:utc_datetime_usec, :duration],
+        [:duration, :utc_datetime_usec],
+        [:naive_datetime, :duration],
+        [:duration, :naive_datetime],
+        [:time, :duration],
+        [:duration, :time],
+        [:time_usec, :duration],
+        [:duration, :time_usec]
+      ],
+      returns: [
+        :same,
+        :duration,
+        :date,
+        :date,
+        :datetime,
+        :datetime,
+        :utc_datetime,
+        :utc_datetime,
+        :utc_datetime_usec,
+        :utc_datetime_usec,
+        :naive_datetime,
+        :naive_datetime,
+        :time,
+        :time,
+        :time_usec,
+        :time_usec
+      ]
     ],
     times: [
       symbol: :*,
@@ -25,7 +61,29 @@ defmodule Ash.Query.Operator.Basic do
     minus: [
       symbol: :-,
       no_nils: true,
-      evaluate_types: :numbers
+      evaluate_types: :numbers,
+      types: [
+        [:same, :any],
+        [:duration, :duration],
+        [:date, :duration],
+        [:datetime, :duration],
+        [:utc_datetime, :duration],
+        [:utc_datetime_usec, :duration],
+        [:naive_datetime, :duration],
+        [:time, :duration],
+        [:time_usec, :duration]
+      ],
+      returns: [
+        :same,
+        :duration,
+        :date,
+        :datetime,
+        :utc_datetime,
+        :utc_datetime_usec,
+        :naive_datetime,
+        :time,
+        :time_usec
+      ]
     ],
     div: [
       symbol: :/,

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -717,6 +717,52 @@ defmodule Ash.Test.Type.DurationTest do
     end
   end
 
+  describe "operand types" do
+    # Without these declarations a duration is typed as whatever it is added to.
+    @temporal_fields [
+      {:datetime, Ash.Type.DateTime},
+      {:utc_datetime, Ash.Type.UtcDatetime},
+      {:utc_datetime_usec, Ash.Type.UtcDatetimeUsec},
+      {:naive_datetime, Ash.Type.NaiveDatetime},
+      {:date, Ash.Type.Date},
+      {:time, Ash.Type.Time},
+      {:time_usec, Ash.Type.TimeUsec}
+    ]
+
+    defp operand_types(expression) do
+      {:ok, %op{} = hydrated} = Ash.Filter.hydrate_refs(expression, %{resource: Post})
+
+      {[{left, _}, {right, _}], {returns, _}} =
+        Ash.Expr.determine_types(op, [hydrated.left, hydrated.right])
+
+      {left, right, returns}
+    end
+
+    test "adding a duration keeps it a duration, and returns the temporal type" do
+      for {field, type} <- @temporal_fields do
+        assert {^type, Ash.Type.Duration, ^type} =
+                 operand_types(expr(^ref(field) + ^Duration.new!(day: 1)))
+      end
+    end
+
+    test "subtracting a duration does the same" do
+      for {field, type} <- @temporal_fields do
+        assert {^type, Ash.Type.Duration, ^type} =
+                 operand_types(expr(^ref(field) - ^Duration.new!(day: 1)))
+      end
+    end
+
+    test "a duration on the left of an addition is kept too" do
+      assert {Ash.Type.Duration, Ash.Type.UtcDatetime, Ash.Type.UtcDatetime} =
+               operand_types(expr(^Duration.new!(day: 1) + ^ref(:utc_datetime)))
+    end
+
+    test "two durations add to a duration" do
+      assert {Ash.Type.Duration, Ash.Type.Duration, Ash.Type.Duration} =
+               operand_types(expr(^ref(:duration_a) + ^ref(:duration_b)))
+    end
+  end
+
   describe "comparison" do
     alias Ash.Query.Operator.{Eq, GreaterThan, LessThan}
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Partially delivers https://github.com/ash-project/ash_postgres/issues/553 (Duration)
Enables an ash_postgres test PR

`Ash.Query.Operator.Basic` implements every temporal ± duration combination in `evaluate/1` — `DateTime`, `Date`, `Time`, `NaiveDateTime` and `Duration` — so these forms work on data layers that evaluate expressions with Ash runtime. 

However an error was discovered that can't be reproduced without a datalayer which doesn't use Ash runtime for expression evaluation. As `plus` and `minus` declare no `types` they take the default `[[:same, :any]]`, which types the right operand as the left. A `%Duration{}` cannot be cast to a datetime, so for example on a SQL-backed data layer such as ash_postgres the expression is refused with `Invalid filter value`.

This PR declares the overloads, as `times` already does for `duration * integer`. It resolves each temporal type to a distinct module, so all seven are listed rather than a single `:datetime`.

Regression tests assert the resolved operand types through `Ash.Expr.determine_types/2`. These assert that a duration operand stays a `Ash.Type.Duration` and the expression returns the temporal type.

No ash_sql change is needed: it renders a `:duration`-typed parameter correctly already, it was simply never told the operand was one. Verified against PostgreSQL 19 — `at + ^dur > ^dt`, `at - ^dur < ^dt`, a multi-unit duration, the reversed `^dur + at` and `date + ^dur` all execute and return the expected rows.


