### PR TITLE
fix: string_position returns an integer position

### DIFF
--- a/lib/ash/query/function/string_position.ex
+++ b/lib/ash/query/function/string_position.ex
@@ -29,7 +29,7 @@ defmodule Ash.Query.Function.StringPosition do
       [:ci_string, :ci_string]
     ]
 
-  def returns, do: [:string, :ci_string, :ci_string, :ci_string]
+  def returns, do: [:integer, :integer, :integer, :integer]
 
   def evaluate(%{arguments: [nil, _]}), do: {:known, nil}
   def evaluate(%{arguments: [_, nil]}), do: {:known, nil}

--- a/test/query/function/string_position_test.exs
+++ b/test/query/function/string_position_test.exs
@@ -7,6 +7,9 @@ defmodule Ash.Query.Function.StringPositionTest do
 
   import Ash.Expr
 
+  alias Ash.Query.Function.StringPosition
+  alias Ash.Query.Operator.GreaterThan
+
   test "string_position is zero based" do
     assert 0 = eval!(expr(string_position("foo-bar", "foo")))
   end
@@ -32,5 +35,25 @@ defmodule Ash.Query.Function.StringPositionTest do
              eval!(
                expr(string_position(^%Ash.CiString{string: "FOO"}, ^%Ash.CiString{string: "oo"}))
              )
+  end
+
+  test "string_position returns an integer" do
+    assert {_, {Ash.Type.Integer, []}} =
+             Ash.Expr.determine_types(StringPosition, ["foo-bar", "foo"])
+  end
+
+  test "string_position of case insensitive strings returns an integer" do
+    assert {_, {Ash.Type.Integer, []}} =
+             Ash.Expr.determine_types(StringPosition, [
+               %Ash.CiString{string: "FOO"},
+               %Ash.CiString{string: "oo"}
+             ])
+  end
+
+  test "comparing string_position resolves integer operands" do
+    {:ok, position} = StringPosition.new(["foo-bar", "foo"])
+
+    assert {[{Ash.Type.Integer, []}, {Ash.Type.Integer, []}], _} =
+             Ash.Expr.determine_types(GreaterThan, [position, 9])
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2890 

`StringPosition.returns/0` declared `[:string, :ci_string, :ci_string, :ci_string]`. It now declares integers, so comparing a `string_position` against an integer resolves both operands to `Ash.Type.Integer`.

Additional ash_postgres tests will be contributed.