### PR TITLE
chore: refactor ash.set.domains to igniter/1

### DIFF
--- a/lib/mix/tasks/ash.set.domains.ex
+++ b/lib/mix/tasks/ash.set.domains.ex
@@ -18,7 +18,7 @@ if Code.ensure_loaded?(Igniter) do
     """
 
     @impl Igniter.Mix.Task
-    def igniter(igniter, _argv) do
+    def igniter(igniter) do
       app_name = Igniter.Project.Application.app_name(igniter)
 
       Mix.shell().info("🔍 Scanning for Ash domains in :#{app_name}...")


### PR DESCRIPTION
Closes #2919.

`Mix.Tasks.Ash.Set.Domains` defines `igniter/2`, which igniter 0.8.4 deprecates. Any project with both `ash` and `igniter` in its dependency tree gets a warning on every compile of `ash`:

```
[warning] Mix.Tasks.Ash.Set.Domains (deps/ash/lib/mix/tasks/ash.set.domains.ex):
    Module defines `igniter/2`, but `igniter/2` is deprecated.
    Please refactor to `igniter/1`.
```

The argument was already discarded as `_argv`, so nothing in the task reads it and the one-arity form is a direct replacement — no `igniter.args` access needed.

This is the only task under `lib/mix/tasks/` still on the two-arity form.

## Verification

- `mix compile --force` on this branch: no `Ash.Set.Domains` warning (was present before the change).
- Behaviour is unchanged; the body is untouched.

Tested against igniter 0.8.4, Elixir 1.18.4 / OTP 27.