### PR TITLE
improvement: passing tenant in the transaction reason

### DIFF
--- a/lib/ash.ex
+++ b/lib/ash.ex
@@ -4242,6 +4242,12 @@ defmodule Ash do
   end
 
   @transaction_opts_schema [
+    tenant: [
+      type: {:protocol, Ash.ToTenant},
+      doc: """
+      The tenant, placed on the transaction reason for data layers that select a connection per tenant.
+      """
+    ],
     timeout: [
       type: :timeout,
       doc: """
@@ -4328,7 +4334,7 @@ defmodule Ash do
                resource_or_resources,
                func,
                opts[:timeout],
-               %{type: :custom, metadata: %{}}
+               %{type: :custom, metadata: %{}, tenant: opts[:tenant]}
              ) do
         if opts[:return_notifications?] do
           notifications = Process.delete(:ash_notifications) || []
@@ -4431,7 +4437,7 @@ defmodule Ash do
                resource_or_resources,
                func,
                opts[:timeout],
-               %{type: :custom, metadata: %{}},
+               %{type: :custom, metadata: %{}, tenant: opts[:tenant]},
                rollback_on_error?: true
              ) do
         if opts[:return_notifications?] do

--- a/lib/ash/actions/action.ex
+++ b/lib/ash/actions/action.ex
@@ -216,6 +216,7 @@ defmodule Ash.Actions.Action do
                 input: input,
                 actor: opts[:actor]
               },
+              tenant: input.tenant,
               data_layer_context: input.context[:data_layer] || %{}
             },
             rollback_on_error?: false

--- a/lib/ash/actions/create/bulk.ex
+++ b/lib/ash/actions/create/bulk.ex
@@ -80,6 +80,7 @@ defmodule Ash.Actions.Create.Bulk do
                 action: action.name,
                 actor: opts[:actor]
               },
+              tenant: opts[:tenant],
               data_layer_context: opts[:data_layer_context] || %{}
             },
             rollback_on_error?: false
@@ -671,6 +672,7 @@ defmodule Ash.Actions.Create.Bulk do
               action: action.name,
               actor: opts[:actor]
             },
+            tenant: opts[:tenant],
             data_layer_context: opts[:data_layer_context] || context
           },
           rollback_on_error?: false

--- a/lib/ash/actions/destroy/bulk.ex
+++ b/lib/ash/actions/destroy/bulk.ex
@@ -356,6 +356,7 @@ defmodule Ash.Actions.Destroy.Bulk do
                         action: atomic_changeset.action.name,
                         actor: opts[:actor]
                       },
+                      tenant: opts[:tenant],
                       data_layer_context: opts[:data_layer_context] || %{}
                     },
                     rollback_on_error?: false
@@ -539,6 +540,7 @@ defmodule Ash.Actions.Destroy.Bulk do
                   action: action.name,
                   actor: opts[:actor]
                 },
+                tenant: opts[:tenant],
                 data_layer_context: opts[:data_layer_context] || %{}
               },
               rollback_on_error?: false
@@ -1644,6 +1646,7 @@ defmodule Ash.Actions.Destroy.Bulk do
               action: action.name,
               actor: opts[:actor]
             },
+            tenant: opts[:tenant],
             data_layer_context: opts[:data_layer_context] || context
           },
           rollback_on_error?: false

--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -1599,6 +1599,7 @@ defmodule Ash.Actions.Read do
                 resource: query.resource,
                 action: query.action.name
               },
+              tenant: query.tenant,
               data_layer_context: query.context[:data_layer]
             },
             rollback_on_error?: false

--- a/lib/ash/actions/update/bulk.ex
+++ b/lib/ash/actions/update/bulk.ex
@@ -368,6 +368,7 @@ defmodule Ash.Actions.Update.Bulk do
                         action: atomic_changeset.action.name,
                         actor: opts[:actor]
                       },
+                      tenant: opts[:tenant],
                       data_layer_context: opts[:data_layer_context] || %{}
                     },
                     rollback_on_error?: false
@@ -594,6 +595,7 @@ defmodule Ash.Actions.Update.Bulk do
                   action: action.name,
                   actor: opts[:actor]
                 },
+                tenant: opts[:tenant],
                 data_layer_context: opts[:data_layer_context] || %{}
               },
               rollback_on_error?: false
@@ -2021,6 +2023,7 @@ defmodule Ash.Actions.Update.Bulk do
               action: action.name,
               actor: opts[:actor]
             },
+            tenant: opts[:tenant],
             data_layer_context: opts[:data_layer_context] || context
           },
           rollback_on_error?: false

--- a/lib/ash/actions/update/update_many.ex
+++ b/lib/ash/actions/update/update_many.ex
@@ -122,7 +122,12 @@ defmodule Ash.Actions.Update.UpdateMany do
          atomic_notifications ++ manual_notifications}
       end,
       nil,
-      %{type: :bulk_update, metadata: %{resource: resource, action: action.name}}
+      %{
+        type: :bulk_update,
+        metadata: %{resource: resource, action: action.name},
+        tenant: opts[:tenant],
+        data_layer_context: opts[:data_layer_context] || %{}
+      }
     )
     |> case do
       {:ok, {records, errors, notifications}} -> {records, errors, notifications}

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -4685,11 +4685,9 @@ defmodule Ash.Changeset do
               end
             end,
             changeset.timeout || :infinity,
-            Map.put(
-              opts[:transaction_metadata],
-              :data_layer_context,
-              changeset.context[:data_layer] || %{}
-            ),
+            opts[:transaction_metadata]
+            |> Map.put(:data_layer_context, changeset.context[:data_layer] || %{})
+            |> Map.put(:tenant, changeset.tenant),
             rollback_on_error?: false
           )
           |> case do

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -16,6 +16,7 @@ defmodule Ash.DataLayer do
           %{
             required(:type) => :create,
             required(:metadata) => %{resource: Ash.Resource.t(), action: atom},
+            optional(:tenant) => term(),
             optional(:data_layer_context) => %{}
           }
           | %{
@@ -26,6 +27,7 @@ defmodule Ash.DataLayer do
                 record: Ash.Resource.Record.t(),
                 actor: term()
               },
+              optional(:tenant) => term(),
               optional(:data_layer_context) => %{}
             }
           | %{
@@ -36,6 +38,7 @@ defmodule Ash.DataLayer do
                 record: Ash.Resource.Record.t(),
                 actor: term()
               },
+              optional(:tenant) => term(),
               optional(:data_layer_context) => %{}
             }
           | %{
@@ -45,6 +48,7 @@ defmodule Ash.DataLayer do
                 query: Ash.Query.t(),
                 actor: term()
               },
+              optional(:tenant) => term(),
               optional(:data_layer_context) => %{}
             }
           | %{
@@ -55,6 +59,7 @@ defmodule Ash.DataLayer do
                 action: atom,
                 actor: term()
               },
+              optional(:tenant) => term(),
               optional(:data_layer_context) => %{}
             }
           | %{
@@ -64,6 +69,7 @@ defmodule Ash.DataLayer do
                 flow: module(),
                 actor: term()
               },
+              optional(:tenant) => term(),
               optional(:data_layer_context) => %{}
             }
           | %{required(:type) => :custom, required(:metadata) => map()}

--- a/lib/ash/data_layer/data_layer.ex
+++ b/lib/ash/data_layer/data_layer.ex
@@ -72,8 +72,16 @@ defmodule Ash.DataLayer do
               optional(:tenant) => term(),
               optional(:data_layer_context) => %{}
             }
-          | %{required(:type) => :custom, required(:metadata) => map()}
-          | %{required(:type) => atom, required(:metadata) => map()}
+          | %{
+              required(:type) => :custom,
+              required(:metadata) => map(),
+              optional(:tenant) => term()
+            }
+          | %{
+              required(:type) => atom,
+              required(:metadata) => map(),
+              optional(:tenant) => term()
+            }
 
   @type combination_type :: :union | :union_all | :intersection
 


### PR DESCRIPTION
A data layer that picks its connection per tenant needs the tenant in `c:Ash.DataLayer.transaction/4`. The reason Ash builds names the resource, the action and the actor, but not the tenant.

- `Ash.DataLayer.transaction_reason/0` gains `optional(:tenant) => term()` on every variant that already declares `optional(:data_layer_context)`. The key is optional, so a data layer that ignores it is unaffected.
- `Ash.Changeset` puts `changeset.tenant` on the reason in `Ash.Changeset.with_hooks/3`. That one site covers create, update and destroy.
- `Ash.Actions.Create.Bulk`, `Ash.Actions.Update.Bulk` and `Ash.Actions.Destroy.Bulk` pass `opts[:tenant]` at both their outer and inner transactions. `Ash.Actions.Read` passes `query.tenant`.
- `Ash.Actions.Update.UpdateMany` gains `:tenant` and `:data_layer_context`. It built the only reason that had neither.

The tenant sits beside `:data_layer_context` rather than inside it, so a data layer reads a named key instead of a convention:

```elixir
def transaction(_resource, fun, _timeout, %{tenant: tenant}) do
  Repo.put_dynamic_repo(repo_for_tenant(tenant))
  Repo.transaction(fun)
end
```

## Where this came from

[ash_sqlite#224](https://github.com/ash-project/ash_sqlite/pull/224) adds `strategy :context` to AshSqlite, giving each tenant its own SQLite file. It carries `AshSqlite.Changes.CarryTenant` and `AshSqlite.Transformers.CarryTenant` only to put the tenant where `transaction/4` can read it. @zachdaniel [asked why that was necessary](https://github.com/ash-project/ash_sqlite/pull/224#discussion_r3952887312) and [suggested Ash set it in the transaction metadata](https://github.com/ash-project/ash_sqlite/pull/224#discussion_r3952909592). Both modules are deleted there once this lands.

With the transformer disabled, create, update, destroy, `bulk_create` and `bulk_update` all reach `transaction/4` with `data_layer_context: %{}` and no tenant. Reads were the only path already carrying it, on `query`.

## Not in this PR

No test asserts the new key. Of the built-in data layers only `Ash.DataLayer.Mnesia` implements `transaction/4`, and it does not read the reason, so a test needs a data layer that records what it is given. `Ash.DataLayer.Ets` answers `false` to `:transact` and implements neither `rollback/2` nor `in_transaction?/1`, so wrapping it means writing a transaction implementation too. I can add such a module under `test/support` if you want the coverage here rather than in the data layer that consumes it.
