### PR TITLE
fix: refuse a temporal read or write the data layer cannot serve.

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -2291,7 +2291,7 @@ defmodule Ash.Changeset do
           message:
             "Could not determine domain for changeset. Provide the `domain` option or configure a domain in the resource directly."
 
-    changeset = %{changeset | domain: domain}
+    changeset = refuse_unserved_temporal(%{changeset | domain: domain})
 
     if changeset.valid? do
       try do
@@ -2951,6 +2951,22 @@ defmodule Ash.Changeset do
     end)
   end
 
+  # The runtime counterpart of `Ash.Resource.Verifiers.ValidateTemporal`.
+  defp refuse_unserved_temporal(changeset) do
+    if Ash.Resource.Info.temporal_strategy(changeset.resource) == :context and
+         not Ash.DataLayer.can?(:temporal, changeset.resource) do
+      add_error(
+        changeset,
+        Ash.Error.Query.TemporalNotSupported.exception(
+          resource: changeset.resource,
+          as_of: changeset.as_of
+        )
+      )
+    else
+      changeset
+    end
+  end
+
   defp do_for_action(changeset, action_or_name, params, opts) do
     domain =
       changeset.domain || opts[:domain] || Ash.Resource.Info.domain(changeset.resource) ||
@@ -3160,6 +3176,7 @@ defmodule Ash.Changeset do
 
   def prepare_changeset_for_action(changeset, action, opts) do
     changeset
+    |> refuse_unserved_temporal()
     |> Map.put(:action, action)
     |> reset_arguments()
     |> handle_errors(action.error_handler)

--- a/lib/ash/error/query/temporal_not_supported.ex
+++ b/lib/ash/error/query/temporal_not_supported.ex
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Error.Query.TemporalNotSupported do
+  @moduledoc "Used when the data layer of a temporal resource cannot serve an `as_of`"
+
+  use Splode.Error, fields: [:resource, :as_of], class: :invalid
+
+  def message(%{resource: resource, as_of: as_of}) do
+    "Data layer for #{inspect(resource)} does not support temporal resources, so it cannot serve as_of: #{inspect(as_of)}"
+  end
+end

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -4769,12 +4769,18 @@ defmodule Ash.Query do
     # `ash_query.as_of` is already a concrete `DateTime` (or nil) — frozen once upstream
     # (see `Ash.Query.freeze_as_of/1`), so this never re-evaluates "now".
     with as_of when not is_nil(as_of) <- ash_query.as_of,
-         :context <- Ash.Resource.Info.temporal_strategy(ash_query.resource),
-         true <- Ash.DataLayer.can?(:temporal, ash_query.resource),
-         {:ok, query} <- Ash.DataLayer.set_as_of(ash_query.resource, query, as_of) do
-      {:ok, query}
+         :context <- Ash.Resource.Info.temporal_strategy(ash_query.resource) do
+      # Refused rather than dropped: without the instant, nothing narrows by period.
+      if Ash.DataLayer.can?(:temporal, ash_query.resource) do
+        Ash.DataLayer.set_as_of(ash_query.resource, query, as_of)
+      else
+        {:error,
+         Ash.Error.Query.TemporalNotSupported.exception(
+           resource: ash_query.resource,
+           as_of: as_of
+         )}
+      end
     else
-      {:error, error} -> {:error, error}
       _ -> {:ok, query}
     end
   end

--- a/test/resource/temporal_unsupported_test.exs
+++ b/test/resource/temporal_unsupported_test.exs
@@ -1,0 +1,75 @@
+defmodule Ash.Test.Resource.TemporalUnsupportedTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  alias Ash.Error.Query.TemporalNotSupported
+  alias Ash.Test.Temporal.RuntimeGated
+  alias Ash.Test.Temporal.RuntimeGatedDataLayer
+  alias Ash.Test.Temporal.Thing
+
+  @as_of ~U[2026-03-01 00:00:00Z]
+
+  setup do
+    on_exit(fn -> RuntimeGatedDataLayer.supported?(true) end)
+  end
+
+  defp record, do: %RuntimeGated{id: 1, name: "one"}
+
+  describe "when the data layer declines temporal" do
+    setup do
+      RuntimeGatedDataLayer.supported?(false)
+      :ok
+    end
+
+    test "a read is refused" do
+      assert {:error, %Ash.Error.Invalid{errors: [%TemporalNotSupported{resource: RuntimeGated}]}} =
+               RuntimeGated |> Ash.Query.as_of(@as_of) |> Ash.read()
+    end
+
+    test "a create is refused" do
+      changeset = Ash.Changeset.for_create(RuntimeGated, :create, %{id: 1, name: "one"})
+
+      refute changeset.valid?
+      assert [%TemporalNotSupported{resource: RuntimeGated}] = changeset.errors
+    end
+
+    test "an update is refused" do
+      changeset = Ash.Changeset.for_update(record(), :update, %{name: "two"})
+
+      refute changeset.valid?
+      assert [%TemporalNotSupported{resource: RuntimeGated}] = changeset.errors
+    end
+
+    test "a destroy is refused" do
+      changeset = Ash.Changeset.for_destroy(record(), :destroy, %{})
+
+      refute changeset.valid?
+      assert [%TemporalNotSupported{resource: RuntimeGated}] = changeset.errors
+    end
+
+    test "a bulk create is refused" do
+      assert %Ash.BulkResult{status: :error, errors: [error]} =
+               Ash.bulk_create([%{id: 1, name: "one"}], RuntimeGated, :create,
+                 return_errors?: true
+               )
+
+      assert %Ash.Error.Invalid{errors: [%TemporalNotSupported{resource: RuntimeGated}]} = error
+    end
+
+    # A non-temporal resource may carry an as_of for a temporal relationship to use.
+    test "a non-temporal resource is unaffected, read or write" do
+      assert {:ok, _} = Thing |> Ash.Query.as_of(@as_of) |> Ash.read()
+      assert Ash.Changeset.for_create(Thing, :create, %{name: "fine"}).valid?
+    end
+  end
+
+  describe "when the data layer serves temporal" do
+    test "a read is honoured" do
+      assert {:ok, []} = RuntimeGated |> Ash.Query.as_of(@as_of) |> Ash.read()
+    end
+
+    test "a create is honoured" do
+      assert Ash.Changeset.for_create(RuntimeGated, :create, %{id: 1, name: "one"}).valid?
+    end
+  end
+end

--- a/test/support/temporal/runtime_gated.ex
+++ b/test/support/temporal/runtime_gated.ex
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Temporal.RuntimeGated do
+  @moduledoc """
+  A temporal resource whose data layer decides at runtime whether it can serve an `as_of`
+  at all. See `Ash.Test.Temporal.RuntimeGatedDataLayer`.
+  """
+  use Ash.Resource,
+    domain: Ash.Test.Domain,
+    data_layer: Ash.Test.Temporal.RuntimeGatedDataLayer
+
+  temporal do
+    strategy :context
+    attribute :valid_at
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      accept [:id, :name]
+    end
+
+    update :update do
+      accept [:name]
+    end
+  end
+
+  attributes do
+    attribute :id, :integer, primary_key?: true, allow_nil?: false, public?: true
+    attribute :name, :string, public?: true
+
+    attribute :valid_at, Ash.Type.Range,
+      allow_nil?: false,
+      generated?: true,
+      constraints: [
+        inner_type: :datetime,
+        lower: [inclusive?: true],
+        upper: [inclusive?: false]
+      ]
+  end
+end

--- a/test/support/temporal/runtime_gated_data_layer.ex
+++ b/test/support/temporal/runtime_gated_data_layer.ex
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Test.Temporal.RuntimeGatedDataLayer do
+  @moduledoc """
+  A data layer whose temporal support depends on the running store, and stores nothing.
+
+  A layer that gates temporal on something it only learns at runtime — a server version,
+  a storage feature, an edition — has to answer `can?(:temporal)` before it knows, because
+  `Ash.Resource.Verifiers.ValidateTemporal` asks at compile time and fails the resource if
+  the answer is false. So it grants temporal while compiling and may withdraw it later.
+
+  That is the only way to reach the branches where a resource is declared temporal and its
+  data layer declines — `Ash.Query.add_as_of/2` on a read, `refuse_unserved_temporal/1` on
+  a write — so `supported?/1` makes the withdrawal explicit for a test. It defaults to
+  granting, which is what compilation needs.
+  """
+  use Spark.Dsl.Extension, transformers: [], sections: []
+
+  @behaviour Ash.DataLayer
+
+  @doc "Grants or withdraws temporal support for subsequently built queries."
+  def supported?(value), do: Application.put_env(:ash, :test_runtime_gated_temporal?, value)
+
+  @doc false
+  @impl true
+  def can?(_, :temporal), do: Application.get_env(:ash, :test_runtime_gated_temporal?, true)
+  def can?(_, :read), do: true
+  def can?(_, type) when type in [:create, :update, :destroy], do: true
+  def can?(_, _), do: false
+
+  @doc false
+  @impl true
+  def resource_to_query(resource, domain) do
+    %Ash.DataLayer.Simple.Query{resource: resource, domain: domain}
+  end
+
+  @doc false
+  @impl true
+  def set_as_of(_resource, query, _as_of), do: {:ok, query}
+
+  @doc false
+  @impl true
+  def run_query(_query, _resource), do: {:ok, []}
+
+  @doc false
+  @impl true
+  def create(_resource, changeset), do: {:ok, changeset.data}
+end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

The verifier `ValidateTemporal` requires `can?(:temporal, ..)` for a given resource to compile, however the checks at runtime are bugged or missing.

This is a PR without an issue as currently temporal data layers must claim `can?(:temporal, ..)` `true` otherwise `as_of(instant)` is silently dropped.

The fix checks the datalayer's capability ahead of all reads and writes, granting the datalayer the ability to safely refuse temporal for instance when the underlying database lacks temporal capability or configuration.