### PR TITLE
fix: anchor today() and a duration ago() to as_of

### DIFF
--- a/documentation/topics/advanced/temporal-resources.md
+++ b/documentation/topics/advanced/temporal-resources.md
@@ -8,13 +8,12 @@ SPDX-License-Identifier: MIT
 
 > ### Experimental {: .warning}
 >
-> Temporal resources are experimental and currently require `ash_postgres`
-> running against **PostgreSQL 19+** (which provides SQL:2011 application-time
-> period tables — `PRIMARY KEY (... WITHOUT OVERLAPS)`, `PERIOD` foreign keys,
-> and `UPDATE/DELETE ... FOR PORTION OF`). The API may change.
-> This documentation is very PostgreSQL specific given that this
-> is the only target we support currently.
-> PostgreSQL 19 itself is still in beta as well
+> Temporal resources are experimental and the API may change. In production
+> they require `ash_postgres` running against **PostgreSQL 19+** (which provides
+> SQL:2011 application-time period tables — `PRIMARY KEY (... WITHOUT OVERLAPS)`,
+> `PERIOD` foreign keys, and `UPDATE/DELETE ... FOR PORTION OF`), which is still
+> in beta itself. This documentation is written against PostgreSQL for that
+> reason. `Ash.DataLayer.Ets` supports temporal resources too, in memory.
 
 A *temporal* resource keeps a full history of each row over time instead of
 overwriting it. Every row is valid for a *period* — a half-open range
@@ -136,10 +135,15 @@ A temporal write establishes validity *from `as_of` onward* — the new row is
   with neither, a single `now` is pinned for the write so the period, any
   `&DateTime.utc_now/0` defaults (e.g. `create_timestamp`), and the stamped
   `as_of` all share the exact same instant.
-- **Updates and destroys split the period.** Updating "as of" an instant
-  truncates the currently-valid row at that instant and writes a new row with
-  the new values for `[as_of, ∞)`, using `FOR PORTION OF`. The prior version is
-  preserved as history.
+- **An update splits the period.** Updating "as of" an instant truncates the
+  currently-valid record at that instant and writes a new one carrying the new
+  values from there **to wherever the old version ended** — `[as_of, ∞)` only when
+  the version it split was itself open-ended. Splitting at the instant a version
+  began leaves nothing before it, so that update reads as an ordinary overwrite.
+- **A destroy ends validity; it does not delete history.** Destroying "as of" an
+  instant truncates the currently-valid record to `[lower, as_of)`. The record is
+  gone from that instant onward and unchanged before it. Destroying at the instant
+  the version began removes it entirely.
 
 ```elixir
 # create the current version, valid from now on
@@ -160,6 +164,38 @@ sub
 > **action option** (`for_create(:create, input, as_of: ...)`), not via
 > `Ash.Changeset.as_of/2` after building the changeset. Those run while the
 > changeset is being constructed, so the instant must be set before then.
+
+### When no version is valid at that instant
+
+An update or destroy acts on the version valid at `as_of`. When none is, there is
+nothing to split and the write is refused as a stale record — whether the last
+version has already ended, the only one has not begun, or `as_of` falls in a gap
+between two.
+
+A record whose history has run out is brought back by **creating** it again, not by
+updating it: the create opens a fresh `[now, ∞)` alongside the closed history, which
+stays readable at its own instants.
+
+### Scheduling a change ahead of now
+
+A create always opens `[as_of, ∞)`, so two of them always overlap and you cannot
+create a record "now" while a version dated later already exists. Only an update
+produces a bounded period, by inheriting the end of the version it splits, so a
+future-dated change is expressed as an update:
+
+```elixir
+# splits into [now, 2027-01-01) and [2027-01-01, ∞)
+sub
+|> Ash.Changeset.for_update(:change_plan, %{plan: "gold"}, as_of: ~U[2027-01-01 00:00:00Z])
+|> Ash.update!()
+```
+
+> ### A future version that was created has to be unwound {: .warning}
+>
+> If the later version was *created* rather than scheduled as an update, it holds
+> `[its instant, ∞)` and nothing can be written before it. Recovering means
+> destroying that version, creating the present one, and re-applying the future
+> change as an update.
 
 ## Relationships
 
@@ -246,8 +282,16 @@ you loaded.)
 
 ## Limitations
 
-- **PostgreSQL 19+ via `ash_postgres` only.** Other data layers report
-  `Ash.DataLayer.can?(:temporal)` as `false`.
+- **`ash_postgres` on PostgreSQL 19+, or `Ash.DataLayer.Ets`.** Every other data
+  layer reports `Ash.DataLayer.can?(:temporal)` as `false`, and a resource that
+  declares itself temporal on one fails to compile. The two behave the same on
+  every point above, by different mechanisms: Postgres keys the table
+  `PRIMARY KEY (id, valid_at WITHOUT OVERLAPS)` and splits with `FOR PORTION OF`,
+  where ETS puts the period in its storage key and rewrites the affected versions.
+- **`Ash.DataLayer.Ets` writes are not transactional.** A split deletes the version
+  and writes both halves, in that order, so a concurrent reader can see the record
+  absent but never as two versions at once. Non-overlap is checked rather than
+  locked: two concurrent creates can both land.
 - **No "all history" reads.** Every read is a single point in time. Querying
   across multiple periods of the same record at once is not supported.
 - **Manual actions bypass temporal handling** — the data layer is never

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -2483,6 +2483,22 @@ defmodule Ash.Actions.Read do
           from_now
         end
 
+      %Ash.Query.Function.Ago{arguments: [duration]} = ago
+      when is_struct(duration, Duration) ->
+        if as_of = opts[:as_of] do
+          Ash.Query.Function.Ago.datetime_add(as_of, Duration.negate(duration))
+        else
+          ago
+        end
+
+      # A date rather than a datetime, so it anchors by taking the date of `as_of`.
+      %Ash.Query.Function.Today{} = today ->
+        if as_of = opts[:as_of] do
+          DateTime.to_date(as_of)
+        else
+          today
+        end
+
       %Ash.Query.Parent{} = parent ->
         if List.wrap(opts[:parent_stack]) != [] do
           %{

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -2059,11 +2059,12 @@ defmodule Ash.DataLayer.Ets do
       changeset.tenant,
       filter,
       changeset.domain,
-      changeset.context[:private][:actor]
+      changeset.context[:private][:actor],
+      supersession(resource, changeset)
     )
   end
 
-  defp do_destroy(resource, record, tenant, filter, domain, actor) do
+  defp do_destroy(resource, record, tenant, filter, domain, actor, supersede) do
     with {:ok, table} <- wrap_or_create_table(resource, tenant) do
       pkey = pkey_map(resource, record)
 
@@ -2072,9 +2073,7 @@ defmodule Ash.DataLayer.Ets do
           {:ok, {_key, record}} when is_map(record) ->
             with {:ok, record} <- cast_record(record, resource),
                  {:ok, [_]} <- filter_matches([record], filter, domain, tenant, actor) do
-              with {:ok, _} <- ETS.Set.delete(table, pkey) do
-                :ok
-              end
+              retire(table, pkey, resource, supersede)
             else
               {:ok, []} ->
                 {:error,
@@ -2091,9 +2090,35 @@ defmodule Ash.DataLayer.Ets do
             {:error, error}
         end
       else
-        with {:ok, _} <- ETS.Set.delete(table, pkey) do
+        retire(table, pkey, resource, supersede)
+      end
+    end
+  end
+
+  defp retire(table, pkey, resource, supersede) do
+    case {supersede, ETS.Set.get(table, pkey)} do
+      {{period, as_of}, {:ok, {_key, stored}}} when is_map(stored) ->
+        close_version(table, pkey, stored, resource, period, as_of)
+
+      _ ->
+        with {:ok, _} <- ETS.Set.delete(table, pkey), do: :ok
+    end
+  end
+
+  # A destroy ends validity at the instant of the write. Closing a version at the
+  # instant it began leaves nothing to keep, so it goes.
+  defp close_version(table, pkey, stored, resource, period, as_of) do
+    with {:ok, closed} <- close_at(Map.get(pkey, period), as_of, resource, period),
+         {:ok, table} <- ETS.Set.delete(table, pkey) do
+      case closed do
+        nil ->
           :ok
-        end
+
+        closed ->
+          with {:ok, version} <- version(resource, pkey, period, stored, closed),
+               {:ok, _} <- ETS.Set.put(table, [version]) do
+            :ok
+          end
       end
     end
   end
@@ -2162,6 +2187,8 @@ defmodule Ash.DataLayer.Ets do
   def update(resource, changeset, pkey \\ nil, from_bulk? \\ false) do
     pkey = pkey || pkey_map(resource, changeset.data)
 
+    supersede = supersession(resource, changeset)
+
     with {:ok, table} <- wrap_or_create_table(resource, changeset.tenant),
          _ <- if(!from_bulk?, do: log_update(resource, pkey, changeset)),
          {:ok, record} <-
@@ -2171,13 +2198,15 @@ defmodule Ash.DataLayer.Ets do
              changeset.domain,
              changeset.tenant,
              resource,
-             changeset.context[:private][:actor]
+             changeset.context[:private][:actor],
+             supersede
            ),
          {:ok, record} <- cast_record(record, resource),
          record <- retain_fields(record, changeset) do
       new_pkey = pkey_map(resource, record)
 
-      if new_pkey != pkey do
+      # A supersession has already retired the old key, so it must not be destroyed.
+      if is_nil(supersede) && new_pkey != pkey do
         case destroy(resource, changeset) do
           :ok ->
             {:ok, %{record | __meta__: %Ecto.Schema.Metadata{state: :loaded, schema: resource}}}
@@ -2191,6 +2220,16 @@ defmodule Ash.DataLayer.Ets do
     else
       {:error, error} ->
         {:error, error}
+    end
+  end
+
+  # `nil` writes in place: no period, or a period with no now to supersede at.
+  defp supersession(resource, changeset) do
+    with period when not is_nil(period) <- Ash.Resource.Info.temporal_attribute(resource),
+         {:ok, as_of} <- write_instant(resource, changeset) do
+      {period, as_of}
+    else
+      _ -> nil
     end
   end
 
@@ -2242,7 +2281,8 @@ defmodule Ash.DataLayer.Ets do
          domain,
          tenant,
          resource,
-         actor
+         actor,
+         supersede
        ) do
     attributes = resource |> Ash.Resource.Info.attributes()
 
@@ -2257,12 +2297,12 @@ defmodule Ash.DataLayer.Ets do
                 empty when empty in [nil, []] ->
                   data = Map.merge(record, casted)
 
-                  put_data(table, pkey, data)
+                  write_version(table, pkey, record, data, resource, supersede)
 
                 atomics ->
                   with {:ok, atomics} <- make_atomics(atomics, resource, domain, casted_record) do
                     data = record |> Map.merge(casted) |> Map.merge(atomics)
-                    put_data(table, pkey, data)
+                    write_version(table, pkey, record, data, resource, supersede)
                   end
               end
             else
@@ -2290,6 +2330,63 @@ defmodule Ash.DataLayer.Ets do
 
       {:error, error} ->
         {:error, error}
+    end
+  end
+
+  defp write_version(table, pkey, _prior, data, _resource, nil), do: put_data(table, pkey, data)
+
+  # The new half ends where the old one did: an edit must not extend a closed version to
+  # forever. No transaction here, so the delete goes first — a reader sees the record
+  # absent, never twice.
+  defp write_version(table, pkey, prior_data, data, resource, {period, as_of}) do
+    prior = Map.get(pkey, period)
+
+    with {:ok, closed} <- close_at(prior, as_of, resource, period),
+         {:ok, {_key, opened_data} = opened} <-
+           version(resource, pkey, period, data, %{prior | lower: as_of}),
+         {:ok, retained} <- retained(resource, pkey, period, prior_data, closed),
+         {:ok, table} <- ETS.Set.delete(table, pkey),
+         {:ok, _table} <- ETS.Set.put(table, retained ++ [opened]) do
+      {:ok, opened_data}
+    end
+  end
+
+  # An instant the version does not hold cannot split it. `nil` drops a half holding none.
+  defp close_at(%Ash.Range{} = prior, as_of, resource, period) do
+    closed = %{prior | upper: as_of}
+
+    cond do
+      not Ash.Range.contains?(prior, as_of) ->
+        {:error, Ash.Error.Changes.StaleRecord.exception(resource: resource, field: period)}
+
+      Ash.Range.empty?(closed) ->
+        {:ok, nil}
+
+      true ->
+        {:ok, closed}
+    end
+  end
+
+  defp close_at(_prior, _as_of, resource, period) do
+    {:error, Ash.Error.Changes.StaleRecord.exception(resource: resource, field: period)}
+  end
+
+  defp retained(_resource, _pkey, _period, _prior_data, nil), do: {:ok, []}
+
+  defp retained(resource, pkey, period, prior_data, closed) do
+    with {:ok, version} <- version(resource, pkey, period, prior_data, closed) do
+      {:ok, [version]}
+    end
+  end
+
+  # Cast in the key, dumped in the data, as every other write leaves it.
+  defp version(resource, pkey, period, data, range) do
+    attribute = Ash.Resource.Info.temporal_period(resource)
+
+    case Ash.Type.dump_to_native(attribute.type, range, attribute.constraints) do
+      {:ok, dumped} -> {:ok, {%{pkey | period => range}, Map.put(data, period, dumped)}}
+      :error -> {:error, "could not store the period #{inspect(range)}"}
+      {:error, error} -> {:error, error}
     end
   end
 

--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -234,6 +234,20 @@ defmodule Ash.Expr do
           as_of -> Ash.Query.Function.Ago.datetime_add(as_of, factor, interval)
         end
 
+      %Ash.Query.Function.Ago{arguments: [duration]} = ago
+      when is_struct(duration, Duration) ->
+        case fill_template_as_of(opts) do
+          nil -> ago
+          as_of -> Ash.Query.Function.Ago.datetime_add(as_of, Duration.negate(duration))
+        end
+
+      # A date rather than a datetime, so it anchors by taking the date of `as_of`.
+      %Ash.Query.Function.Today{} = today ->
+        case fill_template_as_of(opts) do
+          nil -> today
+          as_of -> DateTime.to_date(as_of)
+        end
+
       {:_actor, :_primary_key} ->
         actor = opts[:actor]
 

--- a/lib/ash/policy/filter_check.ex
+++ b/lib/ash/policy/filter_check.ex
@@ -166,6 +166,7 @@ defmodule Ash.Policy.FilterCheck do
       defp references_relative_time?(expr) do
         Ash.Expr.template_references?(expr, fn
           %Ash.Query.Function.Now{} -> true
+          %Ash.Query.Function.Today{} -> true
           %Ash.Query.Function.Ago{} -> true
           %Ash.Query.Function.FromNow{} -> true
           _ -> false

--- a/test/ash/data_layer/ets_temporal_test.exs
+++ b/test/ash/data_layer/ets_temporal_test.exs
@@ -126,16 +126,165 @@ defmodule Ash.DataLayer.EtsTemporalTest do
                EtsVersioned |> Ash.Query.as_of(~U[2026-06-01 00:00:00Z]) |> Ash.read!()
     end
 
-    test "and a destroy removes the version it was given, not the record" do
+    test "and a version is addressable on its own" do
       Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
       open = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "open", valid_at: @open})
 
-      Ash.destroy!(open)
+      assert open.valid_at == @open
+      assert [%{name: "early"}] = EtsVersioned |> Ash.Query.as_of(@early.lower) |> Ash.read!()
+    end
+  end
+
+  describe "an update supersedes the version it acts on" do
+    defp update_at(record, name, as_of) do
+      record
+      |> Ash.Changeset.for_update(:update, %{name: name})
+      |> Ash.Changeset.as_of(as_of)
+      |> Ash.update!()
+    end
+
+    defp names_at(instant) do
+      EtsVersioned
+      |> Ash.Query.as_of(instant)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+    end
+
+    test "the version being updated keeps the values it held, up to the write" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "first", valid_at: @open})
+
+      updated = update_at(record, "second", ~U[2023-01-01 00:00:00Z])
+
+      assert %Ash.Range{lower: ~U[2023-01-01 00:00:00Z], upper: nil, bounds: :"[)"} =
+               updated.valid_at
+
+      assert ["first"] = names_at(~U[2022-01-01 00:00:00Z])
+      assert ["second"] = names_at(~U[2023-06-01 00:00:00Z])
+      # The instant of the write belongs to the version it opens.
+      assert ["second"] = names_at(~U[2023-01-01 00:00:00Z])
+    end
+
+    # Were the new half opened with no end, updating a closed version would make the
+    # record valid forever on the strength of an edit.
+    test "the new version ends where the one it split ended" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "first", valid_at: @early})
+
+      updated = update_at(record, "second", ~U[2020-06-01 00:00:00Z])
+
+      assert %Ash.Range{
+               lower: ~U[2020-06-01 00:00:00Z],
+               upper: ~U[2021-01-01 00:00:00Z]
+             } = updated.valid_at
+
+      assert ["first"] = names_at(~U[2020-03-01 00:00:00Z])
+      assert ["second"] = names_at(~U[2020-09-01 00:00:00Z])
+      assert [] = names_at(~U[2021-06-01 00:00:00Z])
+    end
+
+    # The half before the instant holds none, so it is dropped rather than stored.
+    test "an update at the instant the version began overwrites it" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "first", valid_at: @open})
+
+      updated = update_at(record, "second", @open.lower)
+
+      assert updated.valid_at == @open
+      assert ["second"] = names_at(~U[2021-06-01 00:00:00Z])
+    end
+
+    test "with no as_of the split happens on the layer's own clock" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "first", valid_at: @open})
+      before = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      updated =
+        record
+        |> Ash.Changeset.for_update(:update, %{name: "second"})
+        |> Ash.update!()
+
+      assert %Ash.Range{lower: lower, upper: nil} = updated.valid_at
+      assert DateTime.compare(lower, before) in [:gt, :eq]
+
+      assert ["first"] = names_at(~U[2021-06-01 00:00:00Z])
+      assert ["second"] = EtsVersioned |> Ash.read!() |> Enum.map(& &1.name)
+    end
+
+    # Through an action core refuses first: the atomic upgrade re-reads at `as_of` and
+    # finds nothing. The layer's own guard is the backstop.
+    test "an update at an instant the version does not hold is refused" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "first", valid_at: @early})
+
+      assert_raise Ash.Error.Invalid, ~r/stale record/, fn ->
+        update_at(record, "second", ~U[2026-01-01 00:00:00Z])
+      end
+
+      assert ["first"] = names_at(~U[2020-06-01 00:00:00Z])
+    end
+
+    test "and the layer refuses it on its own account, naming the period" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "first", valid_at: @early})
+
+      changeset =
+        record
+        |> Ash.Changeset.for_update(:update, %{name: "second"})
+        |> Ash.Changeset.as_of(~U[2026-01-01 00:00:00Z])
+
+      assert {:error, %Ash.Error.Changes.StaleRecord{field: :valid_at}} =
+               Ash.DataLayer.update(EtsVersioned, changeset)
+
+      assert ["first"] = names_at(~U[2020-06-01 00:00:00Z])
+    end
+  end
+
+  describe "a destroy ends a version rather than erasing it" do
+    test "the record keeps the values it held up to the instant of the write" do
+      early = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "open", valid_at: @open})
+
+      assert :ok =
+               early
+               |> Ash.Changeset.for_destroy(:destroy, %{}, as_of: ~U[2020-06-01 00:00:00Z])
+               |> Ash.destroy()
+
+      assert [%{name: "early", valid_at: %Ash.Range{upper: ~U[2020-06-01 00:00:00Z]}}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-03-01 00:00:00Z]) |> Ash.read!()
+
+      assert [] = EtsVersioned |> Ash.Query.as_of(~U[2020-09-01 00:00:00Z]) |> Ash.read!()
+
+      assert [%{name: "open"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2026-06-01 00:00:00Z]) |> Ash.read!()
+    end
+
+    # Nothing of the version survives the instant it began.
+    test "destroying at the instant a version began removes it" do
+      early = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+
+      assert :ok =
+               early
+               |> Ash.Changeset.for_destroy(:destroy, %{}, as_of: @early.lower)
+               |> Ash.destroy()
+
+      assert [] = EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+    end
+
+    test "destroying a version at an instant it does not hold is refused" do
+      early = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "early", valid_at: @early})
+
+      assert {:error, _} =
+               early
+               |> Ash.Changeset.for_destroy(:destroy, %{}, as_of: ~U[2026-01-01 00:00:00Z])
+               |> Ash.destroy()
 
       assert [%{name: "early"}] =
                EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+    end
 
-      assert [] = EtsVersioned |> Ash.Query.as_of(~U[2026-06-01 00:00:00Z]) |> Ash.read!()
+    test "a non-temporal resource is still erased" do
+      name = "gone-#{System.unique_integer([:positive])}"
+      thing = Ash.create!(Ash.Test.Temporal.Thing, %{name: name})
+
+      assert :ok = Ash.destroy(thing)
+
+      assert [] =
+               Ash.Test.Temporal.Thing |> Ash.Query.filter(name == ^name) |> Ash.read!()
     end
 
     test "and an upsert conflicts with the version holding its instant, not with every version" do
@@ -251,6 +400,97 @@ defmodule Ash.DataLayer.EtsTemporalTest do
              |> Ash.Query.filter(name == ^name)
              |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z])
              |> Ash.read!()
+  end
+
+  # An update acts on the version valid at `as_of`; when none is, it has nothing to
+  # split and a create is the only way back in.
+  describe "when no version holds the instant of the write" do
+    @past %Ash.Range{
+      lower: ~U[2020-01-01 00:00:00Z],
+      upper: ~U[2021-01-01 00:00:00Z],
+      bounds: :"[)"
+    }
+    @future %Ash.Range{lower: ~U[2027-01-01 00:00:00Z], upper: nil, bounds: :"[)"}
+    @now ~U[2026-06-01 00:00:00Z]
+
+    defp update_now(record) do
+      record
+      |> Ash.Changeset.for_update(:update, %{name: "new"})
+      |> Ash.Changeset.as_of(@now)
+      |> Ash.update()
+    end
+
+    defp create_now do
+      EtsVersioned
+      |> Ash.Changeset.for_create(:create, %{id: 1, name: "new"})
+      |> Ash.Changeset.as_of(@now)
+      |> Ash.create()
+    end
+
+    test "a version that has already ended cannot be updated" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "old", valid_at: @past})
+
+      assert {:error, _} = update_now(record)
+    end
+
+    test "nor can one that has not begun" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "soon", valid_at: @future})
+
+      assert {:error, _} = update_now(record)
+    end
+
+    test "nor can an instant in the gap between two versions" do
+      record = Ash.Seed.seed!(%EtsVersioned{id: 1, name: "old", valid_at: @past})
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "soon", valid_at: @future})
+
+      assert {:error, _} = update_now(record)
+    end
+
+    test "a record whose versions have all ended can be created again" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "old", valid_at: @past})
+
+      assert {:ok, %{valid_at: %Ash.Range{lower: @now, upper: nil}}} = create_now()
+
+      assert [%{name: "old"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2020-06-01 00:00:00Z]) |> Ash.read!()
+
+      assert [%{name: "new"}] = EtsVersioned |> Ash.Query.as_of(@now) |> Ash.read!()
+    end
+
+    # A create opens `[as_of, ∞)`, which overlaps the scheduled version. Only an update
+    # produces a bounded period, by inheriting the end of the version it splits.
+    test "but not while a later version is already scheduled" do
+      Ash.Seed.seed!(%EtsVersioned{id: 1, name: "soon", valid_at: @future})
+
+      assert {:error, _} = create_now()
+    end
+
+    test "so a scheduled version is unwound and re-applied as an update" do
+      {:ok, scheduled} =
+        EtsVersioned
+        |> Ash.Changeset.for_create(:create, %{id: 1, name: "scheduled"})
+        |> Ash.Changeset.as_of(@future.lower)
+        |> Ash.create()
+
+      assert :ok = Ash.destroy(scheduled)
+      assert {:ok, current} = create_now()
+
+      assert {:ok, %{valid_at: %Ash.Range{lower: lower, upper: nil}}} =
+               current
+               |> Ash.Changeset.for_update(:update, %{name: "scheduled"})
+               |> Ash.Changeset.as_of(@future.lower)
+               |> Ash.update()
+
+      assert lower == @future.lower
+
+      assert [%{name: "new", valid_at: %Ash.Range{upper: upper}}] =
+               EtsVersioned |> Ash.Query.as_of(@now) |> Ash.read!()
+
+      assert upper == @future.lower
+
+      assert [%{name: "scheduled"}] =
+               EtsVersioned |> Ash.Query.as_of(~U[2027-06-01 00:00:00Z]) |> Ash.read!()
+    end
   end
 
   # Temporal says nothing about the inner type. Storage works over any ordered extent;

--- a/test/temporal_test.exs
+++ b/test/temporal_test.exs
@@ -204,7 +204,7 @@ defmodule Ash.TemporalTest do
     # `fill_template` runs on already-hydrated expressions, so it matches the
     # `%Function.Now/Ago/FromNow{}` structs (not the raw `%Ash.Query.Call{}` that `expr/1`
     # produces). Construct the hydrated structs directly to exercise the anchoring.
-    alias Ash.Query.Function.{Ago, FromNow, Now}
+    alias Ash.Query.Function.{Ago, FromNow, Now, Today}
 
     @anchor ~U[2026-06-15 12:00:00.000000Z]
 
@@ -223,11 +223,24 @@ defmodule Ash.TemporalTest do
       assert anchored(%FromNow{arguments: [7, :day]}) == Ago.datetime_add(@anchor, 7, :day)
     end
 
+    test "ago(duration) resolves to as_of shifted into the past" do
+      duration = Duration.new!(day: 7)
+
+      assert anchored(%Ago{arguments: [duration]}) ==
+               Ago.datetime_add(@anchor, Duration.negate(duration))
+    end
+
+    test "today() resolves to the date of as_of" do
+      assert anchored(%Today{arguments: []}) == DateTime.to_date(@anchor)
+    end
+
     test "with no as_of in context, relative time is left intact (wall-clock fallback)" do
       no_ctx = [context: %{}]
       assert %Now{arguments: []} = Ash.Expr.fill_template(%Now{arguments: []}, no_ctx)
       assert %Ago{} = Ash.Expr.fill_template(%Ago{arguments: [7, :day]}, no_ctx)
+      assert %Ago{} = Ash.Expr.fill_template(%Ago{arguments: [Duration.new!(day: 7)]}, no_ctx)
       assert %FromNow{} = Ash.Expr.fill_template(%FromNow{arguments: [7, :day]}, no_ctx)
+      assert %Today{} = Ash.Expr.fill_template(%Today{arguments: []}, no_ctx)
     end
   end
 


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Fixes two relative-time expressions that were left at the wall clock on a temporal read.: `today()` and `ago/1` with a `Duration`

`today()` anchors by taking the date of `as_of` rather than by shifting an interval, since it returns a `Date` and not a `DateTime`.

Adds `today'`to `Ash.Policy.FilterCheck`'s relative-time check, so a policy referencing it is not eagerly resolved against the wall clock.

Adds testing coverage for both, and for the wall-clock fallback when no `as_of` is set.

 @zachdaniel this is stacked on https://github.com/ash-project/ash/pull/2896, https://github.com/ash-project/ash/pull/2897, https://github.com/ash-project/ash/pull/2898, https://github.com/ash-project/ash/pull/2899 #2900, tests locally green, format-clean, credo clean.