### PR TITLE
fix: avoid unnecessary compile dependencies for runtime DSL modules

### DIFF
--- a/lib/ash/notifier/pub_sub/pub_sub.ex
+++ b/lib/ash/notifier/pub_sub/pub_sub.ex
@@ -8,6 +8,7 @@ defmodule Ash.Notifier.PubSub do
   @publish %Spark.Dsl.Entity{
     name: :publish,
     target: Ash.Notifier.PubSub.Publication,
+    no_depend_modules: [:dispatcher],
     transform: {Ash.Notifier.PubSub.Publication, :transform, []},
     describe: "Configure a given action to publish its results over a given topic.",
     examples: [
@@ -24,6 +25,7 @@ defmodule Ash.Notifier.PubSub do
   @publish_all %Spark.Dsl.Entity{
     name: :publish_all,
     target: Ash.Notifier.PubSub.Publication,
+    no_depend_modules: [:dispatcher],
     transform: {Ash.Notifier.PubSub.Publication, :transform, []},
     describe: """
     Works the same as `publish`, except that it takes a type and publishes all actions of that type.

--- a/lib/ash/reactor/dsl/action_transformer.ex
+++ b/lib/ash/reactor/dsl/action_transformer.ex
@@ -98,20 +98,20 @@ defmodule Ash.Reactor.Dsl.ActionTransformer do
   end
 
   defp validate_entity_domain(entity, dsl_state) do
-    cond do
-      is_nil(entity.domain) ->
-        {:error,
-         DslError.exception(
-           module: Transformer.get_persisted(dsl_state, :module),
-           path: [:reactor, entity.type, entity.name],
-           message:
-             "The #{entity.type} step `#{inspect(entity.name)}` has no domain. Set one on the step, on the resource, or as the `default_domain` in the `ash` section."
-         )}
+    if is_nil(entity.domain) do
+      {:error,
+       DslError.exception(
+         module: Transformer.get_persisted(dsl_state, :module),
+         path: [:reactor, entity.type, entity.name],
+         message:
+           "The #{entity.type} step `#{inspect(entity.name)}` has no domain. Set one on the step, on the resource, or as the `default_domain` in the `ash` section."
+       )}
+    else
+      Code.ensure_compiled(entity.domain)
 
-      entity.domain.spark_is() == Domain ->
+      if entity.domain.spark_is() == Domain do
         :ok
-
-      true ->
+      else
         {:error,
          DslError.exception(
            module: Transformer.get_persisted(dsl_state, :module),
@@ -119,6 +119,7 @@ defmodule Ash.Reactor.Dsl.ActionTransformer do
            message:
              "The #{entity.type} step `#{inspect(entity.name)}` has its domain set to `#{inspect(entity.domain)}` but it is not a valid `Ash.Domain`."
          )}
+      end
     end
   end
 

--- a/lib/ash/reactor/reactor.ex
+++ b/lib/ash/reactor/reactor.ex
@@ -14,6 +14,7 @@ defmodule Ash.Reactor do
   @ash %Spark.Dsl.Section{
     name: :ash,
     describe: "Ash-related configuration for the `Ash.Reactor` extension",
+    no_depend_modules: [:default_domain],
     schema: [
       default_domain: [
         type: {:behaviour, Ash.Domain},

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -623,7 +623,7 @@ defmodule Ash.Resource.Dsl do
       Ash.Expr
     ],
     target: Ash.Resource.Actions.Action,
-    no_depend_modules: [:touches_resources, :run, :error_handler],
+    no_depend_modules: [:touches_resources, :error_handler],
     schema: Ash.Resource.Actions.Action.opt_schema(),
     transform: {Ash.Resource.Actions.Action, :transform, []},
     entities: [

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -562,7 +562,7 @@ defmodule Ash.Resource.Dsl do
     ],
     target: Ash.Resource.Actions.Create,
     schema: Ash.Resource.Actions.Create.opt_schema(),
-    no_depend_modules: [:manual, :touches_resources],
+    no_depend_modules: [:manual, :touches_resources, :error_handler, :notifiers],
     deprecations: [
       manual?: "Use the `manual` option instead, and provide an implementation."
     ],
@@ -623,6 +623,7 @@ defmodule Ash.Resource.Dsl do
       Ash.Expr
     ],
     target: Ash.Resource.Actions.Action,
+    no_depend_modules: [:touches_resources, :run, :error_handler],
     schema: Ash.Resource.Actions.Action.opt_schema(),
     transform: {Ash.Resource.Actions.Action, :transform, []},
     entities: [
@@ -674,7 +675,7 @@ defmodule Ash.Resource.Dsl do
     target: Ash.Resource.Actions.Read,
     schema: Ash.Resource.Actions.Read.opt_schema(),
     transform: {Ash.Resource.Actions.Read, :transform, []},
-    no_depend_modules: [:touches_resources, :manual],
+    no_depend_modules: [:touches_resources, :manual, :modify_query],
     entities: [
       arguments: [
         @action_argument
@@ -732,7 +733,7 @@ defmodule Ash.Resource.Dsl do
     deprecations: [
       manual?: "Use the `manual` option instead, and provide an implementation."
     ],
-    no_depend_modules: [:touches_resources, :manual],
+    no_depend_modules: [:touches_resources, :manual, :error_handler, :notifiers],
     target: Ash.Resource.Actions.Update,
     schema: Ash.Resource.Actions.Update.opt_schema(),
     transform: {Ash.Resource.Actions.Update, :transform, []},
@@ -761,7 +762,7 @@ defmodule Ash.Resource.Dsl do
     deprecations: [
       manual?: "Use the `manual` option instead, and provide an implementation."
     ],
-    no_depend_modules: [:touches_resources, :manual],
+    no_depend_modules: [:touches_resources, :manual, :error_handler, :notifiers],
     entities: [
       changes: [
         @action_change,
@@ -1441,6 +1442,7 @@ defmodule Ash.Resource.Dsl do
 
   @exists %Spark.Dsl.Entity{
     name: :exists,
+    no_depend_modules: [:relationship_path],
     describe: """
     Declares a named `exists` aggregate on the resource
 
@@ -1482,6 +1484,7 @@ defmodule Ash.Resource.Dsl do
       """
     ],
     target: Ash.Resource.Aggregate,
+    no_depend_modules: [:implementation],
     args: [:name, :relationship_path, :type],
     entities: [
       join_filters: [@join_filter]
@@ -1673,6 +1676,7 @@ defmodule Ash.Resource.Dsl do
 
   @multitenancy %Spark.Dsl.Section{
     name: :multitenancy,
+    no_depend_modules: [:parse_attribute, :tenant_from_attribute],
     describe: """
     Options for configuring the multitenancy behavior of a resource.
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Several Ash DSL fields contain module references that are stored and used at runtime, but were not included in `no_depend_modules`.

As a result, normal module aliases in those fields could create compile dependencies from the resource to runtime callback modules.

This adds the missing `no_depend_modules` declarations for:

- generic action `error_handler` and `touches_resources`
- create, update, and destroy `error_handler` and `notifiers`
- read action `modify_query`
- multitenancy `parse_attribute` and `tenant_from_attribute` callbacks
- custom aggregate `implementation`
- unrelated `exists` aggregate resources
- PubSub publication `dispatcher`
- Reactor `default_domain`

These fields either store module identities or invoke their callbacks at runtime. Their implementations are not used to produce compile-time resource state, so changes to those modules should not require recompiling the resource.

`default_domain` is explicitly ensured compiled before its existing `Ash.Domain` validation so clean parallel compilation does not depend on file ordering.

Fields that are consumed at compile time, including type constraints and aggregate target fields used to derive metadata, intentionally retain their compile dependencies.

# Validation

- Audited each affected field from its DSL declaration through its transformer, verifier, generated state, and runtime consumer
- Verified the full Ash test suite

This pull request was developed with AI assistance and reviewed by the submitter.