### PR TITLE
improvement: make stream_data optional

### DIFF
--- a/lib/ash/generator/generator.ex
+++ b/lib/ash/generator/generator.ex
@@ -1177,7 +1177,7 @@ defmodule Ash.Generator do
   defp to_generators(generators) do
     Map.new(generators, fn {key, value} ->
       case value do
-        %StreamData{} ->
+        value when is_struct(value, StreamData) ->
           {key, value}
 
         value ->

--- a/mix.exs
+++ b/mix.exs
@@ -399,7 +399,7 @@ defmodule Ash.MixProject do
       # Used for aggregatable and standardized exceptions
       {:splode, "~> 0.3"},
       # Testing Utilities
-      {:stream_data, "~> 1.0"},
+      {:stream_data, "~> 1.0", optional: true, runtime: false},
 
       # SAT Solvers
       {:crux, "~> 0.1 and >= 0.1.2"},


### PR DESCRIPTION
Fixes #2906.

Two hunks:

1. `mix.exs`: `{:stream_data, "~> 1.0", optional: true, runtime: false}` (the "Testing Utilities" comment finally becomes accurate).
2. `lib/ash/generator/generator.ex`: the one compile-time dependency — the `%StreamData{}` struct match in `to_generators/1` — becomes an `is_struct/2` guard (same acceptance set, no compile-time module resolution).

With the dep listed, behavior is identical. Without it, ash and `Ash.Generator` still compile and `Ash.Generator` stays present; invoking the generator surface raises `UndefinedFunctionError` on the `StreamData` call — confined and loud. Consumers that use generators list `stream_data` themselves, the same contract as `plug`, `igniter`, `picosat_elixir`, and `simple_sat`.

Scratch-consumer verification against this exact branch:

| consumer shape | result |
| --- | --- |
| without `stream_data` | compiles clean; ash `.app` `applications` no longer lists `stream_data`; generator invocation raises `UndefinedFunctionError` |
| with `stream_data` listed | compiles clean; `Ash.Type.generator(Ash.Type.Float, min:, max:)` returns a working generator |

Also unblocks downstream packages that want `only: :test` scoping on their own `stream_data` entries (see the Mix `:only` convergence error in #2906).
