### PR TITLE
feat: add range predicate adjacent

### DIFF
--- a/lib/ash/range.ex
+++ b/lib/ash/range.ex
@@ -166,6 +166,26 @@ defmodule Ash.Range do
     end
   end
 
+  @doc """
+  Whether two ranges are adjacent: one ends exactly where the other begins, with no
+  point between them and none shared.
+
+  The seam counts only when exactly one side includes it, so `[1,5)` is adjacent to
+  `[5,9)`, where `[1,5]` overlaps it and `(5,9)` leaves a gap. Symmetric, unlike
+  Allen's *meets*, which is directional. An empty range is adjacent to nothing.
+
+  Adjacency is what lets a series of ranges tile: each meets the next, covering
+  everything between the first lower bound and the last upper without overlapping.
+
+  For a discrete inner type this is a question about the canonical form — `[1,4]` and
+  `[5,9)` are adjacent as integers but not as decimals — so compare values that have
+  been through `Ash.Type.Range`, which canonicalises them. Matches Postgres `-|-`.
+  """
+  @spec adjacent?(t(), t()) :: boolean()
+  def adjacent?(%__MODULE__{} = left, %__MODULE__{} = right) do
+    relation(left, right) in [:meets, :met_by]
+  end
+
   # Seam clauses first, holding whatever the bounds compare to; then canonical order.
   defp allen(_lower, _upper, :lt, _), do: :precedes
   defp allen(_lower, _upper, :eq, _), do: :meets

--- a/test/type/range_test.exs
+++ b/test/type/range_test.exs
@@ -213,6 +213,60 @@ defmodule Ash.Type.RangeTest do
     end
   end
 
+  describe "adjacent?/2" do
+    # Cross-checked against Postgres 19: `-|-` on numrange and int4range agrees case
+    # for case, canonical form included.
+    defp adj(lower, upper, bounds), do: %Range{lower: lower, upper: upper, bounds: bounds}
+
+    test "one ends where the other begins, with exactly one side including the seam" do
+      assert Range.adjacent?(adj(1, 5, :"[)"), adj(5, 9, :"[)"))
+      assert Range.adjacent?(adj(1, 5, :"()"), adj(5, 9, :"[)"))
+      assert Range.adjacent?(adj(1, 5, :"[)"), adj(5, 9, :"[]"))
+    end
+
+    test "sharing the seam is overlap, and excluding it from both leaves a gap" do
+      refute Range.adjacent?(adj(1, 5, :"[]"), adj(5, 9, :"[)"))
+      refute Range.adjacent?(adj(1, 5, :"()"), adj(5, 9, :"()"))
+      refute Range.adjacent?(adj(1, 5, :"[)"), adj(6, 9, :"[)"))
+    end
+
+    test "is symmetric, where Allen's meets is directional" do
+      left = adj(1, 5, :"[)")
+      right = adj(5, 9, :"[)")
+
+      assert Range.relation(left, right) == :meets
+      assert Range.relation(right, left) == :met_by
+      assert Range.adjacent?(left, right)
+      assert Range.adjacent?(right, left)
+    end
+
+    test "an empty range is adjacent to nothing, not even itself" do
+      refute Range.adjacent?(Range.empty(), adj(1, 9, :"[)"))
+      refute Range.adjacent?(adj(1, 9, :"[)"), Range.empty())
+      refute Range.adjacent?(Range.empty(), Range.empty())
+    end
+
+    test "a discrete inner type answers on the canonical form" do
+      {:ok, constraints} = Ash.Type.init(Ash.Type.Range, inner_type: :integer)
+      {:ok, left} = Ash.Type.cast_input(Ash.Type.Range, adj(1, 4, :"[]"), constraints)
+      {:ok, right} = Ash.Type.cast_input(Ash.Type.Range, adj(5, 9, :"[)"), constraints)
+
+      assert {left.lower, left.upper, left.bounds} == {1, 5, :"[)"}
+      assert Range.adjacent?(left, right)
+      refute Range.adjacent?(adj(1, 4, :"[]"), adj(5, 9, :"[)"))
+    end
+
+    test "adjacent ranges tile, covering everything between without overlapping" do
+      tiles = [adj(1, 5, :"[)"), adj(5, 9, :"[)"), adj(9, 13, :"[)")]
+
+      assert tiles
+             |> Enum.chunk_every(2, 1, :discard)
+             |> Enum.all?(fn [a, b] ->
+               Range.adjacent?(a, b)
+             end)
+    end
+  end
+
   describe "ordering" do
     # Expectations are Postgres's own answers, on `numrange` so canonicalization
     # doesn't rewrite the bounds first.


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Closes #2871 

There is one commit, it adds `Ash.Range.adjacent?/2`.

Two ranges are adjacent when one ends where the other begins and the seam belongs to exactly one of them. This is symmetric, unlike Allen's `meets`. Matches Postgres `-|-`.
