### PR TITLE
fix: authorize atomic updates on resources with more than one authorizer

### DIFF
--- a/lib/ash/can.ex
+++ b/lib/ash/can.ex
@@ -830,75 +830,25 @@ defmodule Ash.Can do
           {:ok, true, subject}
 
         authorizers ->
-          authorizers
-          |> Enum.reduce(
-            {:ok, true, subject},
-            fn authorizer, {:ok, true, subject} ->
-              authorizer_state =
-                Ash.Authorizer.initial_state(
-                  authorizer,
-                  actor,
-                  subject.resource,
-                  subject.action,
-                  domain
-                )
-
-              context = %{
-                actor: actor,
-                tenant: subject.to_tenant,
-                domain: domain,
-                resource: subject.resource,
-                query: nil,
-                changeset: nil,
-                action_input: nil,
-                subject: subject
-              }
-
-              context =
-                case subject do
-                  %Ash.Query{} -> Map.put(context, :query, subject)
-                  %Ash.Changeset{} -> Map.put(context, :changeset, subject)
-                  %Ash.ActionInput{} -> Map.put(context, :action_input, subject)
-                end
-
-              case subject do
-                %Ash.Query{} = query ->
-                  alter_query(query, authorizer, authorizer_state, context, opts)
-
-                %Ash.Changeset{} = changeset ->
-                  context = Map.put(context, :changeset, changeset)
-
-                  with {:ok, changeset, authorizer_state} <-
-                         Ash.Authorizer.add_calculations(
-                           authorizer,
-                           changeset,
-                           authorizer_state,
-                           context
-                         ) do
-                    if opts[:base_query] do
-                      case alter_query(
-                             opts[:base_query],
-                             authorizer,
-                             authorizer_state,
-                             context,
-                             opts
-                           ) do
-                        {:ok, true, query} ->
-                          {:ok, true, changeset, query}
-
-                        other ->
-                          other
-                      end
-                    else
-                      {:ok, true, changeset}
-                    end
-                  end
-
-                %Ash.ActionInput{} = subject ->
-                  {:ok, true, subject}
+          Enum.reduce_while(authorizers, {:ok, true, subject}, fn authorizer, acc ->
+            {subject, base_query} =
+              case acc do
+                {:ok, true, subject} -> {subject, opts[:base_query]}
+                {:ok, true, subject, query} -> {subject, query}
               end
+
+            case alter_subject(
+                   subject,
+                   authorizer,
+                   domain,
+                   actor,
+                   Keyword.put(opts, :base_query, base_query)
+                 ) do
+              {:ok, true, _subject} = altered -> {:cont, altered}
+              {:ok, true, _subject, _query} = altered -> {:cont, altered}
+              other -> {:halt, other}
             end
-          )
+          end)
       end
     else
       {:ok, true}
@@ -906,6 +856,59 @@ defmodule Ash.Can do
   end
 
   defp alter_source(other, _, _, _, _), do: other
+
+  defp alter_subject(subject, authorizer, domain, actor, opts) do
+    authorizer_state =
+      Ash.Authorizer.initial_state(
+        authorizer,
+        actor,
+        subject.resource,
+        subject.action,
+        domain
+      )
+
+    context = %{
+      actor: actor,
+      tenant: subject.to_tenant,
+      domain: domain,
+      resource: subject.resource,
+      query: nil,
+      changeset: nil,
+      action_input: nil,
+      subject: subject
+    }
+
+    case subject do
+      %Ash.Query{} = query ->
+        alter_query(query, authorizer, authorizer_state, context, opts)
+
+      %Ash.Changeset{} = changeset ->
+        context = Map.put(context, :changeset, changeset)
+
+        with {:ok, changeset, authorizer_state} <-
+               Ash.Authorizer.add_calculations(
+                 authorizer,
+                 changeset,
+                 authorizer_state,
+                 context
+               ) do
+          if opts[:base_query] do
+            case alter_query(opts[:base_query], authorizer, authorizer_state, context, opts) do
+              {:ok, true, query} ->
+                {:ok, true, changeset, query}
+
+              other ->
+                other
+            end
+          else
+            {:ok, true, changeset}
+          end
+        end
+
+      %Ash.ActionInput{} = action_input ->
+        {:ok, true, action_input}
+    end
+  end
 
   defp alter_query(query, authorizer, authorizer_state, context, opts) do
     context = Map.put(context, :query, query)

--- a/test/authorizer/multiple_authorizers_test.exs
+++ b/test/authorizer/multiple_authorizers_test.exs
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Authorizer.MultipleAuthorizersTest do
+  @moduledoc """
+  Authorizing a changeset against a base query returns `{:ok, true, changeset, query}`.
+
+  That four element shape must flow through every authorizer on the resource. Each
+  authorizer must also alter the query that the authorizer before it produced.
+  """
+  use ExUnit.Case, async: true
+
+  require Ash.Expr
+
+  defmodule NotArchivedAuthorizer do
+    @moduledoc false
+    @behaviour Ash.Authorizer
+
+    @impl true
+    def initial_state(actor, _resource, _action, _domain), do: %{actor: actor}
+
+    @impl true
+    def strict_check_context(_), do: []
+
+    @impl true
+    def strict_check(state, _context), do: {:authorized, state}
+
+    @impl true
+    def check_context(_), do: []
+
+    @impl true
+    def check(_state, _context), do: :authorized
+
+    @impl true
+    def alter_filter(filter, _state, context) do
+      addition = Ash.Filter.parse!(context.resource, Ash.Expr.expr(archived == false))
+
+      {:ok, Ash.Filter.add_to_filter!(filter, addition)}
+    end
+  end
+
+  defmodule NotHiddenAuthorizer do
+    @moduledoc false
+    @behaviour Ash.Authorizer
+
+    @impl true
+    def initial_state(actor, _resource, _action, _domain), do: %{actor: actor}
+
+    @impl true
+    def strict_check_context(_), do: []
+
+    @impl true
+    def strict_check(state, _context), do: {:authorized, state}
+
+    @impl true
+    def check_context(_), do: []
+
+    @impl true
+    def check(_state, _context), do: :authorized
+
+    @impl true
+    def alter_filter(filter, _state, context) do
+      addition = Ash.Filter.parse!(context.resource, Ash.Expr.expr(hidden == false))
+
+      {:ok, Ash.Filter.add_to_filter!(filter, addition)}
+    end
+  end
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  defmodule Post do
+    @moduledoc false
+    use Ash.Resource,
+      domain: Domain,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [NotArchivedAuthorizer, NotHiddenAuthorizer]
+
+    ets do
+      private? true
+    end
+
+    actions do
+      defaults [:read, create: [:body], update: [:body]]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :body, :string, public?: true
+      attribute :archived, :boolean, default: false, public?: true
+      attribute :hidden, :boolean, default: false, public?: true
+    end
+  end
+
+  test "every authorizer alters the base query a changeset is authorized against" do
+    record = Ash.create!(Post, %{body: "before"}, authorize?: false)
+
+    changeset = Ash.Changeset.for_update(record, :update, %{body: "after"})
+
+    assert {:ok, true, %Ash.Changeset{}, %Ash.Query{} = query} =
+             Ash.can(changeset, nil,
+               alter_source?: true,
+               run_queries?: false,
+               base_query: Ash.Query.for_read(Post, :read),
+               maybe_is: false,
+               return_forbidden_error?: true
+             )
+
+    filter = inspect(query.filter)
+
+    assert filter =~ "archived == false"
+    assert filter =~ "hidden == false"
+  end
+end

--- a/test/support/manifest/resources/todo/date_grouping.ex
+++ b/test/support/manifest/resources/todo/date_grouping.ex
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 defmodule Ash.Test.Manifest.Todo.DateGrouping do
   @moduledoc """
   Enum used only as a calculation argument type, pinning reachability


### PR DESCRIPTION
Reported by a client on 3.31.3. Present since 3.0.

`Ash.Can.alter_source/5` returns `{:ok, true, changeset, query}` when it authorizes a changeset against a base query. The reducer that walks the authorizers only accepted `{:ok, true, subject}`, so the second authorizer raised a `FunctionClauseError`.

Atomic updates and destroys set `base_query`, so any resource with two or more authorizers failed every atomic update. Only `Ash.Policy.Authorizer` ships with Ash, so a second authorizer is always application code — which is how this survived so long.

Two further defects sat behind the crash:

- Each authorizer now alters the query the previous one produced. The old code always passed the original `base_query`, so authorizer 2 discarded authorizer 1's filter.
- The reducer stops on the first error instead of raising the same `FunctionClauseError`.

Not a security issue — the crash fails closed, and the dropped-filter path was unreachable because the crash always came first. Worth noting for anyone patching this locally: widening the pattern match without threading the query turns a fail-closed crash into a dropped authorization filter.

New test in `test/authorizer/multiple_authorizers_test.exs` fails on `main`, passes here. Full suite: 4059 passed.