### PR TITLE
fix: setting undeclared argument was done with `nil` key

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -6641,8 +6641,15 @@ defmodule Ash.Changeset do
             |> store_casted_argument(action_argument.name, last_val, store_casted?)
         end
       else
-        %{changeset | arguments: Map.put(changeset.arguments, argument, value)}
-        |> store_casted_argument(argument, value, store_casted?)
+        add_error(
+          changeset,
+          NoSuchInput.exception(
+            resource: changeset.resource,
+            action: changeset.action.name,
+            input: argument,
+            inputs: Ash.Resource.Info.action_inputs(changeset.resource, changeset.action.name)
+          )
+        )
       end
     else
       %{changeset | arguments: Map.put(changeset.arguments, argument, value)}

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -6612,29 +6612,33 @@ defmodule Ash.Changeset do
 
   defp do_set_argument(changeset, argument, value, store_casted? \\ false) do
     if changeset.action do
-      argument =
+      action_argument =
         Enum.find(
           changeset.action.arguments,
           &(&1.name == argument || to_string(&1.name) == argument)
         )
 
-      if argument do
-        with value <- Ash.Type.Helpers.handle_indexed_maps(argument.type, value),
+      if action_argument do
+        with value <- Ash.Type.Helpers.handle_indexed_maps(action_argument.type, value),
              constraints <-
-               Ash.Type.include_source(argument.type, changeset, argument.constraints),
+               Ash.Type.include_source(
+                 action_argument.type,
+                 changeset,
+                 action_argument.constraints
+               ),
              {:ok, casted} <-
-               Ash.Type.cast_input(argument.type, value, constraints),
+               Ash.Type.cast_input(action_argument.type, value, constraints),
              {{:ok, casted}, _last_val} <-
-               {Ash.Type.apply_constraints(argument.type, casted, constraints), casted} do
-          %{changeset | arguments: Map.put(changeset.arguments, argument.name, casted)}
-          |> store_casted_argument(argument.name, casted, store_casted?)
+               {Ash.Type.apply_constraints(action_argument.type, casted, constraints), casted} do
+          %{changeset | arguments: Map.put(changeset.arguments, action_argument.name, casted)}
+          |> store_casted_argument(action_argument.name, casted, store_casted?)
         else
           {:error, error} ->
-            add_invalid_errors(value, :argument, changeset, argument, error)
+            add_invalid_errors(value, :argument, changeset, action_argument, error)
 
           {{:error, error}, last_val} ->
-            add_invalid_errors(value, :argument, changeset, argument, error)
-            |> store_casted_argument(argument.name, last_val, store_casted?)
+            add_invalid_errors(value, :argument, changeset, action_argument, error)
+            |> store_casted_argument(action_argument.name, last_val, store_casted?)
         end
       else
         %{changeset | arguments: Map.put(changeset.arguments, argument, value)}

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -1381,14 +1381,34 @@ defmodule Ash.Test.Changeset.ChangesetTest do
       assert Ash.Changeset.get_argument(changeset, :false_optional_argument) == false
     end
 
-    test "arguments not defined on the action are stored under their name" do
+    test "arguments not defined on the action add an error" do
       changeset =
         Category
         |> Ash.Changeset.for_create(:create_with_confirmation)
         |> Ash.Changeset.force_set_argument(:unknown_argument, "foo")
 
-      assert changeset.arguments[:unknown_argument] == "foo"
+      assert Enum.any?(changeset.errors, fn error ->
+               match?(%Ash.Error.Invalid.NoSuchInput{input: :unknown_argument}, error)
+             end)
+
+      refute Map.has_key?(changeset.arguments, :unknown_argument)
       assert is_nil(changeset.arguments[nil])
+    end
+
+    test "arguments set before choosing an action are checked against its declarations" do
+      changeset =
+        Category
+        |> Ash.Changeset.new()
+        |> Ash.Changeset.set_argument(:unknown_argument, "foo")
+
+      assert changeset.valid?
+
+      changeset = Ash.Changeset.for_create(changeset, :create)
+
+      refute changeset.valid?
+
+      assert [%Ash.Error.Invalid.NoSuchInput{input: :unknown_argument, action: :create}] =
+               changeset.errors
     end
   end
 

--- a/test/changeset/changeset_test.exs
+++ b/test/changeset/changeset_test.exs
@@ -1380,6 +1380,16 @@ defmodule Ash.Test.Changeset.ChangesetTest do
       assert Ash.Changeset.get_argument(changeset, :true_optional_argument) == true
       assert Ash.Changeset.get_argument(changeset, :false_optional_argument) == false
     end
+
+    test "arguments not defined on the action are stored under their name" do
+      changeset =
+        Category
+        |> Ash.Changeset.for_create(:create_with_confirmation)
+        |> Ash.Changeset.force_set_argument(:unknown_argument, "foo")
+
+      assert changeset.arguments[:unknown_argument] == "foo"
+      assert is_nil(changeset.arguments[nil])
+    end
   end
 
   describe "validation keyword errors" do


### PR DESCRIPTION
Setting an argument on the changeset that is not defined by the action put the value in the arguments map with a `nil` key. 
This was caused by the `argument` variable being reassigned 


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
