### PR TITLE
docs: point range_overlaps at the predicate it answers

### DIFF
--- a/lib/ash/query/function/range_overlaps.ex
+++ b/lib/ash/query/function/range_overlaps.ex
@@ -6,8 +6,9 @@ defmodule Ash.Query.Function.RangeOverlaps do
   @moduledoc """
   Returns true if two ranges overlap (share at least one point).
 
-  Maps to the Postgres range overlap operator `&&`. Used, among other things, to
-  relate two temporal resources (`range_overlaps(parent(valid_at), valid_at)`).
+  Maps to the Postgres range overlap operator `&&`, and answers in an expression what
+  `Ash.Range.intersects?/2` answers at runtime. Used, among other things, to relate
+  two temporal resources (`range_overlaps(parent(valid_at), valid_at)`).
 
      range_overlaps(range1, range2)
   """


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

`Ash.Range.intersects?/2` explains that `range_overlaps/2` keeps Postgres's name for `&&`, but nothing points back. Someone who learns the predicate and writes `range_intersects/2` gets no function and no signpost.

Naming an alias `range_intersects/2` was the alternative, rejected: one operator, two expression names.