### PR TITLE
fix: evaluate decimal arithmetic with an integer

### DIFF
--- a/lib/ash/query/operator/basic.ex
+++ b/lib/ash/query/operator/basic.ex
@@ -269,7 +269,8 @@ defmodule Ash.Query.Operator.Basic do
         end
 
         defp do_evaluate(op, left, right)
-             when Decimal.is_decimal(left) and Decimal.is_decimal(right) do
+             when (Decimal.is_decimal(left) and (Decimal.is_decimal(right) or is_number(right))) or
+                    (Decimal.is_decimal(right) and is_number(left)) do
           case op do
             :+ -> {:known, Decimal.add(to_decimal(left), to_decimal(right))}
             :* -> {:known, Decimal.mult(to_decimal(left), to_decimal(right))}

--- a/test/type/decimal_test.exs
+++ b/test/type/decimal_test.exs
@@ -124,6 +124,51 @@ defmodule Ash.Test.Type.DecimalTest do
     end
   end
 
+  describe "arithmetic" do
+    test "a decimal multiplies by an integer in either operand order" do
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(^Decimal.new("10.50") * 2)),
+               Decimal.new("21.00")
+             )
+
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(2 * ^Decimal.new("10.50"))),
+               Decimal.new("21.00")
+             )
+    end
+
+    test "a decimal adds, subtracts and divides an integer" do
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(^Decimal.new("10.50") + 1)),
+               Decimal.new("11.50")
+             )
+
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(^Decimal.new("10.50") - 1)),
+               Decimal.new("9.50")
+             )
+
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(^Decimal.new("10.50") / 2)),
+               Decimal.new("5.25")
+             )
+    end
+
+    test "a decimal multiplies by a float" do
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(^Decimal.new("10.50") * 2.0)),
+               Decimal.new("21.00")
+             )
+    end
+
+    test "a decimal multiplies by a decimal" do
+      assert Comp.equal?(
+               Ash.Expr.eval!(Ash.Expr.expr(^Decimal.new("10.50") * ^Decimal.new(2))),
+               Decimal.new("21.00")
+             )
+    end
+  end
+
   test "pass with valid precision constraint" do
     valid_attrs = @valid_attrs |> Map.put(:precise_amount, 1.23)
 


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes #2891

The arithmetic clause in `Ash.Query.Operator.Basic` was guarded on `Decimal.is_decimal(left) and Decimal.is_decimal(right)`. `is_number/1` is now also used.