### PR TITLE
fix: canonicalize a discrete range emptied by its own bounds

### DIFF
--- a/lib/ash/type/range.ex
+++ b/lib/ash/type/range.ex
@@ -239,10 +239,16 @@ defmodule Ash.Type.Range do
   # range read one back. An inverted range is invalid rather than empty, so it is left.
   defp canonicalize(%Range{empty?: true}, _constraints), do: Range.empty()
 
+  # The discrete shift can both hide and create emptiness, so both sides are tested. An
+  # inverted range is empty by neither, and falls through to check_order/2.
   defp canonicalize(%Range{} = range, constraints) do
-    range = discrete_bounds(range, constraints[:inner_type])
+    if empty_bounds?(range) do
+      Range.empty()
+    else
+      shifted = discrete_bounds(range, constraints[:inner_type])
 
-    if empty_bounds?(range), do: Range.empty(), else: range
+      if empty_bounds?(shifted), do: Range.empty(), else: shifted
+    end
   end
 
   defp empty_bounds?(%Range{lower: lower, upper: upper, bounds: bounds})

--- a/test/type/range_test.exs
+++ b/test/type/range_test.exs
@@ -364,6 +364,44 @@ defmodule Ash.Type.RangeTest do
   end
 
   describe "empty ranges" do
+    test "a discrete range on one point is empty unless both bounds include it" do
+      {:ok, constraints} = Ash.Type.init(Ash.Type.Range, inner_type: :integer)
+
+      cast = fn bounds ->
+        {:ok, cast} =
+          Ash.Type.cast_input(
+            Ash.Type.Range,
+            %Range{lower: 5, upper: 5, bounds: bounds},
+            constraints
+          )
+
+        cast
+      end
+
+      # Excluding either end leaves no points. Canonicalizing must see that before the
+      # discrete shift, which would otherwise turn `(5, 5)` into `[6, 5)` and lose the
+      # equality the rule tests. Postgres agrees on all four.
+      assert cast.(:"[)") == Range.empty()
+      assert cast.(:"(]") == Range.empty()
+      assert cast.(:"()") == Range.empty()
+
+      # Including both ends holds the point, so it is the single-point range.
+      assert cast.(:"[]") == %Range{lower: 5, upper: 6, bounds: :"[)"}
+    end
+
+    test "an inverted range is still refused, as Postgres refuses it" do
+      {:ok, constraints} = Ash.Type.init(Ash.Type.Range, inner_type: :integer)
+
+      {:ok, cast} =
+        Ash.Type.cast_input(
+          Ash.Type.Range,
+          %Range{lower: 9, upper: 2, bounds: :"[)"},
+          constraints
+        )
+
+      assert {:error, _} = Ash.Type.apply_constraints(Ash.Type.Range, cast, constraints)
+    end
+
     test "a range admitting no points casts to the empty range" do
       assert {:ok, %Range{empty?: true, lower: nil, upper: nil}} =
                Ash.Type.cast_input(


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Closes #2873 

` canonicalize/2` ran the discrete shift before testing emptiness, so `(5, 5)` became `[6, 5)` and no longer had the equal bounds the rule looks for.

Emptiness is now asked on both sides of the shift: `(5, 5)` is empty before it, `(1, 2)` over integers only after it, having become `[2, 2)`. The rule tests equal bounds, so an inverted range answers to neither and is still left for `check_order/2` to refuse. This matches Postgres, which rejects `'[9,2)'::int4range`.

The test pins all four ways of writing a range on one point: `[5,5)`, `(5,5]` and `(5,5)` are empty, `[5,5]` is `[5,6)` because it holds the point.