### PR TITLE
fix: avoid compile dependencies for runtime-only constraint modules

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -43,6 +43,7 @@ config :ash, :custom_expressions, [Ash.Test.Expressions.JaroDistance]
 config :ash, :keep_read_action_loads_when_loading?, false
 config :ash, :read_action_after_action_hooks_in_order?, true
 config :ash, :bulk_actions_default_to_errors?, true
+config :ash, :constraint_dependencies_from_referenced_types?, true
 config :ash, :redact_sensitive_values_in_errors?, true
 
 config :crux, :sat_testing, true

--- a/documentation/topics/development/backwards-compatibility-config.md
+++ b/documentation/topics/development/backwards-compatibility-config.md
@@ -272,3 +272,37 @@ the destination record (using the given action) and the join record (using the
 primary destroy action on the join resource). This makes the 2-tuple behavior
 consistent with the `:destroy` shorthand and the explicit 3-tuple
 `{:destroy, :dest_action, :join_action}`.
+
+## constraint_dependencies_from_referenced_types?
+
+```elixir
+config :ash, constraint_dependencies_from_referenced_types?: true
+```
+
+### Old Behavior
+
+Every module named inside a field's `constraints` created a compile-time dependency,
+including ones that are only read at runtime. With
+
+```elixir
+attribute :line, :struct do
+  constraints instance_of: MyApp.Invoice
+end
+```
+
+the resource recompiled whenever `MyApp.Invoice` changed, even though `instance_of` is
+only consulted by `cast_input/2` and friends.
+
+### New Behavior
+
+`constraints` no longer creates compile dependencies on its own. They are registered
+instead for the types a type reports from `c:Ash.Type.referenced_types/1` — the ones
+`Ash.Type.init/2` consumes while the DSL is compiled, such as a nested `type:` in
+`fields`. Runtime-only references like `instance_of` drop out.
+
+A custom type that reaches other types through its constraints must implement
+`c:Ash.Type.referenced_types/1` for compile dependencies on them to be kept.
+
+The installer does not set this one. A type from a dependency that does not implement
+that callback loses the compile dependencies it has today, and a new application can
+depend on such a type from the start.

--- a/lib/ash/resource/dsl.ex
+++ b/lib/ash/resource/dsl.ex
@@ -3,6 +3,22 @@
 # SPDX-License-Identifier: MIT
 
 defmodule Ash.Resource.Dsl do
+  # Opt-in for now. A type that references other types without implementing
+  # `c:Ash.Type.referenced_types/1` still relies on `constraints` creating compile
+  # dependencies, so suppressing them by default would leave its initialized state stale.
+  # Intended to default to `true` in 4.0, where reporting referenced types becomes the
+  # contract for getting compile dependencies on constraints.
+  @constraint_modules if Application.compile_env(
+                           :ash,
+                           :constraint_dependencies_from_referenced_types?,
+                           false
+                         ),
+                         do: [:constraints],
+                         else: []
+
+  @doc false
+  def constraint_dependencies_from_referenced_types?, do: @constraint_modules != []
+
   defmodule Filter do
     @moduledoc "Introspection target for a filter for read actions and relationships"
     defstruct [:filter, __spark_metadata__: nil]
@@ -47,6 +63,7 @@ defmodule Ash.Resource.Dsl do
     ],
     transform: {Ash.Resource.Attribute, :transform, []},
     target: Ash.Resource.Attribute,
+    no_depend_modules: @constraint_modules,
     args: [:name, :type],
     schema: Ash.Resource.Attribute.attribute_schema()
   }
@@ -71,6 +88,7 @@ defmodule Ash.Resource.Dsl do
       "create_timestamp :inserted_at"
     ],
     target: Ash.Resource.Attribute,
+    no_depend_modules: @constraint_modules,
     args: [:name],
     schema: Ash.Resource.Attribute.create_timestamp_schema(),
     transform: {Ash.Resource.Attribute, :transform, []}
@@ -97,6 +115,7 @@ defmodule Ash.Resource.Dsl do
       "update_timestamp :updated_at"
     ],
     target: Ash.Resource.Attribute,
+    no_depend_modules: @constraint_modules,
     schema: Ash.Resource.Attribute.update_timestamp_schema(),
     args: [:name],
     transform: {Ash.Resource.Attribute, :transform, []}
@@ -125,6 +144,7 @@ defmodule Ash.Resource.Dsl do
     ],
     args: [:name],
     target: Ash.Resource.Attribute,
+    no_depend_modules: @constraint_modules,
     schema: Ash.Resource.Attribute.integer_primary_key_schema(),
     auto_set_fields: [allow_nil?: false],
     transform: {Ash.Resource.Attribute, :transform, []}
@@ -151,6 +171,7 @@ defmodule Ash.Resource.Dsl do
     ],
     args: [:name],
     target: Ash.Resource.Attribute,
+    no_depend_modules: @constraint_modules,
     schema: Ash.Resource.Attribute.uuid_primary_key_schema(),
     auto_set_fields: [allow_nil?: false],
     transform: {Ash.Resource.Attribute, :transform, []}
@@ -180,6 +201,7 @@ defmodule Ash.Resource.Dsl do
     ],
     args: [:name],
     target: Ash.Resource.Attribute,
+    no_depend_modules: @constraint_modules,
     schema: Ash.Resource.Attribute.uuid_v7_primary_key_schema(),
     auto_set_fields: [allow_nil?: false],
     transform: {Ash.Resource.Attribute, :transform, []}
@@ -443,6 +465,7 @@ defmodule Ash.Resource.Dsl do
       "argument :password_confirmation, :string"
     ],
     target: Ash.Resource.Actions.Argument,
+    no_depend_modules: @constraint_modules,
     args: [:name, :type],
     transform: {Ash.Type, :set_type_transformation, []},
     schema: Ash.Resource.Actions.Argument.schema()
@@ -463,6 +486,7 @@ defmodule Ash.Resource.Dsl do
       """
     ],
     target: Ash.Resource.Actions.Metadata,
+    no_depend_modules: @constraint_modules,
     args: [:name, :type],
     schema: Ash.Resource.Actions.Metadata.schema(),
     transform: {Ash.Type, :set_type_transformation, []}
@@ -623,7 +647,7 @@ defmodule Ash.Resource.Dsl do
       Ash.Expr
     ],
     target: Ash.Resource.Actions.Action,
-    no_depend_modules: [:touches_resources, :error_handler],
+    no_depend_modules: [:touches_resources, :error_handler] ++ @constraint_modules,
     schema: Ash.Resource.Actions.Action.opt_schema(),
     transform: {Ash.Resource.Actions.Action, :transform, []},
     entities: [
@@ -1030,6 +1054,7 @@ defmodule Ash.Resource.Dsl do
     ],
     singleton_entity_keys: [:transform],
     target: Ash.Resource.Interface.CustomInput,
+    no_depend_modules: @constraint_modules,
     args: [:name, :type],
     schema: Ash.Resource.Interface.CustomInput.schema(),
     transform: {Ash.Type, :set_type_transformation, []}
@@ -1597,6 +1622,7 @@ defmodule Ash.Resource.Dsl do
       """
     ],
     target: Ash.Resource.Calculation.Argument,
+    no_depend_modules: @constraint_modules,
     args: [:name, :type],
     schema: Ash.Resource.Calculation.Argument.schema(),
     transform: {Ash.Type, :set_type_transformation, []}
@@ -1642,7 +1668,7 @@ defmodule Ash.Resource.Dsl do
       }
     ],
     target: Ash.Resource.Calculation,
-    no_depend_modules: [:calculation],
+    no_depend_modules: [:calculation] ++ @constraint_modules,
     args: [:name, :type, {:optional, :calculation}],
     entities: [
       arguments: [@argument]
@@ -1769,6 +1795,7 @@ defmodule Ash.Resource.Dsl do
   @persisters [
     Ash.Resource.Transformers.CacheRelationships,
     Ash.Resource.Transformers.ResolveAutoTypes,
+    Ash.Resource.Transformers.TrackConstraintTypeDependencies,
     Ash.Resource.Transformers.CacheCalculations,
     Ash.Resource.Transformers.AttributesByName,
     Ash.Resource.Transformers.ValidationsAndChangesForType,

--- a/lib/ash/resource/transformers/track_constraint_type_dependencies.ex
+++ b/lib/ash/resource/transformers/track_constraint_type_dependencies.ex
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Resource.Transformers.TrackConstraintTypeDependencies do
+  @moduledoc """
+  Registers compile dependencies for the types reachable from a field's constraints.
+
+  `constraints` is in `no_depend_modules`, because the module references it can hold do not
+  share one dependency requirement. `instance_of` is only read at runtime, while a nested
+  `type` is initialized while the DSL is compiled, so its compile-time state would go stale
+  if the resource stopped recompiling when it changed.
+
+  Which of the two a module reference is, is known by the type, not by the DSL: only
+  `Ash.Type.Struct` knows what `instance_of` means. So the dependency is registered here,
+  from what `c:Ash.Type.referenced_types/1` reports, rather than declared in
+  `Ash.Resource.Dsl` against constraint keys the DSL is otherwise unaware of.
+
+  Opt in with:
+
+      config :ash, :constraint_dependencies_from_referenced_types?, true
+
+  A type that references other types without implementing `c:Ash.Type.referenced_types/1`
+  keeps its compile dependencies while this is off.
+  """
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  def after_compile?, do: false
+
+  # Runs as a persister rather than a transformer: `:auto` types are replaced with real ones
+  # by `ResolveAutoTypes`, which is itself a persister, and Spark silently ignores ordering
+  # declarations that cross the two phases.
+  def after?(Ash.Resource.Transformers.ResolveAutoTypes), do: true
+  def after?(_other), do: false
+
+  def transform(dsl_state) do
+    # Without the opt-in, `constraints` still carries its own compile dependencies and there
+    # is nothing to put back.
+    with true <- Ash.Resource.Dsl.constraint_dependencies_from_referenced_types?(),
+         %Macro.Env{} = env <- Transformer.get_persisted(dsl_state, :env) do
+      Enum.each(typed_fields(dsl_state), &register(&1, env))
+    end
+
+    {:ok, dsl_state}
+  end
+
+  # The trace has to happen against the env of the module being compiled, which Spark
+  # persists for us. Only the dependency is wanted here: `init/1` has already run for these
+  # types, through the containing type's `init/2`, so calling it again would repeat that
+  # work and invoke a callback that is not required to tolerate a second invocation.
+  defp register({type, constraints}, env) do
+    type
+    |> Ash.Type.constraint_referenced_types(constraints)
+    |> Enum.each(fn {referenced, _constraints} ->
+      Macro.compile_apply(referenced, :__info__, [:module], env)
+    end)
+  end
+
+  # Only fields whose `type` is an Ash type. A generic action carries `type: :action`
+  # alongside the `constraints` of its `returns`, so entities are read by name rather than by
+  # looking for a `type` key.
+  defp typed_fields(dsl_state) do
+    actions = Ash.Resource.Info.actions(dsl_state)
+    calculations = Ash.Resource.Info.calculations(dsl_state)
+
+    arguments = Enum.flat_map(actions ++ calculations, &Map.get(&1, :arguments, []))
+    metadata = Enum.flat_map(actions, &Map.get(&1, :metadata, []))
+
+    # Not `Ash.Resource.Info.interfaces/1`: it keeps only `Ash.Resource.Interface`, while
+    # `define_calculation` builds an `Ash.Resource.CalculationInterface`, whose custom inputs
+    # carry constraints just the same.
+    custom_inputs =
+      dsl_state
+      |> Spark.Dsl.Extension.get_entities([:code_interface])
+      |> Enum.flat_map(&Map.get(&1, :custom_inputs, []))
+
+    returns =
+      Enum.flat_map(actions, fn action ->
+        typed(Map.get(action, :returns), Map.get(action, :constraints))
+      end)
+
+    fields =
+      Ash.Resource.Info.attributes(dsl_state) ++
+        Ash.Resource.Info.aggregates(dsl_state) ++
+        calculations ++ arguments ++ metadata ++ custom_inputs
+
+    returns ++ Enum.flat_map(fields, &typed(Map.get(&1, :type), Map.get(&1, :constraints)))
+  end
+
+  defp typed(nil, _constraints), do: []
+  defp typed(:auto, _constraints), do: []
+  defp typed(type, constraints), do: [{type, constraints || []}]
+end

--- a/lib/ash/type/type.ex
+++ b/lib/ash/type/type.ex
@@ -371,6 +371,12 @@ defmodule Ash.Type do
   `via` is a small term describing how this reference is reached — used for
   error messages. Conventionally `{:field, name, declared_type}` for composite
   fields and `:subtype_of` for `Ash.Type.NewType`.
+
+  It is called both before `c:init/1`, for the cycle check, and after it, to
+  register compile dependencies, so it must report the same types either way.
+  A type whose `c:init/1` drops a constraint it reads here would report nothing
+  the second time. The built-in composite types normalise such constraints in
+  place rather than removing them.
   """
   @callback referenced_types(constraints) ::
               [{type :: t(), constraints :: Keyword.t(), via :: term()}]
@@ -2528,22 +2534,42 @@ defmodule Ash.Type do
 
   @doc false
   def detect_type_cycle!(type, constraints) do
-    walk_type_graph!(type, constraints, :root, MapSet.new(), [])
+    walk_type_graph!(type, constraints, :root, MapSet.new(), [], MapSet.new())
     :ok
   end
 
-  defp walk_type_graph!({:array, type}, constraints, via, seen, path) do
-    walk_type_graph!(type, item_constraints(constraints), via, seen, path)
+  @doc false
+  # The types reachable from `constraints`, excluding `type` itself: the ones `init/2`
+  # consumes while the DSL is compiled. Callers use this to register compile dependencies on
+  # those modules. Module references that are only read at runtime, such as the `instance_of`
+  # constraint of `Ash.Type.Struct`, are not reported by `c:referenced_types/1` and so are
+  # deliberately absent.
+  def constraint_referenced_types(type, constraints) do
+    {root_type, root_constraints} = unwrap_array(type, constraints)
+
+    type
+    |> walk_type_graph!(constraints, :root, MapSet.new(), [], MapSet.new())
+    |> MapSet.delete({get_type(root_type), root_constraints})
+    |> MapSet.to_list()
   end
 
-  defp walk_type_graph!(type, constraints, via, seen, path) do
+  defp unwrap_array({:array, type}, constraints),
+    do: unwrap_array(type, item_constraints(constraints))
+
+  defp unwrap_array(type, constraints), do: {type, constraints}
+
+  defp walk_type_graph!({:array, type}, constraints, via, seen, path, acc) do
+    walk_type_graph!(type, item_constraints(constraints), via, seen, path, acc)
+  end
+
+  defp walk_type_graph!(type, constraints, via, seen, path, acc) do
     type = get_type(type)
     key = {type, constraints}
     entry = {type, via}
 
     cond do
       not is_atom(type) or is_nil(type) ->
-        :ok
+        acc
 
       match?({:error, _}, Code.ensure_compiled(type)) ->
         raise ArgumentError, format_unloadable(type, path ++ [entry])
@@ -2555,13 +2581,14 @@ defmodule Ash.Type do
       function_exported?(type, :referenced_types, 1) ->
         seen = MapSet.put(seen, key)
         path = path ++ [entry]
+        acc = MapSet.put(acc, key)
 
-        Enum.each(type.referenced_types(constraints), fn {t, c, v} ->
-          walk_type_graph!(t, c, v, seen, path)
+        Enum.reduce(type.referenced_types(constraints), acc, fn {t, c, v}, acc ->
+          walk_type_graph!(t, c, v, seen, path, acc)
         end)
 
       true ->
-        :ok
+        MapSet.put(acc, key)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Ash.MixProject do
     [
       app: :ash,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.16",
       consolidate_protocols: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/type/constraint_referenced_types_test.exs
+++ b/test/type/constraint_referenced_types_test.exs
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Type.ConstraintReferencedTypesTest do
+  use ExUnit.Case, async: true
+
+  defmodule Money do
+    use Ash.Type
+
+    @impl true
+    def storage_type(_constraints), do: :decimal
+
+    @impl true
+    def cast_input(value, _constraints), do: {:ok, value}
+
+    @impl true
+    def cast_stored(value, _constraints), do: {:ok, value}
+
+    @impl true
+    def dump_to_native(value, _constraints), do: {:ok, value}
+  end
+
+  defmodule Line do
+    defstruct [:amount]
+  end
+
+  defp referenced(type, constraints) do
+    type
+    |> Ash.Type.constraint_referenced_types(constraints)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  test "instance_of is not reported" do
+    assert [] == referenced(Ash.Type.Struct, instance_of: Line)
+  end
+
+  test "nested field types are reported" do
+    assert [Money] ==
+             referenced(Ash.Type.Struct, instance_of: Line, fields: [amount: [type: Money]])
+  end
+
+  test "fields marked init?: false are not reported" do
+    assert [] ==
+             referenced(Ash.Type.Struct, fields: [amount: [type: Money, init?: false]])
+  end
+
+  test "array types nested inside constraints are reported" do
+    assert [Money] ==
+             referenced(Ash.Type.Struct, fields: [amounts: [type: {:array, Money}]])
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

A `constraints` value can hold module references with different dependency requirements:

```elixir
attribute :line, :struct do
  constraints instance_of: MyApp.Invoice,
              fields: [amount: [type: MyApp.MoneyType]]
end
```

`instance_of` is only read at runtime, by `cast_input/2`, `matches_type?/2` and friends. `type` is initialized while the DSL is compiled, by `Ash.Type.init/2` from `set_type_transformation/1`.

Since `constraints` is unclassified, both currently create compile dependencies, so a resource recompiles whenever a struct it merely validates against changes.

Which of the two a reference is, is known by the type and not by the DSL — only `Ash.Type.Struct` knows what `instance_of` means. So instead of naming constraint keys in `Ash.Resource.Dsl`, this puts `constraints` in `no_depend_modules` and registers the dependencies from what the type already reports:

- `Ash.Type.constraint_referenced_types/2` collects the types reachable through `c:Ash.Type.referenced_types/1` — the same graph `detect_type_cycle!/2` walks.
- `Ash.Resource.Transformers.TrackConstraintTypeDependencies` traces each of them with `Macro.compile_apply/4`, against the `Macro.Env` Spark persists as `:env`.

`instance_of` drops out by construction: `Ash.Type.Struct.referenced_types/1` returns `constraints[:fields]` and not `instance_of`. Third-party types get the same treatment without touching the core DSL, and fields marked `init?: false` stay excluded, matching the existing cycle walk.

On a private application this cuts the recompile set for a representative resource edit from 58 files to 41.
