### PR TITLE
feat: establish a record's period on create in the ETS data layer

### DIFF
--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1507,6 +1507,7 @@ defmodule Ash.DataLayer.Ets do
       |> resource_to_query(changeset.domain)
       |> Map.put(:filter, query.filter)
       |> Map.put(:tenant, changeset.tenant)
+      |> Map.put(:as_of, upsert_instant(resource, changeset))
       |> run_query(resource)
       |> case do
         {:ok, []} ->
@@ -1531,7 +1532,7 @@ defmodule Ash.DataLayer.Ets do
             resource
             |> update(
               %{changeset | action_type: :update, filter: nil},
-              Map.take(result, pkey),
+              pkey_map(resource, result),
               from_bulk_create?
             )
             |> set_upsert_action(:update)
@@ -1673,15 +1674,24 @@ defmodule Ash.DataLayer.Ets do
     else
       with {:ok, table} <- wrap_or_create_table(resource, options.tenant) do
         Enum.reduce_while(stream, {:ok, []}, fn changeset, {:ok, results} ->
-          with {:ok, pkey} <- get_valid_pkey(resource, changeset),
+          with :ok <- validate_pkey(resource, changeset),
                {:ok, record} <- Ash.Changeset.apply_attributes(changeset),
                {:ok, record} <- apply_atomics(changeset, resource, record),
-               record <- unload_relationships(resource, record) do
+               {:ok, record} <- establish_period(record, resource, changeset),
+               record <- unload_relationships(resource, record),
+               :ok <- check_non_empty(resource, record),
+               :ok <-
+                 check_non_overlapping(
+                   table,
+                   resource,
+                   record,
+                   Enum.map(results, fn {key, _index, _ref, _record} -> key end)
+                 ) do
             {:cont,
              {:ok,
               [
-                {pkey, changeset.context.bulk_create.index, changeset.context.bulk_create.ref,
-                 record}
+                {pkey_map(resource, record), changeset.context.bulk_create.index,
+                 changeset.context.bulk_create.ref, record}
                 | results
               ]}}
           else
@@ -1716,13 +1726,17 @@ defmodule Ash.DataLayer.Ets do
   @doc false
   @impl true
   def create(resource, changeset, from_bulk_create? \\ false) do
-    with {:ok, pkey} <- get_valid_pkey(resource, changeset),
+    with :ok <- validate_pkey(resource, changeset),
          {:ok, table} <- wrap_or_create_table(resource, changeset.tenant),
          _ <- if(!from_bulk_create?, do: log_create(resource, changeset)),
          {:ok, record} <- Ash.Changeset.apply_attributes(changeset),
          {:ok, record} <- apply_atomics(changeset, resource, record),
+         {:ok, record} <- establish_period(record, resource, changeset),
          record <- unload_relationships(resource, record),
-         {:ok, record} <- put_or_insert_new(table, {pkey, record}, resource) do
+         :ok <- check_non_empty(resource, record),
+         :ok <- check_non_overlapping(table, resource, record),
+         {:ok, record} <-
+           put_or_insert_new(table, {pkey_map(resource, record), record}, resource) do
       {:ok, set_loaded(record)}
     else
       {:error, error} -> {:error, error}
@@ -1741,6 +1755,136 @@ defmodule Ash.DataLayer.Ets do
   end
 
   defp apply_atomics(_changeset, _resource, record), do: {:ok, record}
+
+  # The instant is this layer's: a core `now()` resolved earlier could precede the record.
+  defp establish_period(record, resource, changeset) do
+    case Ash.Resource.Info.temporal_attribute(resource) do
+      nil ->
+        {:ok, record}
+
+      attribute ->
+        {:ok,
+         put_established_period(
+           record,
+           attribute,
+           Map.get(record, attribute),
+           resource,
+           changeset
+         )}
+    end
+  end
+
+  defp check_non_empty(resource, record) do
+    with period when not is_nil(period) <- Ash.Resource.Info.temporal_attribute(resource),
+         %Ash.Range{} = value <- Map.get(record, period),
+         true <- Ash.Range.empty?(value) do
+      {:error,
+       Ash.Error.Changes.InvalidAttribute.exception(
+         field: period,
+         value: value,
+         message: "is empty, so the record could not be read at any point in time"
+       )}
+    else
+      _ -> :ok
+    end
+  end
+
+  # Not a lock: the look and the write are separate, so concurrent creates can both land.
+  defp check_non_overlapping(table, resource, record, pending \\ []) do
+    with period when not is_nil(period) <- Ash.Resource.Info.temporal_attribute(resource),
+         %Ash.Range{} = period_value <- Map.get(record, period),
+         {:ok, keys} <- stored_keys(table) do
+      primary_key = Map.take(record, Ash.Resource.Info.primary_key(resource))
+
+      if Enum.any?(keys ++ pending, &overlapping?(&1, primary_key, period, period_value)) do
+        {:error,
+         Ash.Error.Changes.InvalidAttribute.exception(
+           field: period,
+           value: period_value,
+           message: "overlaps the period of an existing version of this record"
+         )}
+      else
+        :ok
+      end
+    else
+      {:error, error} -> {:error, error}
+      _ -> :ok
+    end
+  end
+
+  defp overlapping?(key, primary_key, period, period_value) do
+    Map.take(key, Map.keys(primary_key)) == primary_key and
+      match?(%Ash.Range{}, Map.get(key, period)) and
+      Ash.Range.intersects?(Map.get(key, period), period_value)
+  end
+
+  defp stored_keys(table) do
+    case ETS.Set.to_list(table) do
+      {:ok, stored} -> {:ok, Enum.map(stored, fn {key, _data} -> key end)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp put_established_period(record, _attribute, %Ash.Range{}, _resource, _changeset), do: record
+
+  defp put_established_period(record, attribute, nil, resource, changeset) do
+    case write_instant(resource, changeset) do
+      {:ok, as_of} -> Map.put(record, attribute, %Ash.Range{lower: as_of})
+      :error -> record
+    end
+  end
+
+  defp put_established_period(record, _attribute, _other, _resource, _changeset), do: record
+
+  # Without an instant the query sees every version, not the one holding it.
+  defp upsert_instant(resource, changeset) do
+    case write_instant(resource, changeset) do
+      {:ok, instant} -> instant
+      :error -> nil
+    end
+  end
+
+  # Casting through the inner type settles precision: `:datetime` is second-resolution.
+  defp write_instant(resource, changeset) do
+    inner_type = Ash.Resource.Info.temporal_inner_type(resource)
+
+    with {:ok, raw} <- raw_instant(changeset, inner_type),
+         {:ok, instant} <-
+           Ash.Type.cast_input(
+             inner_type,
+             raw,
+             Ash.Resource.Info.temporal_inner_constraints(resource) || []
+           ) do
+      {:ok, instant}
+    else
+      _ -> :error
+    end
+  end
+
+  defp raw_instant(%{as_of: %DateTime{} = as_of}, _inner_type), do: {:ok, as_of}
+
+  defp raw_instant(%{as_of: as_of}, inner_type) when as_of in [nil, :now],
+    do: now_for(inner_type)
+
+  defp raw_instant(_changeset, _inner_type), do: :error
+
+  # Resolved through `get_type/1`: an inner type reads back as a module, and matching the
+  # short names alone silently answers `:error`.
+  defp now_for(inner_type) do
+    case Ash.Type.get_type(inner_type) do
+      type when type in [Ash.Type.DateTime, Ash.Type.UtcDatetime, Ash.Type.UtcDatetimeUsec] ->
+        {:ok, DateTime.utc_now()}
+
+      Ash.Type.NaiveDatetime ->
+        {:ok, NaiveDateTime.utc_now()}
+
+      Ash.Type.Date ->
+        {:ok, Date.utc_today()}
+
+      _ ->
+        :error
+    end
+  end
 
   defp set_loaded(%resource{} = record) do
     %{record | __meta__: %Ecto.Schema.Metadata{state: :loaded, schema: resource}}
@@ -1815,7 +1959,7 @@ defmodule Ash.DataLayer.Ets do
     end
   end
 
-  defp get_valid_pkey(resource, changeset) do
+  defp validate_pkey(resource, changeset) do
     pkey =
       resource
       |> Ash.Resource.Info.primary_key()
@@ -1826,7 +1970,7 @@ defmodule Ash.DataLayer.Ets do
     if !Enum.empty?(pkey) && Enum.any?(pkey, fn {_, v} -> is_nil(v) end) do
       {:error, InvalidPrimaryKey.exception(resource: resource, value: pkey)}
     else
-      {:ok, pkey}
+      :ok
     end
   end
 
@@ -1921,7 +2065,7 @@ defmodule Ash.DataLayer.Ets do
 
   defp do_destroy(resource, record, tenant, filter, domain, actor) do
     with {:ok, table} <- wrap_or_create_table(resource, tenant) do
-      pkey = Map.take(record, Ash.Resource.Info.primary_key(resource))
+      pkey = pkey_map(resource, record)
 
       if has_filter?(filter) do
         case ETS.Set.get(table, pkey) do
@@ -2077,10 +2221,19 @@ defmodule Ash.DataLayer.Ets do
   @doc false
   def pkey_map(resource, data) do
     resource
-    |> Ash.Resource.Info.primary_key()
+    |> key_fields()
     |> Enum.into(%{}, fn attr ->
       {attr, Map.get(data, attr)}
     end)
+  end
+
+  defp key_fields(resource) do
+    primary_key = Ash.Resource.Info.primary_key(resource)
+
+    case Ash.Resource.Info.temporal_attribute(resource) do
+      nil -> primary_key
+      period -> primary_key ++ [period]
+    end
   end
 
   defp do_update(

--- a/test/ash/data_layer/ets_temporal_test.exs
+++ b/test/ash/data_layer/ets_temporal_test.exs
@@ -60,11 +60,186 @@ defmodule Ash.DataLayer.EtsTemporalTest do
     end
   end
 
-  test "a record with no period is not returned for any instant" do
-    Ash.Seed.seed!(%EtsVersioned{id: 3, name: "undated"})
+  describe "a create establishes the record's period" do
+    test "from the write's instant, with no end" do
+      record = Ash.create!(EtsVersioned, %{id: 1, name: "a"}, as_of: ~U[2020-06-01 00:00:00Z])
 
-    assert [] = EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
-    assert [] = Ash.read!(EtsVersioned)
+      assert record.valid_at == %Ash.Range{
+               lower: ~U[2020-06-01 00:00:00Z],
+               upper: nil,
+               bounds: :"[)"
+             }
+    end
+
+    test "on this layer's clock when the write does not say when" do
+      before = DateTime.truncate(DateTime.utc_now(), :second)
+      record = Ash.create!(EtsVersioned, %{id: 1, name: "a"})
+
+      assert DateTime.compare(record.valid_at.lower, before) in [:eq, :gt]
+      refute record.valid_at.upper
+    end
+
+    test "and the record is readable at that instant, but not before it" do
+      Ash.create!(EtsVersioned, %{id: 1, name: "a"}, as_of: ~U[2020-06-01 00:00:00Z])
+
+      assert [%{name: "a"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+
+      assert [] = EtsVersioned |> Ash.Query.as_of(~U[2020-05-31 23:59:59Z]) |> Ash.read!()
+    end
+
+    test "leaving a period the caller wrote alone" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "a", valid_at: @early})
+
+      assert record.valid_at == @early
+    end
+
+    test "on the bulk path too" do
+      assert %Ash.BulkResult{records: [record]} =
+               Ash.bulk_create!([%{id: 1, name: "bulked"}], EtsVersioned, :create,
+                 return_records?: true
+               )
+
+      assert %Ash.Range{lower: %DateTime{}, upper: nil, bounds: :"[)"} = record.valid_at
+      assert [%{name: "bulked"}] = Ash.read!(EtsVersioned)
+    end
+  end
+
+  describe "the period is part of the storage key" do
+    test "and only on a temporal resource" do
+      record = %EtsVersioned{id: 1, name: "x", valid_at: @open}
+
+      assert Ash.DataLayer.Ets.pkey_map(EtsVersioned, record) == %{id: 1, valid_at: @open}
+
+      assert Ash.DataLayer.Ets.pkey_map(Ash.Test.Temporal.Thing, %{id: "abc", name: "y"}) ==
+               %{id: "abc"}
+    end
+
+    test "so one record can have several versions" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "open", valid_at: @open})
+
+      assert [%{name: "early"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+
+      assert [%{name: "open"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2026-06-01 00:00:00Z]) |> Ash.read!()
+    end
+
+    test "and a destroy removes the version it was given, not the record" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+      open = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "open", valid_at: @open})
+
+      Ash.destroy!(open)
+
+      assert [%{name: "early"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+
+      assert [] = EtsVersioned |> Ash.Query.as_of(~U[2026-06-01 00:00:00Z]) |> Ash.read!()
+    end
+
+    test "and an upsert conflicts with the version holding its instant, not with every version" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "open", valid_at: @open})
+
+      assert {:ok, upserted} =
+               Ash.create(EtsVersioned, %{id: 1, name: "later"},
+                 action: :upsert,
+                 as_of: ~U[2026-06-01 00:00:00Z]
+               )
+
+      assert upserted.name == "later"
+
+      assert [%{name: "early"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+    end
+  end
+
+  describe "versions of one record must not overlap" do
+    defp create_at(id, name, as_of) do
+      EtsVersioned
+      |> Ash.Changeset.for_create(:create, %{id: id, name: name})
+      |> Ash.Changeset.as_of(as_of)
+      |> Ash.create()
+    end
+
+    # Both open a period with no end, so the later holds every instant the earlier does.
+    test "a second open-ended version of one record is refused" do
+      assert {:ok, _} = create_at(1, "first", ~U[2020-01-01 00:00:00Z])
+
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Changes.InvalidAttribute{} = error]}} =
+               create_at(1, "second", ~U[2021-01-01 00:00:00Z])
+
+      assert error.field == :valid_at
+      assert error.message =~ "overlaps the period of an existing version"
+
+      assert [%{name: "first"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2021-06-01 00:00:00Z]) |> Ash.read!()
+    end
+
+    test "adjacent versions of one record are accepted, since they share no instant" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+
+      assert {:ok, _} = create_at(1, "later", ~U[2021-01-01 00:00:00Z])
+
+      assert [%{name: "early"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+
+      assert [%{name: "later"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2021-06-01 00:00:00Z]) |> Ash.read!()
+    end
+
+    test "another record's overlapping period is no concern of this one's" do
+      assert {:ok, _} = create_at(1, "one", ~U[2020-01-01 00:00:00Z])
+      assert {:ok, _} = create_at(2, "two", ~U[2020-01-01 00:00:00Z])
+    end
+
+    test "a bulk create must not overlap what is already stored" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "open", valid_at: @open})
+
+      assert %Ash.BulkResult{status: :error, errors: [error]} =
+               Ash.bulk_create([%{id: 1, name: "clash"}], EtsVersioned, :create,
+                 return_errors?: true
+               )
+
+      assert %Ash.Error.Invalid{errors: [%Ash.Error.Changes.InvalidAttribute{field: :valid_at}]} =
+               error
+    end
+
+    test "nor overlap its own earlier records" do
+      assert %Ash.BulkResult{status: :error, errors: [error]} =
+               Ash.bulk_create(
+                 [%{id: 1, name: "first"}, %{id: 1, name: "second"}],
+                 EtsVersioned,
+                 :create,
+                 return_errors?: true
+               )
+
+      assert %Ash.Error.Invalid{errors: [%Ash.Error.Changes.InvalidAttribute{field: :valid_at}]} =
+               error
+    end
+  end
+
+  describe "a period holding no instant" do
+    @empty %Ash.Range{
+      lower: ~U[2020-01-01 00:00:00Z],
+      upper: ~U[2020-01-01 00:00:00Z],
+      bounds: :"[)"
+    }
+
+    test "is refused by the type before any layer sees it" do
+      assert_raise Ash.Error.Invalid, ~r/range must not be empty/, fn ->
+        Ash.Seed.seed!(%EtsVersioned{id: 1, name: "nowhen", valid_at: @empty})
+      end
+    end
+
+    test "is refused by the layer itself" do
+      changeset = Ash.Changeset.for_create(EtsVersioned, :create, %{id: 1, name: "nowhen"})
+      changeset = %{changeset | attributes: Map.put(changeset.attributes, :valid_at, @empty)}
+
+      assert {:error, %Ash.Error.Changes.InvalidAttribute{field: :valid_at}} =
+               Ash.DataLayer.create(EtsVersioned, changeset)
+    end
   end
 
   test "a non-temporal resource is untouched by an as_of" do
@@ -76,5 +251,55 @@ defmodule Ash.DataLayer.EtsTemporalTest do
              |> Ash.Query.filter(name == ^name)
              |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z])
              |> Ash.read!()
+  end
+
+  # Temporal says nothing about the inner type. Storage works over any ordered extent;
+  # the `as_of` that reads it does not, in two different ways.
+  describe "an extent that is not a period" do
+    alias Ash.Test.Temporal.EtsIntegerExtent
+
+    @first %Ash.Range{lower: 0, upper: 100, bounds: :"[)"}
+    @second %Ash.Range{lower: 100, upper: nil, bounds: :"[)"}
+
+    setup do
+      on_exit(fn -> Ash.DataLayer.Ets.stop(EtsIntegerExtent) end)
+    end
+
+    test "the extent joins the storage key" do
+      record = %EtsIntegerExtent{id: 1, name: "x", valid_over: @first}
+
+      assert Ash.DataLayer.Ets.pkey_map(EtsIntegerExtent, record) == %{id: 1, valid_over: @first}
+    end
+
+    test "versions of one record that overlap on the extent are refused" do
+      Ash.Seed.seed!(%EtsIntegerExtent{id: 1, name: "first", valid_over: @first})
+      Ash.Seed.seed!(%EtsIntegerExtent{id: 1, name: "second", valid_over: @second})
+
+      assert_raise Ash.Error.Invalid, ~r/overlap/i, fn ->
+        Ash.Seed.seed!(%EtsIntegerExtent{
+          id: 1,
+          name: "clash",
+          valid_over: %Ash.Range{lower: 50, upper: 150, bounds: :"[)"}
+        })
+      end
+    end
+
+    # `resolve_query_as_of/2` takes `:now`, a `DateTime` and `nil`, and nothing else.
+    test "narrowing to a point on the extent is refused by core" do
+      Ash.Seed.seed!(%EtsIntegerExtent{id: 1, name: "first", valid_over: @first})
+
+      assert_raise FunctionClauseError, fn ->
+        EtsIntegerExtent |> Ash.Query.as_of(50) |> Ash.read!()
+      end
+    end
+
+    # Comparing the resolved clock value to an integer bound falls back to term order,
+    # where every struct sorts above every number.
+    test "a read naming no point silently answers from term order" do
+      Ash.Seed.seed!(%EtsIntegerExtent{id: 1, name: "first", valid_over: @first})
+      Ash.Seed.seed!(%EtsIntegerExtent{id: 1, name: "second", valid_over: @second})
+
+      assert ["second"] = EtsIntegerExtent |> Ash.read!() |> Enum.map(& &1.name)
+    end
   end
 end

--- a/test/support/temporal/ets_integer_extent.ex
+++ b/test/support/temporal/ets_integer_extent.ex
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule Ash.Test.Temporal.EtsVersioned do
+defmodule Ash.Test.Temporal.EtsIntegerExtent do
   @moduledoc """
-  A temporal resource on the ETS data layer.
+  A temporal resource whose extent is an integer range rather than a period.
 
-  The period is never action input, so a test that needs a particular one seeds it
-  with `Ash.Seed.seed!/2`.
+  Temporal requires an `Ash.Type.Range` with inclusive-exclusive bounds and says
+  nothing about the inner type.
   """
   use Ash.Resource,
     domain: Ash.Test.Domain,
@@ -19,7 +19,7 @@ defmodule Ash.Test.Temporal.EtsVersioned do
 
   temporal do
     strategy :context
-    attribute :valid_at
+    attribute :valid_over
   end
 
   actions do
@@ -34,15 +34,14 @@ defmodule Ash.Test.Temporal.EtsVersioned do
       primary? true
       accept [:name]
     end
-
-    create :upsert do
-      accept [:id, :name]
-      upsert? true
-    end
   end
 
   attributes do
     attribute :id, :integer, primary_key?: true, allow_nil?: false, public?: true
     attribute :name, :string, public?: true
+
+    attribute :valid_over, Ash.Type.Range,
+      allow_nil?: false,
+      constraints: [inner_type: :integer, lower: [inclusive?: true], upper: [inclusive?: false]]
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Adds period establishment on create in the ETS data layer.

Adds the period to the storage key

Adds non-overlap enforcement.

Adds a guard refusing a period that holds no instant. The type refuses it first on every path through an action; this is defence for a caller reaching Ash.DataLayer.create/2 directly.

Adds testing coverage for all of the above, and for an extent that is not a period.

@zachdaniel this is stacked on #2896, #2897, #2898 tests locally green, format-clean, credo clean.