### PR TITLE
refactor: move the as_of algebra into Ash.Temporal

### DIFF
--- a/lib/ash/actions/read/read.ex
+++ b/lib/ash/actions/read/read.ex
@@ -3298,7 +3298,7 @@ defmodule Ash.Actions.Read do
   def add_calc_context_to_query(query, actor, authorize?, tenant, tracer, domain, opts) do
     # Thread the query's `as_of` so `now()`/`ago()`/`from_now()` are anchored to it
     # during calc/aggregate/filter expansion (see `add_calc_context_to_filter`).
-    opts = Keyword.put_new(opts, :as_of, Ash.Query.resolve_as_of(query.as_of))
+    opts = Keyword.put_new(opts, :as_of, Ash.Temporal.resolve_as_of(query.as_of))
 
     {:ok, sort} =
       add_calc_context_to_sort(

--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -4228,17 +4228,18 @@ defmodule Ash.Changeset do
   # A `&DateTime.utc_now/0` default on a write that carries an `as_of` resolves to that
   # instant rather than the wall clock (see `Ash.Helpers.resolve_default/2`).
   defp default(changeset, :create, attribute),
-    do: Ash.Helpers.resolve_default(attribute.default, Ash.Query.resolve_as_of(changeset.as_of))
+    do:
+      Ash.Helpers.resolve_default(attribute.default, Ash.Temporal.resolve_as_of(changeset.as_of))
 
   defp default(changeset, :update, attribute) do
     Ash.Helpers.resolve_default(
       attribute.update_default,
-      Ash.Query.resolve_as_of(changeset.as_of)
+      Ash.Temporal.resolve_as_of(changeset.as_of)
     )
   end
 
   defp resolve_default(changeset, default),
-    do: Ash.Helpers.resolve_default(default, Ash.Query.resolve_as_of(changeset.as_of))
+    do: Ash.Helpers.resolve_default(default, Ash.Temporal.resolve_as_of(changeset.as_of))
 
   defp validation_attribute(changeset) do
     case List.last(changeset.atomics) do

--- a/lib/ash/data_layer/ets/ets.ex
+++ b/lib/ash/data_layer/ets/ets.ex
@@ -1892,8 +1892,8 @@ defmodule Ash.DataLayer.Ets do
   defp put_established_period(record, _attribute, %Ash.Range{}, _resource, _changeset), do: record
 
   defp put_established_period(record, attribute, nil, resource, changeset) do
-    case write_instant(resource, changeset) do
-      {:ok, as_of} -> Map.put(record, attribute, %Ash.Range{lower: as_of})
+    case Ash.Temporal.write_period(resource, write_as_of(changeset)) do
+      {:ok, period} -> Map.put(record, attribute, period)
       :error -> record
     end
   end
@@ -1902,53 +1902,15 @@ defmodule Ash.DataLayer.Ets do
 
   # Without an instant the query sees every version, not the one holding it.
   defp upsert_instant(resource, changeset) do
-    case write_instant(resource, changeset) do
+    case Ash.Temporal.write_instant(resource, write_as_of(changeset)) do
       {:ok, instant} -> instant
       :error -> nil
     end
   end
 
-  # Casting through the inner type settles precision: `:datetime` is second-resolution.
-  defp write_instant(resource, changeset) do
-    inner_type = Ash.Resource.Info.temporal_inner_type(resource)
-
-    with {:ok, raw} <- raw_instant(changeset, inner_type),
-         {:ok, instant} <-
-           Ash.Type.cast_input(
-             inner_type,
-             raw,
-             Ash.Resource.Info.temporal_inner_constraints(resource) || []
-           ) do
-      {:ok, instant}
-    else
-      _ -> :error
-    end
-  end
-
-  defp raw_instant(%{as_of: %DateTime{} = as_of}, _inner_type), do: {:ok, as_of}
-
-  defp raw_instant(%{as_of: as_of}, inner_type) when as_of in [nil, :now],
-    do: now_for(inner_type)
-
-  defp raw_instant(_changeset, _inner_type), do: :error
-
-  # Resolved through `get_type/1`: an inner type reads back as a module, and matching the
-  # short names alone silently answers `:error`.
-  defp now_for(inner_type) do
-    case Ash.Type.get_type(inner_type) do
-      type when type in [Ash.Type.DateTime, Ash.Type.UtcDatetime, Ash.Type.UtcDatetimeUsec] ->
-        {:ok, DateTime.utc_now()}
-
-      Ash.Type.NaiveDatetime ->
-        {:ok, NaiveDateTime.utc_now()}
-
-      Ash.Type.Date ->
-        {:ok, Date.utc_today()}
-
-      _ ->
-        :error
-    end
-  end
+  # A write that is not time travelling names no instant, and takes effect now.
+  defp write_as_of(%{as_of: nil}), do: :now
+  defp write_as_of(%{as_of: as_of}), do: as_of
 
   defp set_loaded(%resource{} = record) do
     %{record | __meta__: %Ecto.Schema.Metadata{state: :loaded, schema: resource}}
@@ -2340,7 +2302,7 @@ defmodule Ash.DataLayer.Ets do
   # `nil` writes in place: no period, or a period with no now to supersede at.
   defp supersession(resource, changeset) do
     with period when not is_nil(period) <- Ash.Resource.Info.temporal_attribute(resource),
-         {:ok, as_of} <- write_instant(resource, changeset) do
+         {:ok, as_of} <- Ash.Temporal.write_instant(resource, write_as_of(changeset)) do
       {period, as_of}
     else
       _ -> nil

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -3123,10 +3123,6 @@ defmodule Ash.Query do
     |> set_context(%{shared: %{as_of: as_of}})
   end
 
-  @doc false
-  # Kept so that data layers calling it keep compiling; `Ash.Temporal` is where it lives.
-  defdelegate resolve_as_of(as_of), to: Ash.Temporal
-
   # Apply an `as_of` from opts without clobbering an unset query when there is none.
   defp maybe_set_as_of(query, nil), do: query
   defp maybe_set_as_of(query, value), do: as_of(query, value)

--- a/lib/ash/query/query.ex
+++ b/lib/ash/query/query.ex
@@ -3124,10 +3124,8 @@ defmodule Ash.Query do
   end
 
   @doc false
-  # `:now` means "current time at execution"; resolve it where as_of is consumed
-  # as a concrete value. A `DateTime` fixes the instant; `nil` means unset.
-  def resolve_as_of(:now), do: DateTime.utc_now()
-  def resolve_as_of(other), do: other
+  # Kept so that data layers calling it keep compiling; `Ash.Temporal` is where it lives.
+  defdelegate resolve_as_of(as_of), to: Ash.Temporal
 
   # Apply an `as_of` from opts without clobbering an unset query when there is none.
   defp maybe_set_as_of(query, nil), do: query
@@ -4552,7 +4550,7 @@ defmodule Ash.Query do
       |> Map.put(:action, ash_query.action)
       |> Map.put_new(:private, %{})
       |> put_in([:private, :tenant], ash_query.tenant)
-      |> put_in([:private, :as_of], resolve_as_of(ash_query.as_of))
+      |> put_in([:private, :as_of], Ash.Temporal.resolve_as_of(ash_query.as_of))
       |> Map.put_new(:data_layer, %{})
 
     context =

--- a/lib/ash/temporal.ex
+++ b/lib/ash/temporal.ex
@@ -4,35 +4,48 @@
 
 defmodule Ash.Temporal do
   @moduledoc """
-  The `as_of` algebra: the instant a read sees, and the period a write establishes.
+  Resolves `as_of` into the point of time or period that the data layer stores.
 
-    * `resolve_as_of/1` — the instant a read sees
-    * `write_instant/2` — the instant a write supersedes at
-    * `write_period/2` — the period a write establishes, `[instant, ∞)`
-    * `now_for/1` — the current instant in an extent
+  On a [temporal resource](/documentation/topics/advanced/temporal-resources.md) every
+  version of a record is valid for a period. You can provide a `DateTime`, a `Date`, or
+  `:now` for resolution by the data layer.
 
-  Each answers in the inner type of the resource's period, so `:now` is a `Date` on a
-  `:date` extent and a second-precision `DateTime` on a `:datetime` one.
+  ```elixir
+  # a read resolves as_of a point in time
+  Ash.Temporal.resolve_as_of(query.as_of)
 
-  A temporal data layer passes `:now` for a write that names no `as_of`.
+  # a write resolves a period beginning at the point,
+  # and extending forever unless a later write closes it
+  {:ok, instant} = Ash.Temporal.write_instant(resource, :now)
+  {:ok, period} = Ash.Temporal.write_period(resource, :now)
+  ```
+
+  The write functions return a value of the type the resource builds its periods from. On a
+  `:date` resource `:now` gives you a `Date`. On a `:datetime` one it gives you a `DateTime`
+  according to its constraints. Not every type has a current value. A resource that numbers
+  its versions from one has no `:now` to give and the write functions return `:error`.
+
+  A write that provides no `as_of` takes effect now. Data layers provide `:now` for this.
   """
 
   @typedoc "An `as_of` as a caller may give it, before it is resolved."
   @type as_of :: :now | term() | nil
 
   @doc """
-  The instant a read "as of" `as_of` sees.
+  Resolves an `as_of` to a point in time.
 
-  `:now` resolves to the current instant; `nil` is unset and stays so.
+  `:now` resolves to the current time. Anything else is returned unchanged. `nil` means no
+  particular time was provided.
   """
   @spec resolve_as_of(as_of()) :: term() | nil
   def resolve_as_of(:now), do: DateTime.utc_now()
   def resolve_as_of(other), do: other
 
   @doc """
-  The period a write "as of" `as_of` establishes, in `resource`'s period type.
+  Resolves the period a write is valid for.
 
-  An instant opens a period at itself: `[instant, ∞)`.
+  The value comes back in the type the resource builds its periods from. It begins where
+  the write takes effect and extends forever unless a later write closes it.
   """
   @spec write_period(Ash.Resource.t(), as_of()) :: {:ok, Ash.Range.t()} | :error
   def write_period(resource, as_of) do
@@ -43,7 +56,10 @@ defmodule Ash.Temporal do
   end
 
   @doc """
-  The instant a write "as of" `as_of` supersedes at, in `resource`'s inner type.
+  Resolves the point where a write first takes effect.
+
+  The value comes back in the type the resource builds its periods from. Converting applies
+  whatever precision its constraints declare.
   """
   @spec write_instant(Ash.Resource.t(), as_of()) :: {:ok, term()} | :error
   def write_instant(resource, as_of) do
@@ -63,10 +79,10 @@ defmodule Ash.Temporal do
   end
 
   @doc """
-  The current instant in `inner_type`.
+  Returns the current time as `inner_type`.
 
-  A datetime extent answers a `DateTime`, `:naive_datetime` a `NaiveDateTime`, `:date` a
-  `Date`. Any other answers `:error`.
+  `:date` gives you a `Date` and `:naive_datetime` a `NaiveDateTime`. The datetime types
+  give you a `DateTime`. Anything else has no current time so this returns `:error`.
   """
   @spec now_for(Ash.Type.t() | nil) :: {:ok, term()} | :error
   # Resolved through `get_type/1`: an inner type reads back as a module, and matching the

--- a/lib/ash/temporal.ex
+++ b/lib/ash/temporal.ex
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2019 ash contributors <https://github.com/ash-project/ash/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Ash.Temporal do
+  @moduledoc """
+  The `as_of` algebra: the instant a read sees, and the period a write establishes.
+
+    * `resolve_as_of/1` — the instant a read sees
+    * `write_instant/2` — the instant a write supersedes at
+    * `write_period/2` — the period a write establishes, `[instant, ∞)`
+    * `now_for/1` — the current instant in an extent
+
+  Each answers in the inner type of the resource's period, so `:now` is a `Date` on a
+  `:date` extent and a second-precision `DateTime` on a `:datetime` one.
+
+  A temporal data layer passes `:now` for a write that names no `as_of`.
+  """
+
+  @typedoc "An `as_of` as a caller may give it, before it is resolved."
+  @type as_of :: :now | term() | nil
+
+  @doc """
+  The instant a read "as of" `as_of` sees.
+
+  `:now` resolves to the current instant; `nil` is unset and stays so.
+  """
+  @spec resolve_as_of(as_of()) :: term() | nil
+  def resolve_as_of(:now), do: DateTime.utc_now()
+  def resolve_as_of(other), do: other
+
+  @doc """
+  The period a write "as of" `as_of` establishes, in `resource`'s period type.
+
+  An instant opens a period at itself: `[instant, ∞)`.
+  """
+  @spec write_period(Ash.Resource.t(), as_of()) :: {:ok, Ash.Range.t()} | :error
+  def write_period(resource, as_of) do
+    case write_instant(resource, as_of) do
+      {:ok, instant} -> {:ok, %Ash.Range{lower: instant}}
+      :error -> :error
+    end
+  end
+
+  @doc """
+  The instant a write "as of" `as_of` supersedes at, in `resource`'s inner type.
+  """
+  @spec write_instant(Ash.Resource.t(), as_of()) :: {:ok, term()} | :error
+  def write_instant(resource, as_of) do
+    inner_type = Ash.Resource.Info.temporal_inner_type(resource)
+
+    with {:ok, raw} <- raw_instant(as_of, inner_type),
+         {:ok, instant} <-
+           Ash.Type.cast_input(
+             inner_type,
+             raw,
+             Ash.Resource.Info.temporal_inner_constraints(resource) || []
+           ) do
+      {:ok, instant}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  The current instant in `inner_type`.
+
+  A datetime extent answers a `DateTime`, `:naive_datetime` a `NaiveDateTime`, `:date` a
+  `Date`. Any other answers `:error`.
+  """
+  @spec now_for(Ash.Type.t() | nil) :: {:ok, term()} | :error
+  # Resolved through `get_type/1`: an inner type reads back as a module, and matching the
+  # short names alone silently answers `:error`.
+  def now_for(inner_type) do
+    case Ash.Type.get_type(inner_type) do
+      type when type in [Ash.Type.DateTime, Ash.Type.UtcDatetime, Ash.Type.UtcDatetimeUsec] ->
+        {:ok, DateTime.utc_now()}
+
+      Ash.Type.NaiveDatetime ->
+        {:ok, NaiveDateTime.utc_now()}
+
+      Ash.Type.Date ->
+        {:ok, Date.utc_today()}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp raw_instant(%DateTime{} = as_of, _inner_type), do: {:ok, as_of}
+  defp raw_instant(:now, inner_type), do: now_for(inner_type)
+  defp raw_instant(_as_of, _inner_type), do: :error
+end

--- a/test/temporal_test.exs
+++ b/test/temporal_test.exs
@@ -312,10 +312,6 @@ defmodule Ash.TemporalTest do
       assert Ash.Temporal.resolve_as_of(@as_of) == @as_of
       assert Ash.Temporal.resolve_as_of(nil) == nil
     end
-
-    test "is what Ash.Query.resolve_as_of/1 answers" do
-      assert Ash.Query.resolve_as_of(@as_of) == Ash.Temporal.resolve_as_of(@as_of)
-    end
   end
 
   describe "Ash.Temporal.now_for/1" do

--- a/test/temporal_test.exs
+++ b/test/temporal_test.exs
@@ -301,6 +301,74 @@ defmodule Ash.TemporalTest do
     end
   end
 
+  describe "Ash.Temporal.resolve_as_of/1" do
+    test "answers the current instant for :now" do
+      before = DateTime.utc_now()
+      resolved = Ash.Temporal.resolve_as_of(:now)
+      assert DateTime.compare(resolved, before) in [:eq, :gt]
+    end
+
+    test "passes an instant and an unset as_of through" do
+      assert Ash.Temporal.resolve_as_of(@as_of) == @as_of
+      assert Ash.Temporal.resolve_as_of(nil) == nil
+    end
+
+    test "is what Ash.Query.resolve_as_of/1 answers" do
+      assert Ash.Query.resolve_as_of(@as_of) == Ash.Temporal.resolve_as_of(@as_of)
+    end
+  end
+
+  describe "Ash.Temporal.now_for/1" do
+    test "answers now in the extent's own type" do
+      assert {:ok, %DateTime{}} = Ash.Temporal.now_for(:datetime)
+      assert {:ok, %DateTime{}} = Ash.Temporal.now_for(:utc_datetime)
+      assert {:ok, %DateTime{}} = Ash.Temporal.now_for(:utc_datetime_usec)
+      assert {:ok, %NaiveDateTime{}} = Ash.Temporal.now_for(:naive_datetime)
+      assert {:ok, %Date{}} = Ash.Temporal.now_for(:date)
+    end
+
+    test "refuses an extent that is not made of time" do
+      assert :error = Ash.Temporal.now_for(:integer)
+      assert :error = Ash.Temporal.now_for(nil)
+    end
+  end
+
+  describe "Ash.Temporal.write_instant/2" do
+    test "casts an instant through the resource's inner type" do
+      assert {:ok, instant} =
+               Ash.Temporal.write_instant(Ash.Test.Temporal.EtsVersioned, @as_of)
+
+      assert instant == DateTime.truncate(@as_of, :second)
+    end
+
+    test "resolves :now in the resource's inner type" do
+      assert {:ok, %DateTime{microsecond: {0, 0}}} =
+               Ash.Temporal.write_instant(Ash.Test.Temporal.EtsVersioned, :now)
+    end
+
+    test "refuses :now on an extent with no current value" do
+      assert :error = Ash.Temporal.write_instant(Ash.Test.Temporal.EtsIntegerExtent, :now)
+    end
+
+    test "refuses an as_of that is not an instant, rather than guessing one" do
+      assert :error = Ash.Temporal.write_instant(Ash.Test.Temporal.EtsVersioned, nil)
+      assert :error = Ash.Temporal.write_instant(Ash.Test.Temporal.EtsVersioned, "2020-06-15")
+    end
+  end
+
+  describe "Ash.Temporal.write_period/2" do
+    test "opens a period at the instant, unbounded above" do
+      assert {:ok, %Ash.Range{lower: lower, upper: nil}} =
+               Ash.Temporal.write_period(Ash.Test.Temporal.EtsVersioned, @as_of)
+
+      assert lower == DateTime.truncate(@as_of, :second)
+    end
+
+    test "has no period when it has no instant" do
+      assert :error = Ash.Temporal.write_period(Ash.Test.Temporal.EtsVersioned, nil)
+    end
+  end
+
   defp narrow(as_of) do
     Ash.Filter.Runtime.as_of_matches(
       [%{valid_at: @period}],


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies

# Summary

The `as_of` algebra is implemented in more than one place, this PR centralizes the better implementation to `Ash.Temporal` and has the ETS data layer call it. This temporal code doesn't belong on `Ash.Range` while used for temporal is and should remain non-temporal.

This PR is a pure refactor, some fixes and improvements to follow.

# Tests

11 new tests
`mix test` 4216 passing, `mix credo --strict` clean, `mix format --check-formatted` clean, `mix compile --warnings-as-errors` clean.

Two inherited failures in `test/mix/tasks/ash.set.domains_test.exs`