### PR TITLE
feat: allow a data layer to override an attribute's Ecto type

### DIFF
--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -354,7 +354,8 @@ defmodule Ash.DataLayer do
   This lets a data layer take charge of dumping/loading a stored value for a core type
   whose native form it needs to translate (e.g. `ash_postgres` rendering
   `Ash.Type.Range` to/from a `Postgrex.Range`). It is consulted at compile time while
-  building the schema, so the returned value must be a valid Ecto type.
+  building the schema, so the returned value must be a valid Ecto type that accepts
+  the attribute's constraints as its parameters.
   """
   @callback attribute_ecto_type(Ash.Resource.t(), Ash.Resource.Attribute.t()) :: nil | term()
 

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -347,6 +347,16 @@ defmodule Ash.DataLayer do
   @callback can?(Ash.Resource.t() | Spark.Dsl.t(), feature()) :: boolean
   @callback set_context(Ash.Resource.t(), data_layer_query(), map) ::
               {:ok, data_layer_query()} | {:error, term}
+  @doc """
+  The Ecto type to use for an attribute in the resource's generated schema, or `nil`
+  to use the default (`Ash.Type.ecto_type/1`).
+
+  This lets a data layer take charge of dumping/loading a stored value for a core type
+  whose native form it needs to translate (e.g. `ash_postgres` rendering
+  `Ash.Type.Range` to/from a `Postgrex.Range`). It is consulted at compile time while
+  building the schema, so the returned value must be a valid Ecto type.
+  """
+  @callback attribute_ecto_type(Ash.Resource.t(), Ash.Resource.Attribute.t()) :: nil | term()
 
   @optional_callbacks source: 1,
                       combination_acc: 1,
@@ -389,12 +399,24 @@ defmodule Ash.DataLayer do
                       run_aggregate_query: 3,
                       run_aggregate_query_with_lateral_join: 5,
                       transform_query: 1,
-                      set_tenant: 3
+                      set_tenant: 3,
+                      attribute_ecto_type: 2
 
   @doc "The data layer of the resource, or nil if it does not have one"
   @spec data_layer(Ash.Resource.t() | Spark.Dsl.t()) :: Ash.DataLayer.t() | nil
   def data_layer(resource) do
     Extension.get_persisted(resource, :data_layer)
+  end
+
+  @doc false
+  # The data-layer-preferred Ecto type for an attribute, or `nil` for the default.
+  def attribute_ecto_type(resource, attribute) do
+    data_layer = data_layer(resource)
+
+    if data_layer && Code.ensure_loaded?(data_layer) &&
+         function_exported?(data_layer, :attribute_ecto_type, 2) do
+      data_layer.attribute_ecto_type(resource, attribute)
+    end
   end
 
   @doc "Whether or not lateral joins should be used for many to many relationships by default"

--- a/lib/ash/resource/schema.ex
+++ b/lib/ash/resource/schema.ex
@@ -50,7 +50,7 @@ defmodule Ash.Schema do
 
               field(
                 attribute.name,
-                Ash.Type.ecto_type(Ash.Schema.not_a_resource!(attribute.type)),
+                Ash.Schema.ecto_type(__MODULE__, attribute),
                 Keyword.merge(constraint_opts,
                   primary_key: attribute.primary_key?,
                   read_after_writes: read_after_writes?,
@@ -197,7 +197,7 @@ defmodule Ash.Schema do
 
               field(
                 attribute.name,
-                Ash.Type.ecto_type(Ash.Schema.not_a_resource!(attribute.type)),
+                Ash.Schema.ecto_type(__MODULE__, attribute),
                 Keyword.merge(constraint_opts,
                   primary_key: attribute.primary_key?,
                   read_after_writes: read_after_writes?,
@@ -403,6 +403,15 @@ defmodule Ash.Schema do
   def attribute_default(fun) when is_function(fun), do: nil
   def attribute_default({_mod, _func, _args}), do: nil
   def attribute_default(value), do: value
+
+  @doc false
+  # The Ecto type for an attribute's schema field. The data layer may override it
+  # (e.g. to take charge of dumping/loading a core type's stored form); otherwise we
+  # fall back to the type's own Ecto type.
+  def ecto_type(resource, attribute) do
+    Ash.DataLayer.attribute_ecto_type(resource, attribute) ||
+      Ash.Type.ecto_type(not_a_resource!(attribute.type))
+  end
 
   @doc false
   # Called at compile time from within the `schema do ... end` block to wire

--- a/test/resource/attribute_ecto_type_test.exs
+++ b/test/resource/attribute_ecto_type_test.exs
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Resource.AttributeEctoTypeTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  # A data layer can take charge of an attribute's field in the generated Ecto
+  # schema, so that dumping and loading its stored value go through a type of the
+  # data layer's choosing.
+
+  defmodule DataLayer do
+    @moduledoc false
+    use Spark.Dsl.Extension, transformers: [], sections: []
+
+    @behaviour Ash.DataLayer
+
+    defdelegate can?(resource, feature), to: Ash.DataLayer.Simple
+    defdelegate resource_to_query(resource, domain), to: Ash.DataLayer.Simple
+    defdelegate run_query(query, resource), to: Ash.DataLayer.Simple
+
+    @doc false
+    def attribute_ecto_type(_resource, %{name: :taken_charge_of}) do
+      Ash.Type.ecto_type(Ash.Type.CiString)
+    end
+
+    def attribute_ecto_type(_resource, _attribute), do: nil
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: DataLayer
+
+    attributes do
+      uuid_primary_key :id
+      attribute :taken_charge_of, :string
+      attribute :left_alone, :string
+    end
+  end
+
+  defmodule UnimplementedPost do
+    @moduledoc false
+    use Ash.Resource, domain: Ash.Test.Domain, data_layer: Ash.DataLayer.Ets
+
+    attributes do
+      uuid_primary_key :id
+      attribute :taken_charge_of, :string
+    end
+  end
+
+  test "the data layer's type is used for the attribute it claims" do
+    assert {:parameterized, {Ash.Type.CiString.EctoType, _}} =
+             Post.__schema__(:type, :taken_charge_of)
+  end
+
+  test "returning nil falls back to the attribute type's own Ecto type" do
+    assert {:parameterized, {Ash.Type.String.EctoType, _}} =
+             Post.__schema__(:type, :left_alone)
+  end
+
+  test "a data layer that does not implement the callback is unaffected" do
+    assert {:parameterized, {Ash.Type.String.EctoType, _}} =
+             UnimplementedPost.__schema__(:type, :taken_charge_of)
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Closes #2853 

1st commit lifted @zachdaniel work on temporal, data_layer.ex and schema.ex:
https://github.com/ash-project/ash/blob/b3d1a7c36084bec99f27eb89d5a72ae41a3716ec/lib/ash/data_layer/data_layer.ex
https://github.com/ash-project/ash/blob/b3d1a7c36084bec99f27eb89d5a72ae41a3716ec/lib/ash/resource/schema.ex

2nd commit added tests and improved documentation, as the return must be a type that accepts the attribute's constraints as its parameters.