### PR TITLE
ci: make the `ash-ci` audit steps individually optional

### DIFF
--- a/.github/workflows/ash-ci.yml
+++ b/.github/workflows/ash-ci.yml
@@ -41,6 +41,12 @@ on:
       sobelow:
         type: boolean
         default: true
+      deps-audit:
+        type: boolean
+        default: true
+      hex-audit:
+        type: boolean
+        default: true
       postgres:
         type: boolean
         default: false
@@ -182,7 +188,9 @@ jobs:
           MIX_HOME: ${{ runner.temp }}/.mix
           OBAN_PRO_LICENSE_KEY: ${{ secrets.OBAN_PRO_LICENSE_KEY }}
       - uses: team-alembic/staple-actions/actions/mix-hex-audit@325af91762b51931c459503300c22c057251b3cf # main
+        if: ${{ inputs.hex-audit }}
       - uses: team-alembic/staple-actions/actions/mix-task@325af91762b51931c459503300c22c057251b3cf # main
+        if: ${{ inputs.deps-audit }}
         with:
           task: deps.audit
   changelog-lint:


### PR DESCRIPTION
The `auditor` job in the shared `ash-ci` reusable workflow runs two audit steps unconditionally. `mix hex.audit` is built into Hex and always available, but `mix deps.audit` comes from the `mix_audit` dependency. Any consuming repo that drops `mix_audit` gets a hard CI failure — "the task deps.audit could not be found" — with no way to opt out.

This adds two boolean inputs, `deps-audit` and `hex-audit`, both defaulting to `true`, and gates the corresponding steps with `if:`. It is a pure opt-out: every existing consumer keeps its current behaviour with no change to its own workflow file.

The two checks read different advisory databases — `mix_audit` uses the dependabot advisory database, `hex.audit` uses the EEF/OSV one — so they are not interchangeable. A repo was recently found with a clean `mix_audit` run against a lockfile carrying 21 advisories, 4 of them HIGH, which is why some repos want to move to `hex.audit` alone.