### PR TITLE
fix: canonicalize the bounds of a discrete range

### DIFF
--- a/lib/ash/type/range.ex
+++ b/lib/ash/type/range.ex
@@ -102,7 +102,11 @@ defmodule Ash.Type.Range do
     with {:ok, lower, upper, bounds, empty?} <- extract(value),
          {:ok, lower} <- cast_bound(lower, :cast_input, constraints),
          {:ok, upper} <- cast_bound(upper, :cast_input, constraints) do
-      {:ok, canonicalize(%Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?})}
+      {:ok,
+       canonicalize(
+         %Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?},
+         constraints
+       )}
     end
   end
 
@@ -113,7 +117,11 @@ defmodule Ash.Type.Range do
     with {:ok, lower, upper, bounds, empty?} <- extract(value),
          {:ok, lower} <- cast_bound(lower, :cast_stored, constraints),
          {:ok, upper} <- cast_bound(upper, :cast_stored, constraints) do
-      {:ok, canonicalize(%Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?})}
+      {:ok,
+       canonicalize(
+         %Range{lower: lower, upper: upper, bounds: bounds, empty?: empty?},
+         constraints
+       )}
     end
   end
 
@@ -141,26 +149,63 @@ defmodule Ash.Type.Range do
     with {:ok, lower} <- apply_bound(type, lower, inner),
          {:ok, upper} <- apply_bound(type, upper, inner),
          :ok <- check_order(lower, upper) do
-      {:ok, %{range | lower: lower, upper: upper}}
+      {:ok, canonicalize(%{range | lower: lower, upper: upper}, constraints)}
     end
   end
 
   # Every range containing no points is the same range, so they cast to one value with
   # no bounds, as Postgres does, letting a data layer that keeps no bounds for an empty
   # range read one back. An inverted range is invalid rather than empty, so it is left.
-  defp canonicalize(%Range{empty?: true}), do: Range.empty()
+  defp canonicalize(%Range{empty?: true}, _constraints), do: Range.empty()
 
-  defp canonicalize(%Range{lower: lower, upper: upper, bounds: bounds} = range)
-       when not is_nil(lower) and not is_nil(upper) do
-    if Comp.equal?(lower, upper) and
-         not (Range.lower_inclusive?(bounds) and Range.upper_inclusive?(bounds)) do
-      Range.empty()
-    else
-      range
-    end
+  defp canonicalize(%Range{} = range, constraints) do
+    range = discrete_bounds(range, constraints[:inner_type])
+
+    if empty_bounds?(range), do: Range.empty(), else: range
   end
 
-  defp canonicalize(%Range{} = range), do: range
+  defp empty_bounds?(%Range{lower: lower, upper: upper, bounds: bounds})
+       when not is_nil(lower) and not is_nil(upper) do
+    Comp.equal?(lower, upper) and
+      not (Range.lower_inclusive?(bounds) and Range.upper_inclusive?(bounds))
+  end
+
+  defp empty_bounds?(%Range{}), do: false
+
+  # A discrete type has a successor, so every range over it has one `[)` spelling: an
+  # exclusive lower and an inclusive upper each move on to the next value, and an
+  # unbounded end is exclusive. A continuous type has none, so is left as written.
+  defp discrete_bounds(%Range{lower: lower, upper: upper} = range, type)
+       when type in [Ash.Type.Integer, Ash.Type.Date] and not is_nil(lower) and
+              not is_nil(upper) do
+    # Shifting an inverted range would answer a cast with one it did not describe.
+    if Comp.less_than?(upper, lower), do: range, else: shift_bounds(range)
+  end
+
+  defp discrete_bounds(%Range{} = range, type) when type in [Ash.Type.Integer, Ash.Type.Date] do
+    shift_bounds(range)
+  end
+
+  defp discrete_bounds(%Range{} = range, _type), do: range
+
+  defp shift_bounds(%Range{} = range) do
+    lower =
+      if is_nil(range.lower) or Range.lower_inclusive?(range.bounds),
+        do: range.lower,
+        else: successor(range.lower)
+
+    upper =
+      if is_nil(range.upper) or not Range.upper_inclusive?(range.bounds),
+        do: range.upper,
+        else: successor(range.upper)
+
+    bounds = if is_nil(lower), do: :"()", else: :"[)"
+
+    %{range | lower: lower, upper: upper, bounds: bounds}
+  end
+
+  defp successor(value) when is_integer(value), do: value + 1
+  defp successor(%Date{} = value), do: Date.add(value, 1)
 
   defp check_order(nil, _), do: :ok
   defp check_order(_, nil), do: :ok

--- a/test/type/range_test.exs
+++ b/test/type/range_test.exs
@@ -79,6 +79,98 @@ defmodule Ash.Type.RangeTest do
     assert {:error, _} = Ash.Type.apply_constraints(Ash.Type.Range, range, @constraints)
   end
 
+  describe "discrete ranges" do
+    # Every expectation here is what Postgres renders for the same range, e.g.
+    # `'[1,5]'::int4range` is `[1,6)` and `'(1,2)'::int4range` is `empty`.
+    setup do
+      {:ok, int} = Ash.Type.init(Ash.Type.Range, inner_type: :integer)
+      {:ok, date} = Ash.Type.init(Ash.Type.Range, inner_type: :date)
+      %{int: int, date: date}
+    end
+
+    defp cast!(range, constraints) do
+      {:ok, cast} = Ash.Type.cast_input(Ash.Type.Range, range, constraints)
+      cast
+    end
+
+    test "an inclusive upper moves on to the next value", %{int: int} do
+      assert %Range{lower: 1, upper: 6, bounds: :"[)"} =
+               cast!(%Range{lower: 1, upper: 5, bounds: :"[]"}, int)
+    end
+
+    test "an exclusive lower moves on to the next value", %{int: int} do
+      assert %Range{lower: 2, upper: 5, bounds: :"[)"} =
+               cast!(%Range{lower: 1, upper: 5, bounds: :"()"}, int)
+    end
+
+    test "both bounds move where both are non-canonical", %{int: int} do
+      assert %Range{lower: 2, upper: 6, bounds: :"[)"} =
+               cast!(%Range{lower: 1, upper: 5, bounds: :"(]"}, int)
+    end
+
+    test "a range already in canonical form is unchanged", %{int: int} do
+      assert %Range{lower: 1, upper: 5, bounds: :"[)"} =
+               cast!(%Range{lower: 1, upper: 5, bounds: :"[)"}, int)
+    end
+
+    test "spellings of the same set cast to one value", %{int: int} do
+      assert cast!(%Range{lower: 1, upper: 5, bounds: :"[]"}, int) ==
+               cast!(%Range{lower: 1, upper: 6, bounds: :"[)"}, int)
+    end
+
+    test "a single point keeps its point", %{int: int} do
+      assert %Range{lower: 5, upper: 6, bounds: :"[)"} =
+               cast!(%Range{lower: 5, upper: 5, bounds: :"[]"}, int)
+    end
+
+    test "bounds with no value between them are empty", %{int: int} do
+      assert %Range{empty?: true} = cast!(%Range{lower: 1, upper: 2, bounds: :"()"}, int)
+    end
+
+    test "an unbounded end is exclusive", %{int: int} do
+      assert %Range{lower: nil, upper: 6, bounds: :"()"} =
+               cast!(%Range{lower: nil, upper: 5, bounds: :"[]"}, int)
+
+      assert %Range{lower: 1, upper: nil, bounds: :"[)"} =
+               cast!(%Range{lower: 1, upper: nil, bounds: :"[]"}, int)
+    end
+
+    test "dates canonicalise by day", %{date: date} do
+      assert %Range{lower: ~D[2026-01-01], upper: ~D[2026-01-09], bounds: :"[)"} =
+               cast!(%Range{lower: ~D[2026-01-01], upper: ~D[2026-01-08], bounds: :"[]"}, date)
+    end
+
+    test "a lower bound above its upper is left for apply_constraints to reject", %{int: int} do
+      range = cast!(%Range{lower: 5, upper: 1, bounds: :"[]"}, int)
+
+      assert %Range{lower: 5, upper: 1, bounds: :"[]"} = range
+      assert {:error, _} = Ash.Type.apply_constraints(Ash.Type.Range, range, int)
+    end
+
+    test "a continuous inner type is left as written" do
+      assert %Range{lower: @lower, upper: @upper, bounds: :"[]"} =
+               cast!(%Range{lower: @lower, upper: @upper, bounds: :"[]"}, @constraints)
+    end
+
+    test "canonicalisation applies on the way out of storage too", %{int: int} do
+      assert {:ok, %Range{lower: 1, upper: 6, bounds: :"[)"}} =
+               Ash.Type.cast_stored(
+                 Ash.Type.Range,
+                 %Range{lower: 1, upper: 5, bounds: :"[]"},
+                 int
+               )
+    end
+
+    test "apply_constraints canonicalises a value that skipped casting", %{int: int} do
+      assert {:ok, %Range{lower: 1, upper: 6, bounds: :"[)"}} =
+               Ash.Type.apply_constraints(
+                 Ash.Type.Range,
+                 %Range{lower: 1, upper: 5, bounds: :"[]"},
+                 int
+               )
+    end
+  end
+
   describe "empty ranges" do
     test "a range admitting no points casts to the empty range" do
       assert {:ok, %Range{empty?: true, lower: nil, upper: nil}} =


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Closes #2859

Requires ash-project/ash#2858 for compilation and correctness.

The commit `fix: canonicalize the bounds of a discrete range` includes:
* `:integer` and `:date` ranges cast to `[)`: an exclusive lower and an inclusive upper each move to the next value, and an unbounded end is exclusive. Continuous inner types are unchanged.
* the shift can result in an empty range : `(1,2)` on integers becomes `[2,2)`, which  is  canonical empty range: `Ash.Range.empty/0`, flagged `empty?: true`, which Postgres renders as `empty`
* an inverted range is left as written, for `apply_constraints/2` to reject as before.
* `apply_constraints/2` canonicalises too, so a value that skipped casting still normalises.
