### PR TITLE
fix: retain compile dependencies for policy check modules

### DIFF
--- a/lib/ash/policy/authorizer/authorizer.ex
+++ b/lib/ash/policy/authorizer/authorizer.ex
@@ -74,7 +74,6 @@ defmodule Ash.Policy.Authorizer do
     describe: "If the check is true, the request is authorized, otherwise run remaining checks.",
     args: [:check],
     schema: @check_schema,
-    no_depend_modules: [:check],
     examples: [
       "authorize_if logged_in()",
       "authorize_if actor_attribute_matches_record(:group, :group)"
@@ -93,7 +92,6 @@ defmodule Ash.Policy.Authorizer do
     schema: @check_schema,
     target: Ash.Policy.Check,
     transform: {Ash.Policy.Check, :transform, []},
-    no_depend_modules: [:check],
     examples: [
       "forbid_if not_logged_in()",
       "forbid_if actor_attribute_matches_record(:group, :blacklisted_groups)"
@@ -110,7 +108,6 @@ defmodule Ash.Policy.Authorizer do
     schema: @check_schema,
     target: Ash.Policy.Check,
     transform: {Ash.Policy.Check, :transform, []},
-    no_depend_modules: [:check],
     examples: [
       "authorize_unless not_logged_in()",
       "authorize_unless actor_attribute_matches_record(:group, :blacklisted_groups)"
@@ -126,7 +123,6 @@ defmodule Ash.Policy.Authorizer do
     args: [:check],
     schema: @check_schema,
     target: Ash.Policy.Check,
-    no_depend_modules: [:check],
     transform: {Ash.Policy.Check, :transform, []},
     examples: [
       "forbid_unless logged_in()",


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Policy check modules used by `authorize_if`, `authorize_unless`, `forbid_if`,
and `forbid_unless` were included in `no_depend_modules`.

However, policy check modules are consumed at compile time. During the DSL
transform, Ash calls the check module's `init/1` callback and stores the
normalized options in the compiled policy state.

Without a compile dependency, changing a check module's `init/1`
implementation may leave a resource with stale normalized options until the
resource is otherwise recompiled. This can also prevent updated option
validation from running.

This removes `check` from `no_depend_modules` for the four shared policy check
entities, restoring the required compile dependency.

Policy and policy-group conditions retain their existing
`no_depend_modules` declarations. Conditions are stored as module references
and evaluated at runtime; their callbacks are not used to generate compiled
policy state.

# Validation

- Verified that policy check `init/1` is invoked during the DSL transform and
  that its normalized options are stored in the compiled policy state
- Verified that policy conditions do not invoke check initialization during
  the DSL transform
- Verified the full Ash test suite

This pull request was developed with AI assistance and reviewed by the
submitter.
