### PR TITLE
fix: canonicalize every empty range to one value

### DIFF
--- a/lib/ash/query/function/range_overlaps.ex
+++ b/lib/ash/query/function/range_overlaps.ex
@@ -36,7 +36,7 @@ defmodule Ash.Query.Function.RangeOverlaps do
   # each bound's inclusivity (`[`/`]` inclusive, `(`/`)` exclusive) and treating a `nil`
   # bound as ±∞. Empty ranges (e.g. `[5, 5)`) overlap nothing. Matches Postgres `&&`.
   defp do_overlap?(left, right) do
-    not empty?(left) and not empty?(right) and
+    not Range.empty?(left) and not Range.empty?(right) and
       not separated?(left, right) and not separated?(right, left)
   end
 
@@ -48,23 +48,8 @@ defmodule Ash.Query.Function.RangeOverlaps do
     cond do
       Comp.less_than?(xu, yl) -> true
       # Touching boundary: a shared point only if BOTH sides include it.
-      Comp.equal?(xu, yl) -> not (upper_inclusive?(xb) and lower_inclusive?(yb))
+      Comp.equal?(xu, yl) -> not (Range.upper_inclusive?(xb) and Range.lower_inclusive?(yb))
       true -> false
     end
   end
-
-  # A bounded range with no points: `lower > upper`, or `lower == upper` unless both bounds
-  # are inclusive (`[x, x]`, the single point `x`). Unbounded ends are never empty.
-  defp empty?(%Range{lower: l, upper: u, bounds: b}) when not is_nil(l) and not is_nil(u) do
-    cond do
-      Comp.less_than?(u, l) -> true
-      Comp.equal?(l, u) -> not (lower_inclusive?(b) and upper_inclusive?(b))
-      true -> false
-    end
-  end
-
-  defp empty?(_range), do: false
-
-  defp lower_inclusive?(bounds), do: bounds in [:"[)", :"[]"]
-  defp upper_inclusive?(bounds), do: bounds in [:"(]", :"[]"]
 end

--- a/lib/ash/range.ex
+++ b/lib/ash/range.ex
@@ -11,6 +11,11 @@ defmodule Ash.Range do
   `[` / `]` inclusive, `(` / `)` exclusive. A `nil` `lower`/`upper` is an
   unbounded (infinite) end. The default `:"[)"` (lower-inclusive, upper-exclusive)
   is the convention that lets adjacent ranges tile a timeline without overlap.
+
+  A range containing no points is empty, and every empty range is the same range.
+  `Ash.Type.Range` casts any such range to `empty/0`, whose bounds are dropped —
+  as Postgres does — so that empty ranges compare equal and survive storage in a
+  data layer that keeps no bounds for them.
   """
 
   @type bounds :: :"[)" | :"[]" | :"()" | :"(]"
@@ -18,14 +23,48 @@ defmodule Ash.Range do
   @type t :: %__MODULE__{
           lower: term() | nil,
           upper: term() | nil,
-          bounds: bounds()
+          bounds: bounds(),
+          empty?: boolean()
         }
 
-  defstruct lower: nil, upper: nil, bounds: :"[)"
+  defstruct lower: nil, upper: nil, bounds: :"[)", empty?: false
 
   @valid_bounds [:"[)", :"[]", :"()", :"(]"]
 
   @doc "Whether the given atom is a valid bounds specifier."
   @spec valid_bounds?(term()) :: boolean()
   def valid_bounds?(bounds), do: bounds in @valid_bounds
+
+  @doc "The empty range: the one range containing no points."
+  @spec empty() :: t()
+  def empty, do: %__MODULE__{lower: nil, upper: nil, bounds: :"[)", empty?: true}
+
+  @doc """
+  Whether the range contains no points.
+
+  True for `empty/0`, and for a bounded range whose bounds admit nothing: a lower
+  above its upper, or bounds that meet without both including the point they meet
+  at. An unbounded end is never empty.
+  """
+  @spec empty?(t()) :: boolean()
+  def empty?(%__MODULE__{empty?: true}), do: true
+
+  def empty?(%__MODULE__{lower: lower, upper: upper, bounds: bounds})
+      when not is_nil(lower) and not is_nil(upper) do
+    cond do
+      Comp.less_than?(upper, lower) -> true
+      Comp.equal?(lower, upper) -> not (lower_inclusive?(bounds) and upper_inclusive?(bounds))
+      true -> false
+    end
+  end
+
+  def empty?(%__MODULE__{}), do: false
+
+  @doc "Whether the range's lower bound includes the point it names."
+  @spec lower_inclusive?(bounds()) :: boolean()
+  def lower_inclusive?(bounds), do: bounds in [:"[)", :"[]"]
+
+  @doc "Whether the range's upper bound includes the point it names."
+  @spec upper_inclusive?(bounds()) :: boolean()
+  def upper_inclusive?(bounds), do: bounds in [:"(]", :"[]"]
 end

--- a/lib/ash/type/range.ex
+++ b/lib/ash/type/range.ex
@@ -99,10 +99,10 @@ defmodule Ash.Type.Range do
   def cast_input(nil, _constraints), do: {:ok, nil}
 
   def cast_input(value, constraints) do
-    with {:ok, lower, upper, bounds} <- extract(value),
+    with {:ok, lower, upper, bounds, empty?} <- extract(value),
          {:ok, lower} <- cast_bound(lower, :cast_input, constraints),
          {:ok, upper} <- cast_bound(upper, :cast_input, constraints) do
-      {:ok, %Range{lower: lower, upper: upper, bounds: bounds}}
+      {:ok, canonicalize(%Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?})}
     end
   end
 
@@ -110,15 +110,16 @@ defmodule Ash.Type.Range do
   def cast_stored(nil, _constraints), do: {:ok, nil}
 
   def cast_stored(value, constraints) do
-    with {:ok, lower, upper, bounds} <- extract(value),
+    with {:ok, lower, upper, bounds, empty?} <- extract(value),
          {:ok, lower} <- cast_bound(lower, :cast_stored, constraints),
          {:ok, upper} <- cast_bound(upper, :cast_stored, constraints) do
-      {:ok, %Range{lower: lower, upper: upper, bounds: bounds}}
+      {:ok, canonicalize(%Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?})}
     end
   end
 
   @impl true
   def dump_to_native(nil, _constraints), do: {:ok, nil}
+  def dump_to_native(%Range{empty?: true}, _constraints), do: {:ok, Range.empty()}
 
   def dump_to_native(%Range{lower: lower, upper: upper, bounds: bounds}, constraints) do
     with {:ok, lower} <- dump_bound(lower, constraints),
@@ -131,6 +132,7 @@ defmodule Ash.Type.Range do
 
   @impl true
   def apply_constraints(nil, _constraints), do: {:ok, nil}
+  def apply_constraints(%Range{empty?: true} = range, _constraints), do: {:ok, range}
 
   def apply_constraints(%Range{lower: lower, upper: upper} = range, constraints) do
     type = constraints[:inner_type]
@@ -142,6 +144,23 @@ defmodule Ash.Type.Range do
       {:ok, %{range | lower: lower, upper: upper}}
     end
   end
+
+  # Every range containing no points is the same range, so they cast to one value with
+  # no bounds, as Postgres does, letting a data layer that keeps no bounds for an empty
+  # range read one back. An inverted range is invalid rather than empty, so it is left.
+  defp canonicalize(%Range{empty?: true}), do: Range.empty()
+
+  defp canonicalize(%Range{lower: lower, upper: upper, bounds: bounds} = range)
+       when not is_nil(lower) and not is_nil(upper) do
+    if Comp.equal?(lower, upper) and
+         not (Range.lower_inclusive?(bounds) and Range.upper_inclusive?(bounds)) do
+      Range.empty()
+    else
+      range
+    end
+  end
+
+  defp canonicalize(%Range{} = range), do: range
 
   defp check_order(nil, _), do: :ok
   defp check_order(_, nil), do: :ok
@@ -173,17 +192,18 @@ defmodule Ash.Type.Range do
     end
   end
 
-  defp extract(%Range{lower: lower, upper: upper, bounds: bounds}) do
-    {:ok, lower, upper, normalize_bounds(bounds)}
+  defp extract(%Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?}) do
+    {:ok, lower, upper, normalize_bounds(bounds), empty?}
   end
 
-  defp extract({lower, upper}), do: {:ok, lower, upper, :"[)"}
+  defp extract({lower, upper}), do: {:ok, lower, upper, :"[)", false}
 
   defp extract(%{} = map) do
     lower = map[:lower] || map["lower"]
     upper = map[:upper] || map["upper"]
     bounds = map[:bounds] || map["bounds"] || :"[)"
-    {:ok, lower, upper, normalize_bounds(bounds)}
+    empty? = map[:empty?] || map["empty?"] || false
+    {:ok, lower, upper, normalize_bounds(bounds), empty?}
   end
 
   defp extract(_), do: {:error, "is not a valid range"}

--- a/test/type/range_test.exs
+++ b/test/type/range_test.exs
@@ -78,4 +78,72 @@ defmodule Ash.Type.RangeTest do
 
     assert {:error, _} = Ash.Type.apply_constraints(Ash.Type.Range, range, @constraints)
   end
+
+  describe "empty ranges" do
+    test "a range admitting no points casts to the empty range" do
+      assert {:ok, %Range{empty?: true, lower: nil, upper: nil}} =
+               Ash.Type.cast_input(
+                 Ash.Type.Range,
+                 %Range{lower: @lower, upper: @lower},
+                 @constraints
+               )
+    end
+
+    test "every empty range casts to the same value" do
+      {:ok, at_lower} =
+        Ash.Type.cast_input(Ash.Type.Range, %Range{lower: @lower, upper: @lower}, @constraints)
+
+      {:ok, at_upper} =
+        Ash.Type.cast_input(Ash.Type.Range, %Range{lower: @upper, upper: @upper}, @constraints)
+
+      assert at_lower == at_upper
+      assert at_lower == Range.empty()
+    end
+
+    test "a range with both bounds inclusive is the single point, not empty" do
+      assert {:ok, %Range{empty?: false, lower: @lower, upper: @lower}} =
+               Ash.Type.cast_input(
+                 Ash.Type.Range,
+                 %Range{lower: @lower, upper: @lower, bounds: :"[]"},
+                 @constraints
+               )
+    end
+
+    test "an unbounded range is not empty" do
+      assert {:ok, %Range{empty?: false}} =
+               Ash.Type.cast_input(Ash.Type.Range, %Range{lower: nil, upper: nil}, @constraints)
+    end
+
+    test "the empty range survives a round trip through a data layer" do
+      {:ok, range} =
+        Ash.Type.cast_input(Ash.Type.Range, %Range{lower: @lower, upper: @lower}, @constraints)
+
+      {:ok, native} = Ash.Type.dump_to_native(Ash.Type.Range, range, @constraints)
+
+      assert {:ok, %Range{empty?: true}} =
+               Ash.Type.cast_stored(Ash.Type.Range, native, @constraints)
+    end
+
+    test "a lower bound above the upper is rejected, not emptied" do
+      {:ok, range} =
+        Ash.Type.cast_input(Ash.Type.Range, %Range{lower: @upper, upper: @lower}, @constraints)
+
+      refute range.empty?
+      assert {:error, _} = Ash.Type.apply_constraints(Ash.Type.Range, range, @constraints)
+    end
+
+    test "apply_constraints accepts the empty range, which has no bounds to check" do
+      assert {:ok, %Range{empty?: true}} =
+               Ash.Type.apply_constraints(Ash.Type.Range, Range.empty(), @constraints)
+    end
+
+    test "empty?/1 reports emptiness whether canonical or implied by the bounds" do
+      assert Range.empty?(Range.empty())
+      assert Range.empty?(%Range{lower: 5, upper: 5, bounds: :"[)"})
+      assert Range.empty?(%Range{lower: 6, upper: 5, bounds: :"[]"})
+      refute Range.empty?(%Range{lower: 5, upper: 5, bounds: :"[]"})
+      refute Range.empty?(%Range{lower: 5, upper: 6, bounds: :"[)"})
+      refute Range.empty?(%Range{lower: nil, upper: nil})
+    end
+  end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Closes #2857 

`RangeOverlaps` had its own private copy of the emptiness rules; it now calls`Ash.Range.empty?/1`.

An inverted range (`lower > upper`) is rejected, not emptied  (matching Postgres, where `'[5,5)'::int4range` is `empty` but `'[5,1)'::int4range` errors). 

`%Ash.Range{}` gains the `empty?` field.