### PR TITLE
perf: resolve each operand once in determine_types

### DIFF
--- a/lib/ash/expr/expr.ex
+++ b/lib/ash/expr/expr.ex
@@ -1174,7 +1174,31 @@ defmodule Ash.Expr do
 
     overloads = Ash.Query.Operator.operator_overloads(name) || %{}
 
-    if types == :var_args || returns == :no_return || returns == :unknown do
+    no_signatures? = types == :var_args || returns == :no_return || returns == :unknown
+
+    # `determine_type/1` is a pure function of the operand: it does not depend on
+    # which candidate signature is being considered. Calling it from inside the
+    # loop over signatures below re-derived every operand once per signature, and
+    # because an operand may itself be an operator, the cost compounded with
+    # nesting depth as `signature_count ^ depth`.
+    #
+    # That stayed invisible while `+` and `-` had one signature each, but they now
+    # declare 16 (the duration overloads), which made a plain chain of integer
+    # additions unusable: a 6-term sum took ~0.3s, 7 took ~5s and 8 took ~83s.
+    # `/` (9 signatures) has had the same behaviour all along.
+    #
+    # Resolving each operand once here and indexing into the result keeps the walk
+    # linear in the size of the expression tree. Skipped when there are no
+    # signatures to consider, so operands of `:var_args` functions such as
+    # `fragment/1` are still never inspected.
+    value_types =
+      if no_signatures? do
+        {}
+      else
+        values |> Enum.map(&determine_type/1) |> List.to_tuple()
+      end
+
+    if no_signatures? do
       []
     else
       {more_match_types, overload_cast_as_types, overload_returns} =
@@ -1294,8 +1318,8 @@ defmodule Ash.Expr do
           last_resort?: false
         },
         fn
-          {{vague_type, value}, index}, acc when vague_type in [:any, :same] ->
-            case determine_type(value) do
+          {{vague_type, _value}, index}, acc when vague_type in [:any, :same] ->
+            case elem(value_types, index) do
               {:ok, {type, constraints}} ->
                 case acc[:basis] do
                   nil ->
@@ -1323,8 +1347,8 @@ defmodule Ash.Expr do
                 {:cont, Map.update!(acc, :must_adopt_basis, &[{index, fn x -> x end} | &1])}
             end
 
-          {{{:array, vague_type}, value}, index}, acc when vague_type in [:any, :same] ->
-            case determine_type(value) do
+          {{{:array, vague_type}, _value}, index}, acc when vague_type in [:any, :same] ->
+            case elem(value_types, index) do
               {:ok, {{:array, type}, constraints}} ->
                 case acc[:basis] do
                   nil ->
@@ -1375,8 +1399,8 @@ defmodule Ash.Expr do
                  )}
             end
 
-          {{{type, constraints}, value}, _index}, acc ->
-            determined_type = determine_type(value)
+          {{{type, constraints}, value}, index}, acc ->
+            determined_type = elem(value_types, index)
 
             cond do
               !Ash.Expr.expr?(value) && !matches_type?(type, value, constraints) ->
@@ -1423,8 +1447,8 @@ defmodule Ash.Expr do
                 end
             end
 
-          {{type, value}, _index}, acc ->
-            determined_type = determine_type(value)
+          {{type, value}, index}, acc ->
+            determined_type = elem(value_types, index)
 
             cond do
               !Ash.Expr.expr?(value) && !matches_type?(type, value, []) ->

--- a/test/expr_test.exs
+++ b/test/expr_test.exs
@@ -129,6 +129,26 @@ defmodule Ash.Test.ExprTest do
 
       assert [{{:array, Ash.Type.UUID}, items: []}, {{:array, Ash.Type.UUID}, items: []}] = types
     end
+
+    test "a long chain of the same operator resolves in linear time" do
+      # Each operand used to be re-resolved once per candidate signature, so a
+      # chain nested `d` deep cost `signature_count ^ d`. With the 16 signatures
+      # that `+` declares for the duration overloads, an 8-term sum took ~83s and
+      # anything longer never finished.
+      count = fn name ->
+        %Ash.Query.Aggregate{name: name, kind: :count, type: Ash.Type.Integer, constraints: []}
+      end
+
+      chain =
+        Enum.reduce(2..40, count.(:c1), fn n, acc ->
+          %Ash.Query.Operator.Basic.Plus{left: acc, right: count.(:"c#{n}")}
+        end)
+
+      {microseconds, result} = :timer.tc(fn -> Ash.Expr.determine_type(chain) end)
+
+      assert {:ok, {Ash.Type.Integer, []}} = result
+      assert microseconds < 1_000_000
+    end
   end
 
   describe "string interpolation" do


### PR DESCRIPTION
## Problem

`Ash.Expr.determine_types/3` calls `determine_type/1` on every operand from *inside* the loop over candidate signatures. Since `determine_type/1` is a pure function of the operand — it doesn't depend on which signature is currently being considered — every operand gets re-resolved once per signature. And because an operand may itself be an operator, the cost compounds with nesting depth:

```
T(depth) = signature_count * T(depth - 1)   ->   signature_count ^ depth
```

This has been the behaviour for a long time, but it stayed invisible for `+` and `-` because they declared a single signature (`1^d == 1`). They now declare **16** each for the duration overloads (#2852), which makes an ordinary chain of integer additions unusable:

| operands | `+` on v3.32.1 |
|---|---|
| 6 | 319 ms |
| 7 | 5 254 ms |
| 8 | 83 250 ms |
| 13 | never returns |

`/` (9 signatures) has had the same characteristic all along — identical timings on v3.31.3 and v3.32.1 — so this is a pre-existing issue that the new overloads exposed rather than caused.

### Reproduction

No database needed:

```elixir
Mix.install([{:ash, "3.32.1"}])

alias Ash.Query.Operator.Basic.Plus

chain = fn n -> Enum.reduce(2..n, 1, fn _, acc -> %Plus{left: acc, right: 1} end) end

for n <- [6, 7, 8] do
  {us, _} = :timer.tc(fn -> Ash.Expr.determine_type(chain.(n)) end)
  IO.puts("#{n} operands: #{Float.round(us / 1000, 2)} ms")
end
```

### Where it bites in practice

In-memory data layers mostly avoid it — a calculation declared `:integer` supplies `known_result`, which short-circuits the walk. SQL data layers don't: `ash_sql` calls `determine_types` at every binary operator node while translating an expression to SQL (`ash_sql/lib/expr.ex:1689`, `:1710`) and then recurses into the operands, hitting the same clause again.

We ran into it on `ash_postgres` with calculations that sum per-relationship count aggregates — `count_a + count_b + ...`. Five resources have them, the largest with 13 terms. `delete_ok?` (`expr(count_descendants == 0)`) gates our destroy actions via `validate attribute_equals(:delete_ok?, true)`, so those actions simply hang. 14 tests timed out at 60s each and our suite went from 159s to 830s on the version bump.

## Fix

Resolve each operand once, before the loop, and index into the result. `signature_count ^ depth` becomes `signature_count * depth`.

The per-operand pass is skipped when no signature survives filtering, so operands of `:var_args` functions like `fragment/1` are still never inspected — that path is unchanged.

| operands | before | after |
|---|---|---|
| 6 | 319 ms | 0.10 ms |
| 7 | 5 254 ms | 0.11 ms |
| 8 | 83 250 ms | 0.11 ms |
| 13 | never returns | 0.14 ms |
| 100 | never returns | 1.09 ms |

Linear from there on. This also retroactively fixes `/` and `<>`.

## Verification

- **`mix check`** — all green (`ex_unit` 4014 passed, `credo`, `check_formatter`, `formatter`, `ex_doc`, `sobelow`, `reuse`, `mix_audit`, `unused_deps`, `check_cheat_sheets`). `mix dialyzer` separately: 0 errors.
- **Behavioural equivalence.** I was more concerned about silently changing inference than about speed, so I ran a differential test over **6 864** generated expressions — every basic and comparison operator, literals of each scalar type, typed refs, typed and untyped aggregates, arrays, random nesting to depth 3, same-operator chains of 2..5 operands per operator, and `determine_types/3` across four `known_result` values. Output is **byte-identical** before and after (matching sha256), covering 40 distinct outcome shapes.

  The corpus is capped at depth 3 / 5 operands because the *unpatched* baseline can't complete anything deeper — so equivalence is established thoroughly for shallow and moderate expressions, and the deep cases only have "after" numbers.
- **Regression test** in `test/expr_test.exs`: a 40-term sum must resolve in under 1s. Confirmed it fails on unpatched `main` (60s ExUnit timeout) and passes with the fix.
- **End-to-end**, per the contributing guide's path-dependency workflow: with our app pointed at this branch, the test file that previously had 14 timeouts passes in 1.5s (68 tests). Three affected resources together: 208 tests, 0 failures, 8.9s.

## Note

I kept the diff deliberately tight (33 insertions / 9 deletions, no re-indentation). A `then/2` restructure reads a little cleaner but re-indents ~200 lines of the closure body, which would bury a 4-line semantic change in noise. Happy to reshape it if you'd prefer that form.

One thing I noticed while testing and did **not** touch, since it's pre-existing and unrelated: `determine_type/1` on `datetime + duration` resolves to `Ash.Type.Date` rather than a datetime type — the `[:date, :duration]` signature appears to win over `[:datetime, :duration]`. Identical on unmodified `main`. Let me know if you'd like a separate issue for it.
