### PR TITLE
fix: restore temporal subtraction type inference

### DIFF
--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -1526,6 +1526,7 @@ defmodule Ash.Expr do
       end
     end)
     |> Enum.filter(& &1)
+    |> prefer_known_result(known_result)
     |> case do
       [{types, returns, _, _}] ->
         {types, returns}
@@ -1541,6 +1542,18 @@ defmodule Ash.Expr do
           end)
 
         select_matches(types, length(values), values)
+    end
+  end
+
+  defp prefer_known_result(matches, nil), do: matches
+
+  defp prefer_known_result(matches, {known_type, _}) do
+    case Enum.filter(matches, fn
+           {_, {return_type, _}, _, _} -> return_type == known_type
+           _ -> false
+         end) do
+      [] -> matches
+      matching -> matching
     end
   end
 

--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -66,23 +66,37 @@ defmodule Ash.Query.Operator.Basic do
         [:same, :any],
         [:duration, :duration],
         [:date, :duration],
+        [:date, :date],
         [:datetime, :duration],
+        [:datetime, :datetime],
         [:utc_datetime, :duration],
+        [:utc_datetime, :utc_datetime],
         [:utc_datetime_usec, :duration],
+        [:utc_datetime_usec, :utc_datetime_usec],
         [:naive_datetime, :duration],
+        [:naive_datetime, :naive_datetime],
         [:time, :duration],
-        [:time_usec, :duration]
+        [:time, :time],
+        [:time_usec, :duration],
+        [:time_usec, :time_usec]
       ],
       returns: [
         :same,
         :duration,
         :date,
+        :integer,
         :datetime,
+        :integer,
         :utc_datetime,
+        :integer,
         :utc_datetime_usec,
+        :integer,
         :naive_datetime,
+        :integer,
         :time,
-        :time_usec
+        :integer,
+        :time_usec,
+        :integer
       ]
     ],
     div: [

--- a/test/type/duration_test.exs
+++ b/test/type/duration_test.exs
@@ -816,11 +816,11 @@ defmodule Ash.Test.Type.DurationTest do
       {:time_usec, Ash.Type.TimeUsec}
     ]
 
-    defp operand_types(expression) do
+    defp operand_types(expression, known_result \\ nil) do
       {:ok, %op{} = hydrated} = Ash.Filter.hydrate_refs(expression, %{resource: Post})
 
       {[{left, _}, {right, _}], {returns, _}} =
-        Ash.Expr.determine_types(op, [hydrated.left, hydrated.right])
+        Ash.Expr.determine_types(op, [hydrated.left, hydrated.right], known_result)
 
       {left, right, returns}
     end
@@ -837,6 +837,27 @@ defmodule Ash.Test.Type.DurationTest do
         assert {^type, Ash.Type.Duration, ^type} =
                  operand_types(expr(^ref(field) - ^Duration.new!(day: 1)))
       end
+    end
+
+    test "subtracting two temporal values of the same type returns an integer" do
+      for {field, type} <- @temporal_fields do
+        assert {^type, ^type, Ash.Type.Integer} =
+                 operand_types(expr(^ref(field) - ^ref(field)))
+      end
+    end
+
+    test "the known result disambiguates a lazy date from a lazy duration" do
+      assert {Ash.Type.Date, Ash.Type.Date, Ash.Type.Integer} =
+               operand_types(
+                 expr(^ref(:date) - lazy({Date, :utc_today, []})),
+                 Ash.Type.Integer
+               )
+
+      assert {Ash.Type.Date, Ash.Type.Duration, Ash.Type.Date} =
+               operand_types(
+                 expr(^ref(:date) - lazy({Duration, :new!, [[day: 1]]})),
+                 Ash.Type.Date
+               )
     end
 
     test "a duration on the left of an addition is kept too" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

The temporal-duration signatures added in #2852 left same-type temporal subtraction undeclared.

The runtime evaluator already supports operations such as `Date.diff/2`, but type resolution reports `date - date` as returning `date`. An untyped `lazy/1` operand can also select the `date - duration` signature even when the surrounding calculation expects an integer, causing SQL data layers to reject the resulting date value.

This change:

- declares same-type temporal subtraction as returning an integer;
- prefers signatures matching the known result type when operands are otherwise ambiguous;
- preserves temporal-duration subtraction behavior.

Regression tests cover all supported temporal types and distinguish a lazy date from a lazy duration using the known calculation result.

Verified with the full Ash test suite (3,971 passing) and the original failing expression in an AshPostgres application without a SQL fragment workaround.

This PR description was drafted with AI assistance and reviewed before submission.
